### PR TITLE
Clerk 認証の初期化タイムアウトを短縮し、Hydration エラーを防止

### DIFF
--- a/docs/CLERK_IMPLEMENTATION_SUMMARY.md
+++ b/docs/CLERK_IMPLEMENTATION_SUMMARY.md
@@ -121,14 +121,11 @@
 **修正内容**:
 
 1. **`src/app/layout.tsx` — `ClerkProvider` に `dynamic` prop を追加（根本修正）**
-   ```tsx
-   <ClerkProvider dynamic>
-   ```
-   `dynamic` を指定することで、サーバーサイドの認証状態を React コンテキストに即座に埋め込む。Clerk CDN スクリプトの読み込み完了を待たずにクライアント側で `isLoaded: true` になるため、Race Condition が解消される。
+   ※ `dynamic` prop は `UserButton` など Clerk のクライアント専用コンポーネントとの Hydration エラーを引き起こすため **採用せず**。
 
-2. **`src/app/history/page.tsx` — タイムアウトフォールバックを追加（安全網）**
-   - `useAuth()` の `isLoaded` を監視し、5 秒経過しても初期化が完了しない場合は「ページを再読み込み」ボタンを表示する
-   - 無限ローディングのユーザー体験を防ぐ
+2. **`src/app/history/page.tsx` — タイムアウトフォールバックを追加（対策）**
+   - `useAuth()` の `isLoaded` を監視し、**2 秒**経過しても初期化が完了しない場合は「ページを再読み込み」ボタンを表示する
+   - 再読み込み後は Clerk CDN がブラウザキャッシュから読み込まれるため高速になる
 
 ---
 

--- a/frontend/src/app/history/page.tsx
+++ b/frontend/src/app/history/page.tsx
@@ -16,14 +16,14 @@ export default function HistoryPage() {
   const [selectedBattle, setSelectedBattle] = useState<BattleResult | null>(null);
   const [clerkTimedOut, setClerkTimedOut] = useState(false);
 
-  // Clerk の初期化が長時間（5秒）完了しない場合はタイムアウトとして扱う
+  // Clerk の初期化が長時間（2秒）完了しない場合はタイムアウトとして扱う
   // スマートフォンエミュレーション時などでCDNスクリプトの読み込みが遅い場合の対策
   useEffect(() => {
     if (isLoaded) {
       setClerkTimedOut(false);
       return;
     }
-    const timer = setTimeout(() => setClerkTimedOut(true), 5000);
+    const timer = setTimeout(() => setClerkTimedOut(true), 2000);
     return () => clearTimeout(timer);
   }, [isLoaded]);
 

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -26,7 +26,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <ClerkProvider dynamic>
+    <ClerkProvider>
       <html lang="ja">
         <body
           className={`${geistSans.variable} ${geistMono.variable} antialiased bg-[#050505] text-[#00ff41] pb-16 md:pb-0`}

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -96,13 +96,15 @@ export default function Header() {
             </Link>
           </SignedOut>
           <SignedIn>
-            <UserButton
-              appearance={{
-                elements: {
-                  avatarBox: "w-10 h-10 border-2 border-[#00ff41]"
-                }
-              }}
-            />
+            <div suppressHydrationWarning>
+              <UserButton
+                appearance={{
+                  elements: {
+                    avatarBox: "w-10 h-10 border-2 border-[#00ff41]"
+                  }
+                }}
+              />
+            </div>
           </SignedIn>
         </div>
 
@@ -114,13 +116,15 @@ export default function Header() {
             </Link>
           </SignedOut>
           <SignedIn>
-            <UserButton
-              appearance={{
-                elements: {
-                  avatarBox: "w-10 h-10 border-2 border-[#00ff41]"
-                }
-              }}
-            />
+            <div suppressHydrationWarning>
+              <UserButton
+                appearance={{
+                  elements: {
+                    avatarBox: "w-10 h-10 border-2 border-[#00ff41]"
+                  }
+                }}
+              />
+            </div>
           </SignedIn>
         </div>
       </div>


### PR DESCRIPTION
Clerk の初期化タイムアウトを5秒から2秒に短縮し、`dynamic` prop を削除してHydrationエラーを防ぐ。`UserButton` を `div` でラップし、Hydration 警告を抑制。