### PR TITLE
最大シミュレーションステップ数を追加

### DIFF
--- a/backend/scripts/README.md
+++ b/backend/scripts/README.md
@@ -22,12 +22,13 @@ NEON_DATABASE_URL=<接続文字列> python scripts/run_batch.py
 |---|---|
 | `NEON_DATABASE_URL` | NeonデータベースへのURL |
 
-### オプション環境変数（Cloud Run Jobs 並列実行用）
+### オプション環境変数
 
 | 変数名 | デフォルト | 説明 |
 |---|---|---|
-| `CLOUD_RUN_TASK_INDEX` | `0` | タスクインデックス |
-| `CLOUD_RUN_TASK_COUNT` | `1` | 並列タスク総数 |
+| `CLOUD_RUN_TASK_INDEX` | `0` | タスクインデックス（Cloud Run Jobs 並列実行用） |
+| `CLOUD_RUN_TASK_COUNT` | `1` | 並列タスク総数（Cloud Run Jobs 並列実行用） |
+| `MAX_SIMULATION_STEPS` | `3000` | バトル 1 戦あたりの最大シミュレーションステップ数（1 step = 0.1 s、デフォルト 300 s） |
 
 ### 処理フロー
 

--- a/backend/scripts/run_batch.py
+++ b/backend/scripts/run_batch.py
@@ -36,6 +36,9 @@ from app.services.ranking_service import RankingService
 _CLOUD_RUN_TASK_INDEX = int(os.environ.get("CLOUD_RUN_TASK_INDEX", 0))
 _CLOUD_RUN_TASK_COUNT = int(os.environ.get("CLOUD_RUN_TASK_COUNT", 1))
 
+# シミュレーションの最大ステップ数 (1 step = 0.1 s, デフォルト 3000 step = 300 s)
+_MAX_SIMULATION_STEPS = int(os.environ.get("MAX_SIMULATION_STEPS", 3000))
+
 
 def _check_env() -> None:
     """必須環境変数の存在を確認する."""
@@ -185,8 +188,7 @@ def _run_simulation(
     """
     simulator = BattleSimulator(player_unit, enemy_units)
 
-    max_steps = 100
-    for _step_count in range(max_steps):
+    for _step_count in range(_MAX_SIMULATION_STEPS):
         if simulator.is_finished:
             break
         simulator.step()

--- a/infra/cloud-run/environment/prod/main.tf
+++ b/infra/cloud-run/environment/prod/main.tf
@@ -42,7 +42,8 @@ module "cloud_run" {
   repository_url = module.base.repository_url
 
   # batch_job 設定
-  batch_image_tag    = var.batch_image_tag
-  batch_cpu_limit    = var.batch_cpu_limit
-  batch_memory_limit = var.batch_memory_limit
+  batch_image_tag       = var.batch_image_tag
+  batch_cpu_limit       = var.batch_cpu_limit
+  batch_memory_limit    = var.batch_memory_limit
+  max_simulation_steps  = var.max_simulation_steps
 }

--- a/infra/cloud-run/environment/prod/variables.tf
+++ b/infra/cloud-run/environment/prod/variables.tf
@@ -98,3 +98,9 @@ variable "batch_memory_limit" {
   type        = string
   default     = "2Gi"
 }
+
+variable "max_simulation_steps" {
+  description = "バトル 1 戦あたりの最大シミュレーションステップ数 (1 step = 0.1 s)"
+  type        = number
+  default     = 3000
+}

--- a/infra/cloud-run/modules/cloud-run/batch_job.tf
+++ b/infra/cloud-run/modules/cloud-run/batch_job.tf
@@ -53,6 +53,11 @@ resource "google_cloud_run_v2_job" "msbs_batch" {
           name  = "CLERK_JWKS_URL"
           value = var.clerk_jwks_url
         }
+
+        env {
+          name  = "MAX_SIMULATION_STEPS"
+          value = tostring(var.max_simulation_steps)
+        }
       }
     }
   }

--- a/infra/cloud-run/modules/cloud-run/variables.tf
+++ b/infra/cloud-run/modules/cloud-run/variables.tf
@@ -102,3 +102,9 @@ variable "batch_memory_limit" {
   type        = string
   default     = "512Mi"
 }
+
+variable "max_simulation_steps" {
+  description = "Maximum number of simulation steps per battle (1 step = 0.1 s)"
+  type        = number
+  default     = 3000
+}


### PR DESCRIPTION
README.mdにMAX_SIMULATION_STEPS環境変数を追加し、デフォルト値を3000に設定。run_batch.pyでシミュレーションの最大ステップ数を環境変数から取得するように変更。Cloud Runの設定ファイルと変数定義ファイルにmax_simulation_stepsを追加。