### PR TITLE
fix: BattleViewer モーダルオープン時に自機MSを中心に表示

### DIFF
--- a/docs/features/battle-viewer-feature.md
+++ b/docs/features/battle-viewer-feature.md
@@ -131,6 +131,45 @@ BattleViewer
 
 ---
 
+---
+
+## BattleScene カメラ初期化
+
+### 概要
+
+モーダルオープン時（`BattleScene` マウント時）に、自機MSの初期位置を中心にカメラを自動配置する。
+
+### 仕様
+
+- `CameraInitializer` コンポーネント（`Canvas` の子）が `useEffect` でマウント時に1回だけ実行
+- カメラ位置: `[px + 50, py + 50, pz + 50]`（自機初期 Three.js 座標からの固定オフセット）
+- `OrbitControls` の target（注視点）: `[px, py, pz]`（自機初期 Three.js 座標）
+- 座標変換: `scale = 0.05`、`game.z → three.y`、`game.y → three.z`（`MobileSuitMesh` と統一）
+
+### 実装詳細
+
+```typescript
+// BattleScene.tsx 内部
+const POSITION_SCALE = 0.05;
+
+function CameraInitializer({ px, py, pz, controlsRef }) {
+    const { camera } = useThree();
+    useEffect(() => {
+        camera.position.set(px + 50, py + 50, pz + 50);
+        if (controlsRef.current) {
+            controlsRef.current.target.set(px, py, pz);
+            controlsRef.current.update();
+        }
+    }, []); // マウント時のみ実行（ユーザー操作後のカメラ位置には干渉しない）
+    return null;
+}
+```
+
+- `useRef` で自機MS初期位置をキャプチャするため、タイムスタンプ更新時に再計算されない
+- ユーザーがカメラを操作した後はカメラ位置・target を変更しない
+
+---
+
 ## 関連ファイル一覧
 
 | ファイル | 役割 |

--- a/frontend/src/components/BattleViewer/scene/BattleScene.tsx
+++ b/frontend/src/components/BattleViewer/scene/BattleScene.tsx
@@ -2,7 +2,8 @@
 
 "use client";
 
-import { Canvas } from "@react-three/fiber";
+import { useRef, useEffect } from "react";
+import { Canvas, useThree } from "@react-three/fiber";
 import { OrbitControls, Stars, Grid } from "@react-three/drei";
 import { MobileSuit } from "@/types/battle";
 import { EnvironmentEffects } from "./EnvironmentEffects";
@@ -11,6 +12,36 @@ import { BattleEventDisplay } from "./BattleEventDisplay";
 import { ObstacleMesh } from "./ObstacleMesh";
 import { BattleEventEffect, WarningType } from "../types";
 import { Obstacle } from "@/types/battle";
+
+// MobileSuitMesh と同じスケール定数（座標変換の一貫性）
+const POSITION_SCALE = 0.05;
+
+// モーダルオープン時に自機MSを中心にカメラを初期配置するコンポーネント
+// Canvas 内部で useThree を呼ぶため、Canvas の子として定義する必要がある
+function CameraInitializer({
+    px, py, pz,
+    controlsRef,
+}: {
+    px: number;
+    py: number;
+    pz: number;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    controlsRef: React.RefObject<any>;
+}) {
+    const { camera } = useThree();
+
+    useEffect(() => {
+        // 自機MS初期位置を中心にカメラを配置（マウント時のみ実行）
+        camera.position.set(px + 50, py + 50, pz + 50);
+        if (controlsRef.current) {
+            controlsRef.current.target.set(px, py, pz);
+            controlsRef.current.update();
+        }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    return null;
+}
 
 interface UnitState {
     pos: { x: number; y: number; z: number };
@@ -40,11 +71,24 @@ export function BattleScene({
     enemyEvents,
     obstacles,
 }: BattleSceneProps) {
+    // 自機MS初期Three.js座標をマウント時のみキャプチャ（MobileSuitMesh と同じ軸変換）
+    const initialPos = useRef({
+        x: playerState.pos.x * POSITION_SCALE,
+        y: playerState.pos.z * POSITION_SCALE, // game.z → Three.js の高さ方向 y
+        z: playerState.pos.y * POSITION_SCALE, // game.y → Three.js の奥行き方向 z
+    });
+    const { x: px, y: py, z: pz } = initialPos.current;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const controlsRef = useRef<any>(null);
+
     return (
         <Canvas
             camera={{ position: [50, 50, 50], fov: 60 }}
             dpr={[1, 2]}
         >
+            {/* モーダルオープン時に自機MSを中心にカメラを初期配置 */}
+            <CameraInitializer px={px} py={py} pz={pz} controlsRef={controlsRef} />
+
             <ambientLight intensity={0.5} />
             <pointLight position={[10, 10, 10]} intensity={1.5} />
 
@@ -60,7 +104,8 @@ export function BattleScene({
                 sectionColor={environment === "COLONY" ? "#8a8aaa" : "#00ff00"} 
                 cellColor={environment === "COLONY" ? "#4a4a6a" : "#003300"} 
             />
-            <OrbitControls 
+            <OrbitControls
+                ref={controlsRef}
                 enableZoom={true}
                 enablePan={true}
                 enableRotate={true}


### PR DESCRIPTION
## Summary

- `BattleScene.tsx` のカメラ・`OrbitControls` の初期設定が固定の原点 `[0,0,0]` を向いており、自機MSが原点付近にいない場合に画面中心からズレるバグを修正
- `CameraInitializer` コンポーネント（Canvas内部）をマウント時に1回だけ実行し、自機MSの初期 Three.js 座標にカメラ位置と注視点を設定する
- `useRef` で初期位置をキャプチャし、タイムスタンプ更新のたびにカメラが動かないよう制御

## Changes

- `frontend/src/components/BattleViewer/scene/BattleScene.tsx`: `CameraInitializer` 追加、`OrbitControls` に `ref` 追加
- `docs/features/battle-viewer-feature.md`: カメラ初期化仕様を追記

## Test plan

- [ ] バトルヒストリーページでバトルをクリックし、詳細モーダルを開く
- [ ] BattleViewer の中央に自機MSが表示されることを確認
- [ ] タイムラインを操作しても OrbitControls が正常に動作する（パン・ズーム・回転）ことを確認
- [ ] 異なる環境（SPACE / GROUND / COLONY）のバトルでも正常に動作することを確認

Closes #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)