### PR TITLE
fix: BattleViewer向き矢印の座標系バグを修正（#336）

### DIFF
--- a/backend/app/engine/movement.py
+++ b/backend/app/engine/movement.py
@@ -236,7 +236,7 @@ class MovementMixin:
                         self.unit_resources[str(actor.id)]["velocity_vec"]  # type: ignore[attr-defined]
                     ),
                     heading=self.unit_resources[str(actor.id)].get(  # type: ignore[attr-defined]
-                        "movement_heading_deg"
+                        "body_heading_deg"
                     ),
                 )
             )

--- a/frontend/src/components/BattleViewer/scene/MobileSuitMesh.tsx
+++ b/frontend/src/components/BattleViewer/scene/MobileSuitMesh.tsx
@@ -42,8 +42,10 @@ export function MobileSuitMesh({
     const headingArrow = useMemo(() => {
         if (heading === undefined) return null;
         const headingRad = (heading * Math.PI) / 180;
+        // ゲーム座標→Three.js座標: game.x→X, game.z→Y, game.y(高さ=0)→Z
+        // バックエンド: direction=[cos,0,sin] (XZ平面) → Three.js: (cos, sin, 0) (XY平面)
         const dir = new THREE.Vector3(
-            Math.sin(headingRad), 0, Math.cos(headingRad)
+            Math.cos(headingRad), Math.sin(headingRad), 0
         ).normalize();
         return new THREE.ArrowHelper(dir, new THREE.Vector3(0, 0, 0), 4, 0x4488ff, 1.5, 1.0);
     // eslint-disable-next-line react-hooks/exhaustive-deps


### PR DESCRIPTION
## Summary

- **MobileSuitMesh.tsx**: 向き矢印の方向ベクトルを `(sin, 0, cos)` → `(cos, sin, 0)` に修正
- **movement.py**: MOVE ログの heading を `movement_heading_deg` → `body_heading_deg` に統一

## 根本原因

ゲーム座標と Three.js 座標のマッピングが以下のとおり：

| ゲーム軸 | Three.js 軸 |
|---|---|
| `game.x` | Three.js **X** |
| `game.z` | Three.js **Y**（地上の南北） |
| `game.y`（高さ=0固定） | Three.js **Z** = 0 |

Three.js の地上平面は **XY 平面（Z=0）**。バックエンドの方向ベクトル `[cos(h), 0, sin(h)]` は Three.js では `(cos(h), sin(h), 0)` になるが、旧コードは `(sin, 0, cos)` を使っており平面も軸も間違っていた。

## Test plan

- [ ] バトルビューアでリプレイを再生し、移動時に青色矢印が移動先方向を向くことを確認
- [ ] 攻撃時に青色矢印が敵MS方向を向くことを確認（旋回途中は部分的でOK）
- [ ] `pytest backend/tests/unit/test_phase_6_1_fire_arc.py` が全件 PASS
- [ ] `cd frontend && ./node_modules/.bin/tsc --noEmit` がエラーなし（既存の無関係エラーを除く）

Closes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)