### PR TITLE
refactor(tests): TestScenarioLosObstacleBasic のフィクスチャ共有・恒真テスト修正

### DIFF
--- a/backend/tests/unit/test_phase_d_integration.py
+++ b/backend/tests/unit/test_phase_d_integration.py
@@ -65,35 +65,34 @@ def _import_scenario(name: str):
 # ---------------------------------------------------------------------------
 
 
+@pytest.fixture(scope="class")
+def los_obstacle_result():
+    """シミュレーションを1回だけ実行してクラス内で共有するフィクスチャ."""
+    mod = _import_scenario("scenario_los_obstacle_basic")
+    return mod.run_scenario(max_steps=5000)
+
+
 class TestScenarioLosObstacleBasic:
     """scenario_los_obstacle_basic — LOS 遮断・障害物迂回行動の統合テスト."""
 
-    def test_scenario_runs_without_error(self) -> None:
+    def test_scenario_runs_without_error(self, los_obstacle_result) -> None:
         """シミュレーションがクラッシュせず完了すること."""
-        mod = _import_scenario("scenario_los_obstacle_basic")
-        result = mod.run_scenario(max_steps=5000)
-        assert result["step_count"] > 0, "少なくとも 1 ステップ実行されること"
+        assert los_obstacle_result["step_count"] > 0, (
+            "少なくとも 1 ステップ実行されること"
+        )
 
-    def test_logs_are_generated(self) -> None:
-        """ログが生成されること."""
-        mod = _import_scenario("scenario_los_obstacle_basic")
-        result = mod.run_scenario(max_steps=5000)
-        assert len(result["logs"]) > 0, "ログが生成されること"
-
-    def test_move_logs_exist(self) -> None:
+    def test_move_logs_exist(self, los_obstacle_result) -> None:
         """MOVE ログが生成されること（ユニットが移動したこと）."""
-        mod = _import_scenario("scenario_los_obstacle_basic")
-        result = mod.run_scenario(max_steps=5000)
         assert (
-            "MOVE" in result["log_action_types"]
-            or "AI_DECISION" in result["log_action_types"]
+            "MOVE" in los_obstacle_result["log_action_types"]
+            or "AI_DECISION" in los_obstacle_result["log_action_types"]
         ), "MOVE または AI_DECISION ログが存在すること"
 
-    def test_battle_resolves(self) -> None:
-        """一方が勝利または引き分けで決着すること."""
-        mod = _import_scenario("scenario_los_obstacle_basic")
-        result = mod.run_scenario(max_steps=5000)
-        assert result["win_loss"] in ("WIN", "LOSE", "DRAW"), "勝敗が決定していること"
+    def test_battle_resolves(self, los_obstacle_result) -> None:
+        """Player が敗北しないこと（障害物による LOS 遮断で引き分けも許容）."""
+        assert los_obstacle_result["win_loss"] != "LOSE", (
+            f"Player が敗北しないこと (実際: {los_obstacle_result['win_loss']})"
+        )
 
     def test_obstacle_passed_to_simulator(self) -> None:
         """BattleField に障害物が 1 個設定されること."""


### PR DESCRIPTION
## Summary

- `@pytest.fixture(scope="class")` を導入し、`run_scenario()` の重複実行を **4回 → 1回** に削減（クラス実行時間 **~37秒 → ~9秒**）
- `test_battle_resolves` の恒真アサーション（`in ("WIN", "LOSE", "DRAW")`）を `!= "LOSE"` に修正（実際の結果は `DRAW` であることも判明）
- `test_logs_are_generated` を削除（`test_scenario_runs_without_error` と実質重複）

## Changes

| ファイル | 変更内容 |
|---|---|
| `backend/tests/unit/test_phase_d_integration.py` | fixture 追加、テスト3本修正、1本削除 |

## Test plan

- [ ] `pytest tests/unit/test_phase_d_integration.py::TestScenarioLosObstacleBasic -v` が 5 PASSED
- [ ] クラス全体の実行時間が10秒以内であること（`--durations=10` で確認）

Closes #349

🤖 Generated with [Claude Code](https://claude.com/claude-code)