### PR TITLE
feat(E-3.5-1): フランキングスキル定義・定数追加

### DIFF
--- a/backend/app/core/skills.py
+++ b/backend/app/core/skills.py
@@ -43,6 +43,13 @@ SKILL_MASTER_DATA: dict[str, SkillDefinition] = {
         "effect_per_level": 1.0,  # +1% / Lv
         "max_level": 10,
     },
+    "flanking": {
+        "id": "flanking",
+        "name": "フランキング",
+        "description": "目標の背後へ回り込む確率が上昇する。ブーストENを消費する",
+        "effect_per_level": 0.0,  # 効果は FLANKING_ACTIVATION_PROBS で管理
+        "max_level": 3,
+    },
 }
 
 # スキルポイントコスト（一律1 SP）

--- a/backend/app/engine/constants.py
+++ b/backend/app/engine/constants.py
@@ -219,3 +219,14 @@ SECTOR_DAMAGE_MODIFIERS: dict[str, float] = {
 SECTOR_FRONT_DEG: float = 60.0
 SECTOR_FRONT_SIDE_DEG: float = 120.0
 SECTOR_REAR_SIDE_DEG: float = 150.0
+
+# フランキング（背後移動）パッシブスキル定数 (Phase E-3.5)
+FLANKING_OFFSET_DISTANCE: float = 30.0
+FLANKING_ATTRACTION_WEIGHT: float = 1.5
+FLANKING_ENERGY_COST_RATE: float = 1.5  # DEFAULT_BOOST_EN_COST に対する乗数
+FLANKING_ACTIVATION_PROBS: dict[int, float] = {
+    0: 0.05,  # スキルなし: 5%（偶発的な背後取得）
+    1: 0.30,  # Lv.1: 30%（経験者）
+    2: 0.60,  # Lv.2: 60%（ベテラン）
+    3: 0.90,  # Lv.3: 90%（エース級）
+}


### PR DESCRIPTION
## Summary

- `constants.py` にフランキング関連定数 4 つを追加（`FLANKING_OFFSET_DISTANCE`, `FLANKING_ATTRACTION_WEIGHT`, `FLANKING_ENERGY_COST_RATE`, `FLANKING_ACTIVATION_PROBS`）
- `skills.py` に `"flanking"` スキルエントリを追加（`max_level=3`、他スキルの `max_level=10` と意図的に異なる）

Closes #352
Parent Issue: #351

## Test plan

- [x] 既存ユニットテスト全通過確認（`pytest tests/unit --tb=short`）
- [ ] E-3.5-2 の実装後に `test_phase_e35_flanking.py` で定数値を検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)