### PR TITLE
feat(E-3.5-2): ポテンシャルフィールドへのフランキング統合

### DIFF
--- a/backend/app/core/npc_data.py
+++ b/backend/app/core/npc_data.py
@@ -131,6 +131,7 @@ ACE_PILOTS = [
         "bounty_exp": 500,
         "bounty_credits": 1000,
         "stats": {"sht": 10, "mel": 10, "intel": 9, "ref": 15, "tou": 7, "luk": 8},
+        "skills": {"flanking": 3},
     },
     {
         "id": "ace_ramba_ral",
@@ -175,6 +176,7 @@ ACE_PILOTS = [
         "bounty_exp": 450,
         "bounty_credits": 900,
         "stats": {"sht": 7, "mel": 14, "intel": 8, "ref": 10, "tou": 12, "luk": 6},
+        "skills": {"flanking": 3},
     },
     {
         "id": "ace_yazan_gable",
@@ -220,6 +222,7 @@ ACE_PILOTS = [
         "bounty_exp": 480,
         "bounty_credits": 950,
         "stats": {"sht": 10, "mel": 13, "intel": 7, "ref": 11, "tou": 13, "luk": 5},
+        "skills": {"flanking": 3},
     },
     {
         "id": "ace_amuro_ray",
@@ -266,6 +269,7 @@ ACE_PILOTS = [
         "bounty_exp": 800,
         "bounty_credits": 2000,
         "stats": {"sht": 13, "mel": 11, "intel": 15, "ref": 14, "tou": 9, "luk": 12},
+        "skills": {"flanking": 2},
     },
     {
         "id": "ace_haman_karn",
@@ -312,6 +316,7 @@ ACE_PILOTS = [
         "bounty_exp": 750,
         "bounty_credits": 1800,
         "stats": {"sht": 11, "mel": 10, "intel": 14, "ref": 11, "tou": 8, "luk": 13},
+        "skills": {"flanking": 2},
     },
 ]
 

--- a/backend/app/core/skills.py
+++ b/backend/app/core/skills.py
@@ -43,6 +43,13 @@ SKILL_MASTER_DATA: dict[str, SkillDefinition] = {
         "effect_per_level": 1.0,  # +1% / Lv
         "max_level": 10,
     },
+    "flanking": {
+        "id": "flanking",
+        "name": "フランキング",
+        "description": "目標の背後へ回り込む確率が上昇する。ブーストENを消費する",
+        "effect_per_level": 0.0,  # 効果は FLANKING_ACTIVATION_PROBS で管理
+        "max_level": 3,
+    },
 }
 
 # スキルポイントコスト（一律1 SP）

--- a/backend/app/engine/constants.py
+++ b/backend/app/engine/constants.py
@@ -219,3 +219,14 @@ SECTOR_DAMAGE_MODIFIERS: dict[str, float] = {
 SECTOR_FRONT_DEG: float = 60.0
 SECTOR_FRONT_SIDE_DEG: float = 120.0
 SECTOR_REAR_SIDE_DEG: float = 150.0
+
+# フランキング（背後移動）パッシブスキル定数 (Phase E-3.5)
+FLANKING_OFFSET_DISTANCE: float = 30.0
+FLANKING_ATTRACTION_WEIGHT: float = 1.5
+FLANKING_ENERGY_COST_RATE: float = 1.5  # DEFAULT_BOOST_EN_COST に対する乗数
+FLANKING_ACTIVATION_PROBS: dict[int, float] = {
+    0: 0.05,  # スキルなし: 5%（偶発的な背後取得）
+    1: 0.30,  # Lv.1: 30%（経験者）
+    2: 0.60,  # Lv.2: 60%（ベテラン）
+    3: 0.90,  # Lv.3: 90%（エース級）
+}

--- a/backend/app/engine/movement.py
+++ b/backend/app/engine/movement.py
@@ -10,8 +10,13 @@ from app.engine.constants import (
     ALLY_REPULSION_RADIUS,
     BOUNDARY_MARGIN,
     DEFAULT_BOOST_COOLDOWN,
+    DEFAULT_BOOST_EN_COST,
     DEFAULT_BOOST_MAX_DURATION,
     DEFAULT_BOOST_SPEED_MULTIPLIER,
+    FLANKING_ACTIVATION_PROBS,
+    FLANKING_ATTRACTION_WEIGHT,
+    FLANKING_ENERGY_COST_RATE,
+    FLANKING_OFFSET_DISTANCE,
     HIGH_THREAT_THRESHOLD,
     MELEE_BOOST_ARRIVAL_RANGE,
     MOVE_LOG_MIN_DIST,
@@ -128,11 +133,59 @@ class MovementMixin:
                 force += RETREAT_ATTRACTION_COEFF * vec / dist
         return force
 
+    def _flanking_attraction(
+        self,
+        unit: MobileSuit,
+        target: MobileSuit,
+        dt: float,
+    ) -> np.ndarray:
+        """フランキング引力ベクトルを計算し EN を消費する (Phase E-3.5).
+
+        スキルレベルに応じた確率でターゲット後方への引力ベクトルを返す。
+        EN 不足時はゼロベクトルを返してフォールバックする。
+
+        Args:
+            unit: 移動するユニット
+            target: 攻撃対象ユニット
+            dt: 時間ステップ幅 (s)
+
+        Returns:
+            3D 引力ベクトル（未正規化）。未発動または EN 不足時はゼロベクトル。
+        """
+        unit_id = str(unit.id)
+        resources = self.unit_resources[unit_id]  # type: ignore[attr-defined]
+
+        skill_level = resources.get("flanking_skill_level", 0)
+        prob = FLANKING_ACTIVATION_PROBS.get(skill_level, 0.0)
+        if prob <= 0.0 or random.random() > prob:
+            return np.zeros(3)
+
+        boost_en_cost = getattr(unit, "boost_en_cost", DEFAULT_BOOST_EN_COST)
+        flanking_en_cost = FLANKING_ENERGY_COST_RATE * boost_en_cost * dt
+        if resources.get("current_en", 0.0) < flanking_en_cost:
+            return np.zeros(3)
+        resources["current_en"] -= flanking_en_cost
+
+        # ターゲット後方 = body_heading + 180°
+        target_heading_deg = self.unit_resources[str(target.id)].get(  # type: ignore[attr-defined]
+            "body_heading_deg", 0.0
+        )
+        rear_rad = math.radians(target_heading_deg + 180.0)
+        rear_dir = np.array([math.cos(rear_rad), 0.0, math.sin(rear_rad)])
+        rear_point = target.position.to_numpy() + rear_dir * FLANKING_OFFSET_DISTANCE
+
+        vec = rear_point - unit.position.to_numpy()
+        dist = float(np.linalg.norm(vec))
+        if dist < 1e-6:
+            return np.zeros(3)
+        return FLANKING_ATTRACTION_WEIGHT * vec / dist
+
     def _calculate_potential_field(
         self,
         unit: MobileSuit,
         target: MobileSuit | None = None,
         retreat_points: list[RetreatPoint] | None = None,
+        dt: float = 0.1,
     ) -> np.ndarray:
         """ポテンシャルフィールド法による目標方向ベクトルを計算する.
 
@@ -145,6 +198,7 @@ class MovementMixin:
             unit: 移動するユニット
             target: 攻撃対象ユニット（ATTACK 行動時に強引力を与える）
             retreat_points: 撤退ポイントのリスト（Phase 3-3 用）
+            dt: 時間ステップ幅 (s)（フランキング EN 消費計算に使用）
 
         Returns:
             3D 単位ベクトル（XZ 平面）
@@ -193,6 +247,11 @@ class MovementMixin:
                 away_vec = (pos_unit - obs_pos) / max(obs_dist, 1.0)
                 total_force += OBSTACLE_REPULSION_COEFF * away_vec
 
+        # 8. フランキング引力: 目標の背後方向への引力 (Phase E-3.5)
+        # ATTACK / MOVE 行動かつターゲットが存在する場合のみ有効
+        if current_action in ("ATTACK", "MOVE") and target is not None:
+            total_force += self._flanking_attraction(unit, target, dt)
+
         # 正規化 — ゼロベクトル時はランダム方向でローカルミニマムを回避
         total_force[1] = 0.0  # Y 成分を XZ 平面に固定
         magnitude = float(np.linalg.norm(total_force))
@@ -220,6 +279,7 @@ class MovementMixin:
             actor,
             target,
             self.retreat_points,  # type: ignore[attr-defined]
+            dt,
         )
         self._apply_inertia(actor, desired_direction, dt)
 
@@ -487,6 +547,7 @@ class MovementMixin:
                         actor,
                         target=None,
                         retreat_points=self.retreat_points,  # type: ignore[attr-defined]
+                        dt=dt,
                     )
                     self._apply_inertia(actor, desired_direction, dt)
                     if distance >= MOVE_LOG_MIN_DIST:
@@ -525,6 +586,7 @@ class MovementMixin:
             actor,
             target=None,
             retreat_points=self.retreat_points,  # type: ignore[attr-defined]
+            dt=dt,
         )
         self._apply_inertia(actor, desired_direction, dt)
 

--- a/backend/app/engine/simulation.py
+++ b/backend/app/engine/simulation.py
@@ -94,6 +94,35 @@ def _build_unit_pilot_stats(
     return result
 
 
+def _resolve_flanking_skill_level(
+    unit: "MobileSuit",
+    is_player: bool,
+    player_skills: dict[str, int] | None,
+) -> int:
+    """ユニットのフランキングスキルレベルを解決する (Phase E-3.5).
+
+    Args:
+        unit: 対象ユニット
+        is_player: プレイヤーユニットかどうか
+        player_skills: プレイヤーのスキル辞書
+
+    Returns:
+        フランキングスキルレベル (0〜3)
+    """
+    from app.core.npc_data import get_ace_pilot_by_id  # noqa: PLC0415
+
+    if is_player:
+        return (player_skills or {}).get("flanking", 0)
+
+    ace_id: str | None = getattr(unit, "ace_id", None)
+    if getattr(unit, "is_ace", False) and ace_id is not None:
+        ace_data = get_ace_pilot_by_id(ace_id)
+        if ace_data and "skills" in ace_data:
+            return int(ace_data["skills"].get("flanking", 0))
+
+    return 1 if getattr(unit, "personality", None) == "AGGRESSIVE" else 0
+
+
 class BattleSimulator(
     BattleUtilsMixin,
     CombatMixin,
@@ -219,6 +248,7 @@ class BattleSimulator(
                 "is_boosting": False,  # ブースト中フラグ (Phase B)
                 "boost_elapsed": 0.0,  # 現ブーストの継続時間 (s) (Phase B)
                 "boost_cooldown_remaining": 0.0,  # 残クールダウン時間 (s) (Phase B)
+                "flanking_skill_level": 0,  # フランキングスキルレベル (Phase E-3.5)
             }
             # 各武器のリソース状態を初期化
             for weapon in unit.weapons:
@@ -229,6 +259,15 @@ class BattleSimulator(
                     else None,
                     "cooldown_remaining_sec": 0.0,  # 残りクールダウン時間（秒）(Phase 6-2)
                 }
+
+            # フランキングスキルレベルの解決 (Phase E-3.5)
+            self.unit_resources[unit_id]["flanking_skill_level"] = (
+                _resolve_flanking_skill_level(
+                    unit,
+                    is_player=str(unit.id) == str(self.player.id),
+                    player_skills=self.player_skills,
+                )
+            )
 
         # 中階層ファジィ推論エンジン（AGGRESSIVEルールセット）
         self._fuzzy_engine: FuzzyEngine = FuzzyEngine.from_json(


### PR DESCRIPTION
## Summary

- `npc_data.py`: エース 5 体に `skills.flanking` を追加（AGGRESSIVE→Lv.3、その他→Lv.2）
- `simulation.py`: `_resolve_flanking_skill_level()` をモジュールレベル関数として追加。`unit_resources` 初期化時にプレイヤー・Ace NPC・通常 NPC の優先順位でスキルレベルを解決
- `movement.py`: `_flanking_attraction()` メソッドを追加。`_calculate_potential_field()` の step 8 としてターゲット後方引力を合算し、EN を消費する

Closes #353
Parent Issue: #351
依存: #355 (E-3.5-1)

## Test plan

- [x] 全ユニットテスト 610 件通過（`pytest tests/unit`）
- [x] mypy・ruff 通過
- [ ] E-3.5-3 のテストで詳細な挙動を検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)