### PR TITLE
feat(E-3.5-3): フランキングスキルのテスト追加

### DIFF
--- a/backend/app/core/npc_data.py
+++ b/backend/app/core/npc_data.py
@@ -131,6 +131,7 @@ ACE_PILOTS = [
         "bounty_exp": 500,
         "bounty_credits": 1000,
         "stats": {"sht": 10, "mel": 10, "intel": 9, "ref": 15, "tou": 7, "luk": 8},
+        "skills": {"flanking": 3},
     },
     {
         "id": "ace_ramba_ral",
@@ -175,6 +176,7 @@ ACE_PILOTS = [
         "bounty_exp": 450,
         "bounty_credits": 900,
         "stats": {"sht": 7, "mel": 14, "intel": 8, "ref": 10, "tou": 12, "luk": 6},
+        "skills": {"flanking": 3},
     },
     {
         "id": "ace_yazan_gable",
@@ -220,6 +222,7 @@ ACE_PILOTS = [
         "bounty_exp": 480,
         "bounty_credits": 950,
         "stats": {"sht": 10, "mel": 13, "intel": 7, "ref": 11, "tou": 13, "luk": 5},
+        "skills": {"flanking": 3},
     },
     {
         "id": "ace_amuro_ray",
@@ -266,6 +269,7 @@ ACE_PILOTS = [
         "bounty_exp": 800,
         "bounty_credits": 2000,
         "stats": {"sht": 13, "mel": 11, "intel": 15, "ref": 14, "tou": 9, "luk": 12},
+        "skills": {"flanking": 2},
     },
     {
         "id": "ace_haman_karn",
@@ -312,6 +316,7 @@ ACE_PILOTS = [
         "bounty_exp": 750,
         "bounty_credits": 1800,
         "stats": {"sht": 11, "mel": 10, "intel": 14, "ref": 11, "tou": 8, "luk": 13},
+        "skills": {"flanking": 2},
     },
 ]
 

--- a/backend/app/core/skills.py
+++ b/backend/app/core/skills.py
@@ -43,6 +43,13 @@ SKILL_MASTER_DATA: dict[str, SkillDefinition] = {
         "effect_per_level": 1.0,  # +1% / Lv
         "max_level": 10,
     },
+    "flanking": {
+        "id": "flanking",
+        "name": "フランキング",
+        "description": "目標の背後へ回り込む確率が上昇する。ブーストENを消費する",
+        "effect_per_level": 0.0,  # 効果は FLANKING_ACTIVATION_PROBS で管理
+        "max_level": 3,
+    },
 }
 
 # スキルポイントコスト（一律1 SP）

--- a/backend/app/engine/constants.py
+++ b/backend/app/engine/constants.py
@@ -219,3 +219,14 @@ SECTOR_DAMAGE_MODIFIERS: dict[str, float] = {
 SECTOR_FRONT_DEG: float = 60.0
 SECTOR_FRONT_SIDE_DEG: float = 120.0
 SECTOR_REAR_SIDE_DEG: float = 150.0
+
+# フランキング（背後移動）パッシブスキル定数 (Phase E-3.5)
+FLANKING_OFFSET_DISTANCE: float = 30.0
+FLANKING_ATTRACTION_WEIGHT: float = 1.5
+FLANKING_ENERGY_COST_RATE: float = 1.5  # DEFAULT_BOOST_EN_COST に対する乗数
+FLANKING_ACTIVATION_PROBS: dict[int, float] = {
+    0: 0.05,  # スキルなし: 5%（偶発的な背後取得）
+    1: 0.30,  # Lv.1: 30%（経験者）
+    2: 0.60,  # Lv.2: 60%（ベテラン）
+    3: 0.90,  # Lv.3: 90%（エース級）
+}

--- a/backend/app/engine/movement.py
+++ b/backend/app/engine/movement.py
@@ -10,8 +10,13 @@ from app.engine.constants import (
     ALLY_REPULSION_RADIUS,
     BOUNDARY_MARGIN,
     DEFAULT_BOOST_COOLDOWN,
+    DEFAULT_BOOST_EN_COST,
     DEFAULT_BOOST_MAX_DURATION,
     DEFAULT_BOOST_SPEED_MULTIPLIER,
+    FLANKING_ACTIVATION_PROBS,
+    FLANKING_ATTRACTION_WEIGHT,
+    FLANKING_ENERGY_COST_RATE,
+    FLANKING_OFFSET_DISTANCE,
     HIGH_THREAT_THRESHOLD,
     MELEE_BOOST_ARRIVAL_RANGE,
     MOVE_LOG_MIN_DIST,
@@ -128,11 +133,59 @@ class MovementMixin:
                 force += RETREAT_ATTRACTION_COEFF * vec / dist
         return force
 
+    def _flanking_attraction(
+        self,
+        unit: MobileSuit,
+        target: MobileSuit,
+        dt: float,
+    ) -> np.ndarray:
+        """フランキング引力ベクトルを計算し EN を消費する (Phase E-3.5).
+
+        スキルレベルに応じた確率でターゲット後方への引力ベクトルを返す。
+        EN 不足時はゼロベクトルを返してフォールバックする。
+
+        Args:
+            unit: 移動するユニット
+            target: 攻撃対象ユニット
+            dt: 時間ステップ幅 (s)
+
+        Returns:
+            3D 引力ベクトル（未正規化）。未発動または EN 不足時はゼロベクトル。
+        """
+        unit_id = str(unit.id)
+        resources = self.unit_resources[unit_id]  # type: ignore[attr-defined]
+
+        skill_level = resources.get("flanking_skill_level", 0)
+        prob = FLANKING_ACTIVATION_PROBS.get(skill_level, 0.0)
+        if prob <= 0.0 or random.random() > prob:
+            return np.zeros(3)
+
+        boost_en_cost = getattr(unit, "boost_en_cost", DEFAULT_BOOST_EN_COST)
+        flanking_en_cost = FLANKING_ENERGY_COST_RATE * boost_en_cost * dt
+        if resources.get("current_en", 0.0) < flanking_en_cost:
+            return np.zeros(3)
+        resources["current_en"] -= flanking_en_cost
+
+        # ターゲット後方 = body_heading + 180°
+        target_heading_deg = self.unit_resources[str(target.id)].get(  # type: ignore[attr-defined]
+            "body_heading_deg", 0.0
+        )
+        rear_rad = math.radians(target_heading_deg + 180.0)
+        rear_dir = np.array([math.cos(rear_rad), 0.0, math.sin(rear_rad)])
+        rear_point = target.position.to_numpy() + rear_dir * FLANKING_OFFSET_DISTANCE
+
+        vec = rear_point - unit.position.to_numpy()
+        dist = float(np.linalg.norm(vec))
+        if dist < 1e-6:
+            return np.zeros(3)
+        return FLANKING_ATTRACTION_WEIGHT * vec / dist
+
     def _calculate_potential_field(
         self,
         unit: MobileSuit,
         target: MobileSuit | None = None,
         retreat_points: list[RetreatPoint] | None = None,
+        dt: float = 0.1,
     ) -> np.ndarray:
         """ポテンシャルフィールド法による目標方向ベクトルを計算する.
 
@@ -145,6 +198,7 @@ class MovementMixin:
             unit: 移動するユニット
             target: 攻撃対象ユニット（ATTACK 行動時に強引力を与える）
             retreat_points: 撤退ポイントのリスト（Phase 3-3 用）
+            dt: 時間ステップ幅 (s)（フランキング EN 消費計算に使用）
 
         Returns:
             3D 単位ベクトル（XZ 平面）
@@ -193,6 +247,11 @@ class MovementMixin:
                 away_vec = (pos_unit - obs_pos) / max(obs_dist, 1.0)
                 total_force += OBSTACLE_REPULSION_COEFF * away_vec
 
+        # 8. フランキング引力: 目標の背後方向への引力 (Phase E-3.5)
+        # ATTACK / MOVE 行動かつターゲットが存在する場合のみ有効
+        if current_action in ("ATTACK", "MOVE") and target is not None:
+            total_force += self._flanking_attraction(unit, target, dt)
+
         # 正規化 — ゼロベクトル時はランダム方向でローカルミニマムを回避
         total_force[1] = 0.0  # Y 成分を XZ 平面に固定
         magnitude = float(np.linalg.norm(total_force))
@@ -220,6 +279,7 @@ class MovementMixin:
             actor,
             target,
             self.retreat_points,  # type: ignore[attr-defined]
+            dt,
         )
         self._apply_inertia(actor, desired_direction, dt)
 
@@ -487,6 +547,7 @@ class MovementMixin:
                         actor,
                         target=None,
                         retreat_points=self.retreat_points,  # type: ignore[attr-defined]
+                        dt=dt,
                     )
                     self._apply_inertia(actor, desired_direction, dt)
                     if distance >= MOVE_LOG_MIN_DIST:
@@ -525,6 +586,7 @@ class MovementMixin:
             actor,
             target=None,
             retreat_points=self.retreat_points,  # type: ignore[attr-defined]
+            dt=dt,
         )
         self._apply_inertia(actor, desired_direction, dt)
 

--- a/backend/app/engine/simulation.py
+++ b/backend/app/engine/simulation.py
@@ -94,6 +94,35 @@ def _build_unit_pilot_stats(
     return result
 
 
+def _resolve_flanking_skill_level(
+    unit: "MobileSuit",
+    is_player: bool,
+    player_skills: dict[str, int] | None,
+) -> int:
+    """ユニットのフランキングスキルレベルを解決する (Phase E-3.5).
+
+    Args:
+        unit: 対象ユニット
+        is_player: プレイヤーユニットかどうか
+        player_skills: プレイヤーのスキル辞書
+
+    Returns:
+        フランキングスキルレベル (0〜3)
+    """
+    from app.core.npc_data import get_ace_pilot_by_id  # noqa: PLC0415
+
+    if is_player:
+        return (player_skills or {}).get("flanking", 0)
+
+    ace_id: str | None = getattr(unit, "ace_id", None)
+    if getattr(unit, "is_ace", False) and ace_id is not None:
+        ace_data = get_ace_pilot_by_id(ace_id)
+        if ace_data and "skills" in ace_data:
+            return int(ace_data["skills"].get("flanking", 0))
+
+    return 1 if getattr(unit, "personality", None) == "AGGRESSIVE" else 0
+
+
 class BattleSimulator(
     BattleUtilsMixin,
     CombatMixin,
@@ -219,6 +248,7 @@ class BattleSimulator(
                 "is_boosting": False,  # ブースト中フラグ (Phase B)
                 "boost_elapsed": 0.0,  # 現ブーストの継続時間 (s) (Phase B)
                 "boost_cooldown_remaining": 0.0,  # 残クールダウン時間 (s) (Phase B)
+                "flanking_skill_level": 0,  # フランキングスキルレベル (Phase E-3.5)
             }
             # 各武器のリソース状態を初期化
             for weapon in unit.weapons:
@@ -229,6 +259,15 @@ class BattleSimulator(
                     else None,
                     "cooldown_remaining_sec": 0.0,  # 残りクールダウン時間（秒）(Phase 6-2)
                 }
+
+            # フランキングスキルレベルの解決 (Phase E-3.5)
+            self.unit_resources[unit_id]["flanking_skill_level"] = (
+                _resolve_flanking_skill_level(
+                    unit,
+                    is_player=str(unit.id) == str(self.player.id),
+                    player_skills=self.player_skills,
+                )
+            )
 
         # 中階層ファジィ推論エンジン（AGGRESSIVEルールセット）
         self._fuzzy_engine: FuzzyEngine = FuzzyEngine.from_json(

--- a/backend/tests/unit/test_phase_e35_flanking.py
+++ b/backend/tests/unit/test_phase_e35_flanking.py
@@ -1,0 +1,394 @@
+"""Phase E-3.5: フランキングパッシブスキルのテスト."""
+
+from unittest.mock import patch
+
+import numpy as np
+import pytest
+
+from app.core.npc_data import ACE_PILOTS
+from app.core.skills import SKILL_MASTER_DATA
+from app.engine.constants import (
+    DEFAULT_BOOST_EN_COST,
+    FLANKING_ACTIVATION_PROBS,
+    FLANKING_ATTRACTION_WEIGHT,
+    FLANKING_ENERGY_COST_RATE,
+    FLANKING_OFFSET_DISTANCE,
+)
+from app.engine.simulation import BattleSimulator, _resolve_flanking_skill_level
+from app.models.models import MobileSuit, Vector3, Weapon
+
+# ---------------------------------------------------------------------------
+# テストヘルパー
+# ---------------------------------------------------------------------------
+
+
+def _make_weapon() -> Weapon:
+    return Weapon(
+        id="test_weapon",
+        name="Test Rifle",
+        power=100,
+        range=600.0,
+        accuracy=80,
+        type="BEAM",
+        optimal_range=300.0,
+        decay_rate=0.05,
+        cooldown_sec=0.0,
+        max_ammo=999,
+    )
+
+
+def _make_unit(
+    name: str,
+    side: str,
+    position: Vector3,
+    personality: str | None = None,
+    is_ace: bool = False,
+    ace_id: str | None = None,
+    max_en: float = 2000.0,
+) -> MobileSuit:
+    team_id = "PLAYER_TEAM" if side == "PLAYER" else "ENEMY_TEAM"
+    return MobileSuit(
+        name=name,
+        max_hp=1000,
+        current_hp=1000,
+        armor=0,
+        mobility=1.0,
+        position=position,
+        weapons=[_make_weapon()],
+        side=side,
+        team_id=team_id,
+        tactics={"priority": "CLOSEST", "range": "BALANCED"},
+        max_speed=100.0,
+        acceleration=30.0,
+        sensor_range=10000.0,
+        personality=personality,
+        is_ace=is_ace,
+        ace_id=ace_id,
+        max_en=max_en,
+    )
+
+
+def _make_sim(
+    player_flanking: int = 0,
+    player_en: float = 2000.0,
+    enemy_personality: str | None = None,
+) -> tuple[MobileSuit, MobileSuit, BattleSimulator]:
+    """BattleSimulator の標準フィクスチャ."""
+    player = _make_unit(
+        "Player",
+        "PLAYER",
+        Vector3(x=0.0, y=0.0, z=500.0),
+        max_en=player_en,
+    )
+    enemy = _make_unit(
+        "Enemy",
+        "ENEMY",
+        Vector3(x=0.0, y=0.0, z=0.0),
+        personality=enemy_personality,
+    )
+    skills = {"flanking": player_flanking} if player_flanking > 0 else {}
+    sim = BattleSimulator(player, [enemy], player_skills=skills)
+    sim.team_detected_units["PLAYER_TEAM"].add(enemy.id)
+    sim.team_detected_units["ENEMY_TEAM"].add(player.id)
+    return player, enemy, sim
+
+
+# ---------------------------------------------------------------------------
+# TestFlankingConstants: 定数値とスキルマスタデータの確認
+# ---------------------------------------------------------------------------
+
+
+class TestFlankingConstants:
+    """フランキング関連定数と SKILL_MASTER_DATA エントリの値を検証する."""
+
+    def test_flanking_offset_distance(self) -> None:
+        """FLANKING_OFFSET_DISTANCE が 30.0 であること."""
+        assert FLANKING_OFFSET_DISTANCE == 30.0
+
+    def test_flanking_attraction_weight(self) -> None:
+        """FLANKING_ATTRACTION_WEIGHT が 1.5 であること."""
+        assert FLANKING_ATTRACTION_WEIGHT == 1.5
+
+    def test_flanking_energy_cost_rate(self) -> None:
+        """FLANKING_ENERGY_COST_RATE が 1.5 であること."""
+        assert FLANKING_ENERGY_COST_RATE == 1.5
+
+    def test_flanking_activation_probs_values(self) -> None:
+        """各スキルレベルの発動確率が仕様通りであること."""
+        assert FLANKING_ACTIVATION_PROBS[0] == pytest.approx(0.05)
+        assert FLANKING_ACTIVATION_PROBS[1] == pytest.approx(0.30)
+        assert FLANKING_ACTIVATION_PROBS[2] == pytest.approx(0.60)
+        assert FLANKING_ACTIVATION_PROBS[3] == pytest.approx(0.90)
+
+    def test_flanking_skill_in_master_data(self) -> None:
+        """Flanking スキルが SKILL_MASTER_DATA に登録されていること."""
+        assert "flanking" in SKILL_MASTER_DATA
+
+    def test_flanking_skill_max_level(self) -> None:
+        """Flanking スキルの最大レベルが 3 であること."""
+        assert SKILL_MASTER_DATA["flanking"]["max_level"] == 3
+
+    def test_flanking_skill_id(self) -> None:
+        """Flanking スキルの ID が正しいこと."""
+        assert SKILL_MASTER_DATA["flanking"]["id"] == "flanking"
+
+
+# ---------------------------------------------------------------------------
+# TestFlankingSkillLevelResolution: スキルレベル解決
+# ---------------------------------------------------------------------------
+
+
+class TestFlankingSkillLevelResolution:
+    """unit_resources["flanking_skill_level"] の解決ロジックを検証する."""
+
+    def test_player_gets_flanking_from_player_skills(self) -> None:
+        """プレイヤーは player_skills["flanking"] の値を参照すること."""
+        player, enemy, sim = _make_sim(player_flanking=2)
+        assert sim.unit_resources[str(player.id)]["flanking_skill_level"] == 2
+
+    def test_player_default_flanking_is_zero(self) -> None:
+        """player_skills に flanking がない場合はレベル 0 になること."""
+        player, enemy, sim = _make_sim(player_flanking=0)
+        assert sim.unit_resources[str(player.id)]["flanking_skill_level"] == 0
+
+    def test_aggressive_npc_gets_level_1(self) -> None:
+        """personality=AGGRESSIVE の通常 NPC はレベル 1 になること."""
+        player, enemy, sim = _make_sim(enemy_personality="AGGRESSIVE")
+        assert sim.unit_resources[str(enemy.id)]["flanking_skill_level"] == 1
+
+    def test_cautious_npc_gets_level_0(self) -> None:
+        """personality=CAUTIOUS の通常 NPC はレベル 0 になること."""
+        player, enemy, sim = _make_sim(enemy_personality="CAUTIOUS")
+        assert sim.unit_resources[str(enemy.id)]["flanking_skill_level"] == 0
+
+    def test_sniper_npc_gets_level_0(self) -> None:
+        """personality=SNIPER の通常 NPC はレベル 0 になること."""
+        player, enemy, sim = _make_sim(enemy_personality="SNIPER")
+        assert sim.unit_resources[str(enemy.id)]["flanking_skill_level"] == 0
+
+    def test_no_personality_npc_gets_level_0(self) -> None:
+        """personality=None の通常 NPC はレベル 0 になること."""
+        player, enemy, sim = _make_sim(enemy_personality=None)
+        assert sim.unit_resources[str(enemy.id)]["flanking_skill_level"] == 0
+
+    def test_ace_npc_aggressive_gets_level_3(self) -> None:
+        """AGGRESSIVE エース（シャア）は flanking Lv.3 になること."""
+        player = _make_unit("Player", "PLAYER", Vector3(x=0.0, y=0.0, z=500.0))
+        ace_enemy = _make_unit(
+            "Char",
+            "ENEMY",
+            Vector3(x=0.0, y=0.0, z=0.0),
+            personality="AGGRESSIVE",
+            is_ace=True,
+            ace_id="ace_char_aznable",
+        )
+        sim = BattleSimulator(player, [ace_enemy])
+        assert sim.unit_resources[str(ace_enemy.id)]["flanking_skill_level"] == 3
+
+    def test_ace_npc_non_aggressive_gets_level_2(self) -> None:
+        """非 AGGRESSIVE エース（アムロ）は flanking Lv.2 になること."""
+        player = _make_unit("Player", "PLAYER", Vector3(x=0.0, y=0.0, z=500.0))
+        ace_enemy = _make_unit(
+            "Amuro",
+            "ENEMY",
+            Vector3(x=0.0, y=0.0, z=0.0),
+            personality="CAUTIOUS",
+            is_ace=True,
+            ace_id="ace_amuro_ray",
+        )
+        sim = BattleSimulator(player, [ace_enemy])
+        assert sim.unit_resources[str(ace_enemy.id)]["flanking_skill_level"] == 2
+
+    def test_resolve_flanking_helper_player(self) -> None:
+        """_resolve_flanking_skill_level がプレイヤーのスキルを正しく返すこと."""
+        player = _make_unit("P", "PLAYER", Vector3(x=0.0, y=0.0, z=0.0))
+        level = _resolve_flanking_skill_level(
+            player, is_player=True, player_skills={"flanking": 3}
+        )
+        assert level == 3
+
+    def test_resolve_flanking_helper_no_skills(self) -> None:
+        """_resolve_flanking_skill_level が player_skills=None のとき 0 を返すこと."""
+        player = _make_unit("P", "PLAYER", Vector3(x=0.0, y=0.0, z=0.0))
+        level = _resolve_flanking_skill_level(
+            player, is_player=True, player_skills=None
+        )
+        assert level == 0
+
+
+# ---------------------------------------------------------------------------
+# TestFlankingAttractionVector: ベクトル計算
+# ---------------------------------------------------------------------------
+
+
+class TestFlankingAttractionVector:
+    """_flanking_attraction() のベクトル計算・条件分岐を検証する."""
+
+    def test_no_flanking_force_when_level_0_and_roll_above_threshold(self) -> None:
+        """Lv.0（確率 5%）のとき random=0.1（> 0.05）では発動しないこと."""
+        player, enemy, sim = _make_sim(player_flanking=0)
+        with patch("app.engine.movement.random.random", return_value=0.1):
+            force = sim._flanking_attraction(player, enemy, dt=0.1)
+        assert np.allclose(force, np.zeros(3))
+
+    def test_flanking_force_nonzero_when_level3_activated(self) -> None:
+        """Lv.3 で random=0.0（< 0.9）のとき非ゼロベクトルを返すこと."""
+        player, enemy, sim = _make_sim(player_flanking=3)
+        with patch("app.engine.movement.random.random", return_value=0.0):
+            force = sim._flanking_attraction(player, enemy, dt=0.1)
+        assert not np.allclose(force, np.zeros(3))
+
+    def test_flanking_force_zero_when_en_insufficient(self) -> None:
+        """EN 不足時はゼロベクトルを返してフォールバックすること."""
+        player, enemy, sim = _make_sim(player_flanking=3, player_en=0.0)
+        sim.unit_resources[str(player.id)]["current_en"] = 0.0
+        with patch("app.engine.movement.random.random", return_value=0.0):
+            force = sim._flanking_attraction(player, enemy, dt=0.1)
+        assert np.allclose(force, np.zeros(3))
+
+    def test_flanking_rear_direction_geometry(self) -> None:
+        """Target が heading=0（+X 向き）のとき後方引力が -X 方向になること."""
+        player = _make_unit("Player", "PLAYER", Vector3(x=200.0, y=0.0, z=0.0))
+        enemy = _make_unit("Enemy", "ENEMY", Vector3(x=0.0, y=0.0, z=0.0))
+        sim = BattleSimulator(player, [enemy], player_skills={"flanking": 3})
+        sim.team_detected_units["PLAYER_TEAM"].add(enemy.id)
+        sim.team_detected_units["ENEMY_TEAM"].add(player.id)
+
+        # enemy の body_heading_deg = 0 (デフォルト) → 正面=+X, 後方=-X
+        sim.unit_resources[str(enemy.id)]["body_heading_deg"] = 0.0
+
+        with patch("app.engine.movement.random.random", return_value=0.0):
+            force = sim._flanking_attraction(player, enemy, dt=0.1)
+
+        # 後方ポイントは (-30, 0, 0)、プレイヤーは (200, 0, 0) → 力は -X 方向
+        assert force[0] < 0.0
+        assert abs(force[2]) < abs(force[0])  # Z 成分は X 成分より小さい
+
+    def test_flanking_force_zero_when_not_activated(self) -> None:
+        """random=1.0（> 0.9）のとき Lv.3 でも発動しないこと."""
+        player, enemy, sim = _make_sim(player_flanking=3)
+        with patch("app.engine.movement.random.random", return_value=1.0):
+            force = sim._flanking_attraction(player, enemy, dt=0.1)
+        assert np.allclose(force, np.zeros(3))
+
+
+# ---------------------------------------------------------------------------
+# TestFlankingEnergyConsumption: EN 消費
+# ---------------------------------------------------------------------------
+
+
+class TestFlankingEnergyConsumption:
+    """フランキング発動時の EN 消費量を検証する."""
+
+    def test_flanking_consumes_en_when_activated(self) -> None:
+        """発動時に FLANKING_ENERGY_COST_RATE * boost_en_cost * dt を消費すること."""
+        player, enemy, sim = _make_sim(player_flanking=3, player_en=2000.0)
+        en_before = sim.unit_resources[str(player.id)]["current_en"]
+        dt = 0.1
+        expected_cost = FLANKING_ENERGY_COST_RATE * DEFAULT_BOOST_EN_COST * dt
+
+        with patch("app.engine.movement.random.random", return_value=0.0):
+            sim._flanking_attraction(player, enemy, dt=dt)
+
+        en_after = sim.unit_resources[str(player.id)]["current_en"]
+        assert en_after == pytest.approx(en_before - expected_cost)
+
+    def test_flanking_does_not_consume_en_when_not_activated(self) -> None:
+        """未発動時は EN が変化しないこと."""
+        player, enemy, sim = _make_sim(player_flanking=3, player_en=2000.0)
+        en_before = sim.unit_resources[str(player.id)]["current_en"]
+
+        with patch("app.engine.movement.random.random", return_value=1.0):
+            sim._flanking_attraction(player, enemy, dt=0.1)
+
+        en_after = sim.unit_resources[str(player.id)]["current_en"]
+        assert en_after == pytest.approx(en_before)
+
+    def test_flanking_does_not_consume_en_when_insufficient(self) -> None:
+        """EN=0 の場合は消費せずゼロのまま返すこと."""
+        player, enemy, sim = _make_sim(player_flanking=3, player_en=0.0)
+        sim.unit_resources[str(player.id)]["current_en"] = 0.0
+
+        with patch("app.engine.movement.random.random", return_value=0.0):
+            sim._flanking_attraction(player, enemy, dt=0.1)
+
+        assert sim.unit_resources[str(player.id)]["current_en"] == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# TestFlankingIntegration: 統合テスト
+# ---------------------------------------------------------------------------
+
+
+class TestFlankingIntegration:
+    """フランキングスキルのシステム全体としての挙動を検証する."""
+
+    def test_flanking_does_not_activate_during_retreat(self) -> None:
+        """RETREAT 行動中はフランキングが発動せず EN が消費されないこと."""
+        player, enemy, sim = _make_sim(player_flanking=3)
+        sim.unit_resources[str(player.id)]["current_action"] = "RETREAT"
+        en_before = sim.unit_resources[str(player.id)]["current_en"]
+
+        with patch("app.engine.movement.random.random", return_value=0.0):
+            sim._calculate_potential_field(player, enemy, dt=0.1)
+
+        assert sim.unit_resources[str(player.id)]["current_en"] == pytest.approx(
+            en_before
+        )
+
+    def test_flanking_level3_drains_more_en_per_step_than_level0(self) -> None:
+        """Lv.3（常時発動）は Lv.0（常時不発動）より EN 消費が多いこと."""
+        n_steps = 50
+        dt = 0.1
+        expected_per_step = FLANKING_ENERGY_COST_RATE * DEFAULT_BOOST_EN_COST * dt
+
+        # Lv.3: random=0.0 で常に発動 (0.0 <= 0.90)
+        player3, enemy3, sim3 = _make_sim(player_flanking=3, player_en=10000.0)
+        en_start3 = sim3.unit_resources[str(player3.id)]["current_en"]
+        with patch("app.engine.movement.random.random", return_value=0.0):
+            for _ in range(n_steps):
+                sim3._flanking_attraction(player3, enemy3, dt=dt)
+        en_consumed3 = en_start3 - sim3.unit_resources[str(player3.id)]["current_en"]
+
+        # Lv.0: random=1.0 で常に不発動 (1.0 > 0.05)
+        player0, enemy0, sim0 = _make_sim(player_flanking=0, player_en=10000.0)
+        en_start0 = sim0.unit_resources[str(player0.id)]["current_en"]
+        with patch("app.engine.movement.random.random", return_value=1.0):
+            for _ in range(n_steps):
+                sim0._flanking_attraction(player0, enemy0, dt=dt)
+        en_consumed0 = en_start0 - sim0.unit_resources[str(player0.id)]["current_en"]
+
+        assert en_consumed3 == pytest.approx(n_steps * expected_per_step)
+        assert en_consumed0 == pytest.approx(0.0)
+        assert en_consumed3 > en_consumed0
+
+    def test_ace_pilots_have_flanking_skills(self) -> None:
+        """全エースパイロットに flanking スキルが定義されていること."""
+        for ace in ACE_PILOTS:
+            assert "skills" in ace, f"{ace['id']} に skills キーがない"
+            assert "flanking" in ace["skills"], f"{ace['id']} に flanking スキルがない"
+            level = ace["skills"]["flanking"]
+            assert 2 <= level <= 3, f"{ace['id']} の flanking レベルが範囲外: {level}"
+
+    def test_aggressive_ace_has_flanking_level3(self) -> None:
+        """AGGRESSIVE エースは flanking Lv.3 を持つこと."""
+        aggressive_aces = [a for a in ACE_PILOTS if a["personality"] == "AGGRESSIVE"]
+        for ace in aggressive_aces:
+            assert ace["skills"]["flanking"] == 3, (
+                f"{ace['id']} は AGGRESSIVE なので flanking Lv.3 のはず"
+            )
+
+    def test_calculate_potential_field_accepts_dt(self) -> None:
+        """_calculate_potential_field が dt に応じた EN を消費すること."""
+        player, enemy, sim = _make_sim(player_flanking=3, player_en=2000.0)
+        sim.unit_resources[str(player.id)]["current_action"] = "ATTACK"
+        en_before = sim.unit_resources[str(player.id)]["current_en"]
+
+        dt = 0.5
+        expected_cost = FLANKING_ENERGY_COST_RATE * DEFAULT_BOOST_EN_COST * dt
+
+        with patch("app.engine.movement.random.random", return_value=0.0):
+            sim._calculate_potential_field(player, enemy, dt=dt)
+
+        en_after = sim.unit_resources[str(player.id)]["current_en"]
+        assert en_after == pytest.approx(en_before - expected_cost)


### PR DESCRIPTION
## Summary

`backend/tests/unit/test_phase_e35_flanking.py` を新規追加（30 件）。

| クラス | 件数 | 内容 |
|---|---|---|
| `TestFlankingConstants` | 7 | 定数値・スキルマスタデータ確認 |
| `TestFlankingSkillLevelResolution` | 10 | Player / Ace NPC / 通常 NPC のレベル解決 |
| `TestFlankingAttractionVector` | 5 | ベクトル計算・EN 不足フォールバック・後方方向幾何 |
| `TestFlankingEnergyConsumption` | 3 | 発動時消費量・未発動時 EN 不変 |
| `TestFlankingIntegration` | 5 | RETREAT 時非発動・EN 消費比較・エース全員確認 |

Closes #354
Parent Issue: #351
依存: #356 (E-3.5-2)

## Test plan

- [x] 新規テスト 30 件全通過
- [x] 既存ユニットテスト 640 件通過（リグレッションなし）
- [x] mypy・ruff 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)