### PR TITLE
fix: スキル取得時の hydration エラーと KeyError を修正

### DIFF
--- a/backend/app/services/pilot_service.py
+++ b/backend/app/services/pilot_service.py
@@ -303,7 +303,9 @@ class PilotService:
             raise ValueError(f"スキルポイントが不足しています (必要: {SKILL_COST})")
 
         # スキルレベルアップとSP消費
-        pilot.skills[skill_id] = current_level + 1
+        # JSON カラムは dict のインプレース変更を SQLAlchemy が追跡できないため、
+        # 新しい dict を代入して変更を確実に検知させる
+        pilot.skills = {**pilot.skills, skill_id: current_level + 1}
         pilot.skill_points -= SKILL_COST
         pilot.updated_at = datetime.now(UTC)
 

--- a/frontend/src/components/pilot/ParameterTuningPanel.tsx
+++ b/frontend/src/components/pilot/ParameterTuningPanel.tsx
@@ -125,10 +125,10 @@ export default function ParameterTuningPanel({ pilot, mutatePilot }: ParameterTu
                 </div>
                 <div className="text-right shrink-0 ml-2">
                   <p className="text-xl font-bold text-[#ffb000]">
-                    <p className={`font-bold ${rankColor}`}>
+                    <span className={`font-bold ${rankColor}`}>
                       Rank {rank}
                       ({displayVal})
-                    </p>
+                    </span>
                     {pendingVal > 0 && (
                       <span className="text-sm text-[#00ff41]"> (+{pendingVal})</span>
                     )}


### PR DESCRIPTION
## 概要

Closes #360

スキル取得操作で発生していた 2 つのバグを修正します。

---

## 変更内容

### フロントエンド: `<p>` 入れ子問題の修正

**ファイル:** `frontend/src/components/pilot/ParameterTuningPanel.tsx`

HTML 仕様で `<p>` の子要素に `<p>` を置くことは禁止されています。ブラウザが強制的に DOM を修正するため、Next.js の hydration と不一致が生じていました。

```diff
- <p className={`font-bold ${rankColor}`}>
+ <span className={`font-bold ${rankColor}`}>
    Rank {rank}
    ({displayVal})
- </p>
+ </span>
```

### バックエンド: SQLAlchemy JSON カラムの変更追跡問題の修正

**ファイル:** `backend/app/services/pilot_service.py`

`pilot.skills` は `Column(JSON)` で定義されています。SQLAlchemy は dict のインプレース変更（`d[k] = v`）を追跡できないため、`commit()` 時に変更が DB に書き込まれず、`session.refresh()` 後に元の状態に戻り KeyError が発生していました。

```diff
- pilot.skills[skill_id] = current_level + 1
+ pilot.skills = {**pilot.skills, skill_id: current_level + 1}
```

---

## 検証

- [x] `tsc --noEmit` — 修正ファイルに新規エラーなし（既存の無関係なエラーのみ）
- [x] `pytest tests/unit/test_pilot_skills.py` — 7 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)