### PR TITLE
fix: HoldSciFiButton の onHoldComplete を setProgress updater 外に移動

### DIFF
--- a/frontend/src/components/ui/HoldSciFiButton.tsx
+++ b/frontend/src/components/ui/HoldSciFiButton.tsx
@@ -37,28 +37,33 @@ export default function HoldSciFiButton({
   const [progress, setProgress] = useState(0);
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const firedRef = useRef(false);
+  // setInterval コールバック内で最新の進行度を参照するための ref
+  const progressRef = useRef(0);
 
   const startHold = useCallback(() => {
     if (disabled || loading) return;
     firedRef.current = false;
+    progressRef.current = 0;
 
     intervalRef.current = setInterval(() => {
-      setProgress((prev) => {
-        const next = prev + (TICK_MS / HOLD_DURATION_MS) * 100;
-        if (next >= 100) {
-          // 満タン → インターバルを止めて発火
-          if (intervalRef.current) {
-            clearInterval(intervalRef.current);
-            intervalRef.current = null;
-          }
-          if (!firedRef.current) {
-            firedRef.current = true;
-            onHoldComplete();
-          }
-          return 100;
+      const next = Math.min(
+        progressRef.current + (TICK_MS / HOLD_DURATION_MS) * 100,
+        100,
+      );
+      progressRef.current = next;
+      setProgress(next);
+
+      if (next >= 100 && !firedRef.current) {
+        // 満タン → インターバルを止めて発火
+        // onHoldComplete は updater 関数の外（setInterval コールバック直下）で呼び出す。
+        // updater 内で親コンポーネントの setState を呼ぶとレンダー中の setState 警告が出るため。
+        if (intervalRef.current) {
+          clearInterval(intervalRef.current);
+          intervalRef.current = null;
         }
-        return next;
-      });
+        firedRef.current = true;
+        onHoldComplete();
+      }
     }, TICK_MS);
   }, [disabled, loading, onHoldComplete]);
 
@@ -69,6 +74,7 @@ export default function HoldSciFiButton({
     }
     // 発火済みの場合はリセットしない（ローディング中の見た目を保つ）
     if (!firedRef.current) {
+      progressRef.current = 0;
       setProgress(0);
     }
   }, []);
@@ -76,6 +82,7 @@ export default function HoldSciFiButton({
   // loading が終わったらゲージをリセット
   useEffect(() => {
     if (!loading) {
+      progressRef.current = 0;
       setProgress(0);
       firedRef.current = false;
     }


### PR DESCRIPTION
## 概要

Closes #362

`setProgress` の updater 関数内で `onHoldComplete()` を呼び出していたことで発生していた "setState in render" 警告を修正します。

---

## 原因

```ts
// 修正前（問題あり）
setProgress((prev) => {
  const next = ...;
  if (next >= 100) {
    onHoldComplete(); // ← updater 内での親 setState → React 警告
  }
  return next;
});
```

React の updater 関数はレンダーフェーズ相当で実行されます。ここで親コンポーネント (`SkillDevelopmentPanel`) の `setUnlocking` を呼ぶと React の「レンダー中に別コンポーネントを更新している」制約に違反します。

## 修正内容

進行度を `progressRef` でも追跡し、`setInterval` コールバック直下（updater 外）で `onHoldComplete()` を呼ぶよう変更しました。

```ts
// 修正後
intervalRef.current = setInterval(() => {
  const next = Math.min(progressRef.current + ..., 100);
  progressRef.current = next;
  setProgress(next); // updater ではなく値を直接渡す

  if (next >= 100 && !firedRef.current) {
    // setInterval コールバック直下（レンダー外）で呼ぶので安全
    onHoldComplete();
  }
}, TICK_MS);
```

---

## 検証

- [x] `tsc --noEmit` — 修正ファイルに新規エラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)