### PR TITLE
feat: Hit-and-Away行動パターン + BattleLog速度情報拡充 (Issue #368)

### DIFF
--- a/backend/app/engine/action_handler.py
+++ b/backend/app/engine/action_handler.py
@@ -78,11 +78,51 @@ class ActionHandlerMixin:
             self._handle_boost_dash_action(
                 actor, target, weapon, pos_actor, pos_target, diff_vector, distance, dt
             )
+        elif current_action == "HIT_AND_AWAY":
+            self._handle_hit_and_away_action(
+                actor, target, weapon, pos_actor, pos_target, diff_vector, distance, dt
+            )
         else:
             # MOVE 行動（RETREAT フォールバックを含む）: 移動のみ（攻撃対象引力なし）
             self._process_movement(  # type: ignore[attr-defined]
                 actor, pos_actor, pos_target, diff_vector, distance, dt
             )
+
+    def _handle_hit_and_away_action(
+        self,
+        actor: MobileSuit,
+        target: MobileSuit,
+        weapon: object,
+        pos_actor: np.ndarray,
+        pos_target: np.ndarray,
+        diff_vector: np.ndarray,
+        distance: float,
+        dt: float,
+    ) -> None:
+        """Hit-and-Away行動処理 (Issue #368 A-2).
+
+        1ステップ内で3フェーズを処理:
+        ① ターゲットが射程外 → 接近移動
+        ② 射程内 → _process_attack() で攻撃
+        ③ 攻撃完了後 → ターゲットを斥力源として離脱移動
+        """
+        unit_id = str(actor.id)
+        if weapon and isinstance(weapon, Weapon) and distance <= weapon.range:
+            # フェーズ②: 射程内 → 攻撃
+            self._process_attack(actor, target, distance, pos_actor, weapon)  # type: ignore[attr-defined]
+            # フェーズ③: 攻撃後 → ターゲットを斥力源として離脱
+            # _calculate_potential_field() の HIT_AND_AWAY ケースでターゲット斥力を適用
+            self._process_movement(  # type: ignore[attr-defined]
+                actor, pos_actor, pos_target, diff_vector, distance, dt, target=target
+            )
+        else:
+            # フェーズ①: 射程外 → 接近移動
+            # MOVE アクション扱いで最近敵への引力を有効化し、処理後に HIT_AND_AWAY に戻す
+            self.unit_resources[unit_id]["current_action"] = "MOVE"  # type: ignore[attr-defined]
+            self._process_movement(  # type: ignore[attr-defined]
+                actor, pos_actor, pos_target, diff_vector, distance, dt, target=target
+            )
+            self.unit_resources[unit_id]["current_action"] = "HIT_AND_AWAY"  # type: ignore[attr-defined]
 
     def _handle_boost_dash_action(
         self,

--- a/backend/app/engine/ai_decision.py
+++ b/backend/app/engine/ai_decision.py
@@ -188,6 +188,11 @@ class AiDecisionMixin:
         if action == "ENGAGE_MELEE" and strategy_mode == "RETREAT":
             return "MOVE"
 
+        if action == "HIT_AND_AWAY":
+            current_en = self.unit_resources[unit_id].get("current_en", 999)  # type: ignore[attr-defined]
+            if current_en < 10:
+                return "ATTACK"
+
         return action
 
     def _ai_decision_phase(self, unit: MobileSuit) -> None:

--- a/backend/app/engine/combat.py
+++ b/backend/app/engine/combat.py
@@ -373,6 +373,9 @@ class CombatMixin:
                 action_type="WAIT",
                 message=wait_message,
                 position_snapshot=snapshot,
+                velocity_snapshot=Vector3.from_numpy(
+                    self.unit_resources[str(actor.id)]["velocity_vec"]  # type: ignore[attr-defined]
+                ),  # type: ignore[attr-defined]
             )
         )
 
@@ -522,6 +525,9 @@ class CombatMixin:
                 ),
                 position_snapshot=snapshot,
                 heading=self.unit_resources[unit_id].get("body_heading_deg"),  # type: ignore[attr-defined]
+                velocity_snapshot=Vector3.from_numpy(
+                    self.unit_resources[str(actor.id)]["velocity_vec"]  # type: ignore[attr-defined]
+                ),  # type: ignore[attr-defined]
             )
         )
         return True
@@ -554,6 +560,9 @@ class CombatMixin:
                     f"{target.name}への射線が確保できない"
                 ),
                 position_snapshot=snapshot,
+                velocity_snapshot=Vector3.from_numpy(
+                    self.unit_resources[str(actor.id)]["velocity_vec"]  # type: ignore[attr-defined]
+                ),  # type: ignore[attr-defined]
             )
         )
         return True
@@ -611,6 +620,9 @@ class CombatMixin:
                     position_snapshot=snapshot,
                     chatter=attack_chatter or hit_chatter,
                     heading=self.unit_resources[str(actor.id)].get("body_heading_deg"),  # type: ignore[attr-defined]
+                    velocity_snapshot=Vector3.from_numpy(
+                        self.unit_resources[str(actor.id)]["velocity_vec"]  # type: ignore[attr-defined]
+                    ),  # type: ignore[attr-defined]
                 )
             )
             return
@@ -665,6 +677,9 @@ class CombatMixin:
                 skill_activated=True if skill_activated else None,
                 heading=self.unit_resources[str(actor.id)].get("body_heading_deg"),  # type: ignore[attr-defined]
                 attack_sector=attack_sector,
+                velocity_snapshot=Vector3.from_numpy(
+                    self.unit_resources[str(actor.id)]["velocity_vec"]  # type: ignore[attr-defined]
+                ),  # type: ignore[attr-defined]
             )
         )
 
@@ -744,6 +759,9 @@ class CombatMixin:
                     chatter=attack_chatter,
                     combo_count=combo_count,
                     combo_message=combo_message,
+                    velocity_snapshot=Vector3.from_numpy(
+                        self.unit_resources[str(actor.id)]["velocity_vec"]  # type: ignore[attr-defined]
+                    ),  # type: ignore[attr-defined]
                 )
             )
 
@@ -923,6 +941,9 @@ class CombatMixin:
                 chatter=attack_chatter or miss_chatter,
                 skill_activated=True if skill_activated else None,
                 heading=self.unit_resources[str(actor.id)].get("body_heading_deg"),  # type: ignore[attr-defined]
+                velocity_snapshot=Vector3.from_numpy(
+                    self.unit_resources[str(actor.id)]["velocity_vec"]  # type: ignore[attr-defined]
+                ),  # type: ignore[attr-defined]
             )
         )
 

--- a/backend/app/engine/movement.py
+++ b/backend/app/engine/movement.py
@@ -229,6 +229,29 @@ class MovementMixin:
 
         return STRAFE_ATTRACTION_COEFF * direction * tangent
 
+    def _obstacle_repulsion(self, pos_unit: np.ndarray) -> np.ndarray:
+        """障害物への斥力ベクトルを返す (Phase A — LOS システム)."""
+        force = np.zeros(3)
+        for obs in self.obstacles:  # type: ignore[attr-defined]
+            obs_pos = np.array([obs.position.x, obs.position.y, obs.position.z])
+            obs_dist = float(np.linalg.norm(pos_unit - obs_pos))
+            if obs_dist <= obs.radius + OBSTACLE_MARGIN:
+                away_vec = (pos_unit - obs_pos) / max(obs_dist, 1.0)
+                force += OBSTACLE_REPULSION_COEFF * away_vec
+        return force
+
+    def _hit_and_away_target_repulsion(
+        self, pos_unit: np.ndarray, target: MobileSuit | None
+    ) -> np.ndarray:
+        """HIT_AND_AWAY 行動時のターゲット斥力ベクトルを返す (Issue #368)."""
+        force = np.zeros(3)
+        if target is not None:
+            vec_away = pos_unit - target.position.to_numpy()
+            dist = float(np.linalg.norm(vec_away))
+            if dist > 0:
+                force += 2.0 * vec_away / dist
+        return force
+
     def _calculate_potential_field(
         self,
         unit: MobileSuit,
@@ -268,6 +291,10 @@ class MovementMixin:
         if current_action == "MOVE":
             total_force += self._closest_enemy_attraction(unit, pos_unit)
 
+        # 2b. HIT_AND_AWAY: ターゲットを斥力源として離脱移動 (Issue #368)
+        if current_action == "HIT_AND_AWAY":
+            total_force += self._hit_and_away_target_repulsion(pos_unit, target)
+
         # 3. 高脅威敵（自機射程外）への斥力
         weapon = unit.get_active_weapon()
         weapon_range = float(weapon.range) if weapon else 0.0
@@ -289,22 +316,14 @@ class MovementMixin:
             total_force += self._retreat_points_attraction(pos_unit, applicable_rps)
 
         # 7. 障害物への斥力 (Phase A — LOS システム)
-        for obs in self.obstacles:  # type: ignore[attr-defined]
-            obs_pos = np.array([obs.position.x, obs.position.y, obs.position.z])
-            obs_dist = float(np.linalg.norm(pos_unit - obs_pos))
-            if obs_dist <= obs.radius + OBSTACLE_MARGIN:
-                away_vec = (pos_unit - obs_pos) / max(obs_dist, 1.0)
-                total_force += OBSTACLE_REPULSION_COEFF * away_vec
+        total_force += self._obstacle_repulsion(pos_unit)
 
-        # 8. フランキング引力: 目標の背後方向への引力 (Phase E-3.5)
-        # ATTACK / MOVE 行動かつターゲットが存在する場合のみ有効
-        if current_action in ("ATTACK", "MOVE") and target is not None:
-            total_force += self._flanking_attraction(unit, target, dt)
-
-        # 9. ストレイフ引力: 攻撃中の軌道旋回（接線方向への引力）(Issue #366)
-        # ATTACK 行動かつターゲットが存在する場合のみ有効
-        if current_action == "ATTACK" and target is not None:
-            total_force += self._strafe_attraction(unit, target)
+        # 8. フランキング引力・ストレイフ引力（ターゲット存在時のみ）
+        if target is not None:
+            if current_action in ("ATTACK", "MOVE"):
+                total_force += self._flanking_attraction(unit, target, dt)
+            if current_action == "ATTACK":
+                total_force += self._strafe_attraction(unit, target)
 
         # 正規化 — ゼロベクトル時はランダム方向でローカルミニマムを回避
         total_force[1] = 0.0  # Y 成分を XZ 平面に固定

--- a/backend/data/fuzzy_rules/aggressive.json
+++ b/backend/data/fuzzy_rules/aggressive.json
@@ -145,6 +145,28 @@
       ],
       "operator": "AND",
       "output": { "variable": "action", "set": "BOOST_DASH" }
+    },
+    {
+      "id": "rule_014",
+      "conditions": [
+        { "variable": "hp_ratio", "set": "MEDIUM" },
+        { "variable": "distance_to_nearest_enemy", "set": "CLOSE" },
+        { "variable": "ranged_ammo_ratio", "set": "SUFFICIENT" }
+      ],
+      "operator": "AND",
+      "output": { "variable": "action", "set": "HIT_AND_AWAY" },
+      "comment": "HP中程度・近距離・弾薬十分なら一撃離脱"
+    },
+    {
+      "id": "rule_015",
+      "conditions": [
+        { "variable": "hp_ratio", "set": "LOW" },
+        { "variable": "distance_to_nearest_enemy", "set": "CLOSE" },
+        { "variable": "los_blocked", "set": "CLEAR" }
+      ],
+      "operator": "AND",
+      "output": { "variable": "action", "set": "HIT_AND_AWAY" },
+      "comment": "HP低下・近距離・LOS確保なら一撃離脱で生存優先"
     }
   ],
   "membership_functions": {
@@ -190,6 +212,7 @@
     "action": {
       "ATTACK":       { "type": "trapezoid", "params": [0.0, 0.0, 0.10, 0.20] },
       "MOVE":         { "type": "triangle",  "params": [0.15, 0.30, 0.45] },
+      "HIT_AND_AWAY": { "type": "triangle",  "params": [0.30, 0.45, 0.60] },
       "ENGAGE_MELEE": { "type": "triangle",  "params": [0.40, 0.55, 0.70] },
       "BOOST_DASH":   { "type": "triangle",  "params": [0.60, 0.75, 0.90] },
       "RETREAT":      { "type": "trapezoid", "params": [0.80, 0.90, 1.0, 1.0] }

--- a/backend/tests/unit/test_hit_and_away.py
+++ b/backend/tests/unit/test_hit_and_away.py
@@ -1,0 +1,238 @@
+"""Tests for the Hit-and-Away action pattern (Issue #368 A-2).
+
+HIT_AND_AWAY の3フェーズ（接近→攻撃→離脱）・EN不足フォールバック・
+ファジィルール選択を検証する。
+"""
+
+from app.engine.simulation import BattleSimulator
+from app.models.models import MobileSuit, Vector3, Weapon
+
+# ---------------------------------------------------------------------------
+# ヘルパー
+# ---------------------------------------------------------------------------
+
+
+def _make_weapon(range_: float = 500.0, is_melee: bool = False) -> Weapon:
+    return Weapon(
+        id="test_weapon",
+        name="Test Weapon",
+        power=10,
+        range=range_,
+        accuracy=80,
+        is_melee=is_melee,
+        max_ammo=100,
+    )
+
+
+def _make_unit(
+    name: str,
+    side: str,
+    team_id: str,
+    position: Vector3,
+    max_speed: float = 80.0,
+    acceleration: float = 30.0,
+    deceleration: float = 50.0,
+    max_turn_rate: float = 360.0,
+    weapon_range: float = 500.0,
+    max_hp: int = 1000,
+    current_hp: int = 1000,
+    max_en: int = 1000,
+    sensor_range: float = 5000.0,
+) -> MobileSuit:
+    return MobileSuit(
+        name=name,
+        max_hp=max_hp,
+        current_hp=current_hp,
+        armor=0,
+        mobility=1.0,
+        position=position,
+        weapons=[_make_weapon(weapon_range)],
+        side=side,
+        team_id=team_id,
+        tactics={"priority": "CLOSEST", "range": "BALANCED"},
+        max_speed=max_speed,
+        acceleration=acceleration,
+        deceleration=deceleration,
+        max_turn_rate=max_turn_rate,
+        max_en=max_en,
+        en_recovery=0,
+        sensor_range=sensor_range,
+    )
+
+
+# ---------------------------------------------------------------------------
+# フェーズ①: 射程外では接近移動すること
+# ---------------------------------------------------------------------------
+
+
+def test_hit_and_away_approaches_when_out_of_range() -> None:
+    """射程外のターゲットに対して HIT_AND_AWAY は接近移動すること."""
+    # マップ中央付近に配置（境界斥力の影響を排除するため）
+    # 武器射程 200m、ターゲットは 500m 先に配置
+    player = _make_unit(
+        "Player", "PLAYER", "PT", Vector3(x=500, y=0, z=500), weapon_range=200.0
+    )
+    enemy = _make_unit("Enemy", "ENEMY", "ET", Vector3(x=1000, y=0, z=500))
+    sim = BattleSimulator(player, [enemy])
+
+    uid = str(player.id)
+    # ターゲットを発見済みにする
+    sim.team_detected_units[player.team_id] = {enemy.id}
+    sim.unit_resources[uid]["current_action"] = "HIT_AND_AWAY"
+    sim.unit_resources[uid]["current_target_id"] = str(enemy.id)
+
+    initial_x = player.position.x
+
+    # 1ステップ実行
+    sim._action_phase(player, dt=0.1)
+
+    new_x = player.position.x
+    # プレイヤーが敵方向（+X）に近づいていること
+    assert new_x > initial_x, (
+        f"射程外では敵に接近するはず: {initial_x:.2f} → {new_x:.2f}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# フェーズ②③: 射程内では攻撃後に離脱すること
+# ---------------------------------------------------------------------------
+
+
+def test_hit_and_away_attacks_and_retreats_when_in_range() -> None:
+    """射程内のターゲットに対して HIT_AND_AWAY は攻撃後に離脱移動すること."""
+    # マップ中央付近に配置（境界斥力の影響を排除するため）
+    # 武器射程 500m、ターゲットは 100m 先（+X方向）に配置（射程内）
+    # max_turn_rate を極大に設定して 1ステップで即座に方向転換できるようにする
+    player = _make_unit(
+        "Player",
+        "PLAYER",
+        "PT",
+        Vector3(x=500, y=0, z=500),
+        weapon_range=500.0,
+        acceleration=300.0,
+        max_turn_rate=36000.0,  # 即時方向転換で離脱挙動を確認
+    )
+    enemy = _make_unit("Enemy", "ENEMY", "ET", Vector3(x=600, y=0, z=500))
+    sim = BattleSimulator(player, [enemy])
+
+    uid = str(player.id)
+    sim.team_detected_units[player.team_id] = {enemy.id}
+    sim.unit_resources[uid]["current_action"] = "HIT_AND_AWAY"
+
+    initial_x = player.position.x
+
+    # 攻撃ログが記録されること
+    log_count_before = len(sim.logs)
+    sim._action_phase(player, dt=0.1)
+
+    attack_logs = [
+        lg
+        for lg in sim.logs[log_count_before:]
+        if lg.actor_id == player.id and lg.action_type in ("ATTACK", "MISS", "WAIT")
+    ]
+    assert len(attack_logs) > 0, (
+        "射程内なら攻撃ログ（ATTACK/MISS/WAIT）が記録されるべき"
+    )
+
+    # 離脱: プレイヤーが敵（+X方向）から遠ざかる方向（-X方向）に移動していること
+    new_x = player.position.x
+    assert new_x < initial_x, (
+        f"攻撃後は敵（+X）から離れるはず: {initial_x:.2f} → {new_x:.2f}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# EN 不足フォールバック
+# ---------------------------------------------------------------------------
+
+
+def test_hit_and_away_falls_back_to_attack_when_en_low() -> None:
+    """EN が低い場合 HIT_AND_AWAY は ATTACK にフォールバックすること."""
+    player = _make_unit("Player", "PLAYER", "PT", Vector3(x=0, y=0, z=0))
+    enemy = _make_unit("Enemy", "ENEMY", "ET", Vector3(x=200, y=0, z=0))
+    sim = BattleSimulator(player, [enemy])
+
+    uid = str(player.id)
+    # EN をほぼゼロに設定
+    sim.unit_resources[uid]["current_en"] = 5
+
+    resolved = sim._resolve_final_action("HIT_AND_AWAY", uid, "AGGRESSIVE")
+    assert resolved == "ATTACK", (
+        f"EN不足時は ATTACK にフォールバックするべき、実際: {resolved}"
+    )
+
+
+def test_hit_and_away_not_fallen_back_when_en_sufficient() -> None:
+    """EN が十分な場合 HIT_AND_AWAY は変更されないこと."""
+    player = _make_unit("Player", "PLAYER", "PT", Vector3(x=0, y=0, z=0))
+    enemy = _make_unit("Enemy", "ENEMY", "ET", Vector3(x=200, y=0, z=0))
+    sim = BattleSimulator(player, [enemy])
+
+    uid = str(player.id)
+    sim.unit_resources[uid]["current_en"] = 1000
+
+    resolved = sim._resolve_final_action("HIT_AND_AWAY", uid, "AGGRESSIVE")
+    assert resolved == "HIT_AND_AWAY", (
+        f"EN十分なら HIT_AND_AWAY を維持するべき、実際: {resolved}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# velocity_snapshot が攻撃ログに記録されること
+# ---------------------------------------------------------------------------
+
+
+def test_attack_log_has_velocity_snapshot() -> None:
+    """攻撃ログ（ATTACK/MISS）に velocity_snapshot が記録されること."""
+    player = _make_unit(
+        "Player", "PLAYER", "PT", Vector3(x=0, y=0, z=0), weapon_range=500.0
+    )
+    enemy = _make_unit("Enemy", "ENEMY", "ET", Vector3(x=100, y=0, z=0))
+    sim = BattleSimulator(player, [enemy])
+
+    uid = str(player.id)
+    sim.team_detected_units[player.team_id] = {enemy.id}
+    # ATTACK アクションで攻撃を発生させる
+    sim.unit_resources[uid]["current_action"] = "ATTACK"
+    sim.unit_resources[uid]["current_target_id"] = str(enemy.id)
+    # ランダム命中を確実にするため accuracy を最大に設定
+    player.weapons[0].accuracy = 100
+
+    log_count_before = len(sim.logs)
+    sim._action_phase(player, dt=0.1)
+
+    combat_logs = [
+        lg
+        for lg in sim.logs[log_count_before:]
+        if lg.actor_id == player.id and lg.action_type in ("ATTACK", "MISS")
+    ]
+    assert len(combat_logs) > 0, "ATTACK/MISS ログが記録されるべき"
+    for lg in combat_logs:
+        assert lg.velocity_snapshot is not None, (
+            f"action_type={lg.action_type} ログに velocity_snapshot が設定されるべき"
+        )
+
+
+# ---------------------------------------------------------------------------
+# ファジィルール: AGGRESSIVE 戦略で HIT_AND_AWAY が選択されること
+# ---------------------------------------------------------------------------
+
+
+def test_aggressive_fuzzy_engine_has_hit_and_away_action() -> None:
+    """AGGRESSIVE 戦略のファジィエンジンに HIT_AND_AWAY アクションが定義されていること."""
+    player = _make_unit("Player", "PLAYER", "PT", Vector3(x=0, y=0, z=0))
+    enemy = _make_unit("Enemy", "ENEMY", "ET", Vector3(x=100, y=0, z=0))
+    sim = BattleSimulator(player, [enemy])
+
+    # _strategy_engines プロパティから AGGRESSIVE の behavior_selection エンジンを取得
+    aggressive_engines = sim._strategy_engines.get("AGGRESSIVE")
+    assert aggressive_engines is not None, "AGGRESSIVE エンジンが存在するべき"
+
+    behavior_engine = aggressive_engines.get("behavior")
+    assert behavior_engine is not None, "behavior エンジンが存在するべき"
+
+    # HIT_AND_AWAY がメンバーシップ関数に登録されていること
+    action_mfs = behavior_engine.rule_set.membership_functions.get("action", {})
+    assert "HIT_AND_AWAY" in action_mfs, (
+        "AGGRESSIVE エンジンの action MF に HIT_AND_AWAY が定義されているべき"
+    )

--- a/frontend/src/components/BattleViewer/hooks/useBattleSnapshot.ts
+++ b/frontend/src/components/BattleViewer/hooks/useBattleSnapshot.ts
@@ -40,6 +40,10 @@ export function getBattleSnapshot(
     let heading: number | undefined = undefined;
     let prevHeadingTs: number | undefined = undefined;
     let unitTargetId: string | undefined = undefined;
+    // 物理補間用: velocity_snapshot を持つ最後のログの情報を保持
+    let lastVelocity: { x: number; y: number; z: number } | undefined = undefined;
+    let lastVelocityPos: { x: number; y: number; z: number } | undefined = undefined;
+    let lastVelocityTs: number | undefined = undefined;
     
     // 武器の初期弾数を設定
     initialMs.weapons.forEach(weapon => {
@@ -55,6 +59,13 @@ export function getBattleSnapshot(
         // 位置更新
         if (log.actor_id === targetId && log.position_snapshot) {
             pos = log.position_snapshot;
+        }
+
+        // velocity_snapshot を記録（ログ間の物理補間用）
+        if (log.actor_id === targetId && log.velocity_snapshot) {
+            lastVelocity = log.velocity_snapshot;
+            lastVelocityPos = log.position_snapshot;
+            lastVelocityTs = log.timestamp;
         }
 
         // 向き更新（自ユニットのログに heading フィールドがあれば取得）
@@ -100,6 +111,18 @@ export function getBattleSnapshot(
                 heading = lerpAngle(heading, log.heading, Math.max(0, Math.min(1, t)));
                 break;
             }
+        }
+    }
+
+    // 物理補間: pos = prev_pos + velocity × dt（ログ間の滑らかな移動表示）
+    if (lastVelocity && lastVelocityTs !== undefined && lastVelocityPos !== undefined) {
+        const dt = currentTimestamp - lastVelocityTs;
+        if (dt > 0) {
+            pos = {
+                x: lastVelocityPos.x + lastVelocity.x * dt,
+                y: lastVelocityPos.y + lastVelocity.y * dt,
+                z: lastVelocityPos.z + lastVelocity.z * dt,
+            };
         }
     }
 


### PR DESCRIPTION
## Summary

- **A-2**: AGGRESSIVE戦略のMSが近距離攻撃後に即離脱する `HIT_AND_AWAY` 行動パターンを実装
- **C-1**: 全攻撃ログ（7箇所）に `velocity_snapshot` を追加し、フロントエンドでの物理補間による滑らかな移動表示を実現

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `backend/data/fuzzy_rules/aggressive.json` | `HIT_AND_AWAY` のファジィMF・ルール2件追加（rule_014, rule_015） |
| `backend/app/engine/action_handler.py` | `_handle_hit_and_away_action()` 追加（接近→攻撃→離脱の3フェーズ） |
| `backend/app/engine/movement.py` | `_hit_and_away_target_repulsion()` / `_obstacle_repulsion()` ヘルパー追加、HIT_AND_AWAY斥力を `_calculate_potential_field()` に組み込み |
| `backend/app/engine/ai_decision.py` | `_resolve_final_action()` にEN不足時のATTACKフォールバック追加 |
| `backend/app/engine/combat.py` | 全BattleLog生成箇所7箇所に `velocity_snapshot` 追加 |
| `frontend/src/components/BattleViewer/hooks/useBattleSnapshot.ts` | `getBattleSnapshot()` に物理補間（pos = prev_pos + vel × dt）追加 |
| `backend/tests/unit/test_hit_and_away.py` | 新規テスト6件追加 |

## Test plan

- [x] `test_hit_and_away_approaches_when_out_of_range` — 射程外では接近移動すること
- [x] `test_hit_and_away_attacks_and_retreats_when_in_range` — 射程内では攻撃後に離脱すること
- [x] `test_hit_and_away_falls_back_to_attack_when_en_low` — EN不足でATTACKへフォールバックすること
- [x] `test_hit_and_away_not_fallen_back_when_en_sufficient` — EN十分ならHIT_AND_AWAYを維持すること
- [x] `test_attack_log_has_velocity_snapshot` — 攻撃ログにvelocity_snapshotが記録されること
- [x] `test_aggressive_fuzzy_engine_has_hit_and_away_action` — ファジィエンジンにHIT_AND_AWAYが定義されていること
- [x] 既存651テスト全通過（回帰なし）

Closes #368

🤖 Generated with [Claude Code](https://claude.com/claude-code)