### PR TITLE
feat: Cloud Run ログを Grafana Cloud に転送する基盤を追加 (Issue #371)

### DIFF
--- a/docs/features/grafana-cloud-integration.md
+++ b/docs/features/grafana-cloud-integration.md
@@ -1,0 +1,91 @@
+# Grafana Cloud 統合
+
+**バージョン:** v1.0  
+**関連 Issue:** #371
+
+## 概要
+
+Cloud Run（FastAPI バックエンド）のログおよびメトリクスを **Grafana Cloud Free Plan** で可視化・監視する機能です。  
+GCP のサービスアカウントを使ったプル型の統合により、追加のインフラ（Pub/Sub・Loki Agent 等）を不要で実現します。
+
+## アーキテクチャ
+
+```
+Cloud Run
+   │
+   ▼ 自動転送
+Cloud Logging / Cloud Monitoring
+   │
+   ▼ サービスアカウント認証でプル
+Grafana Cloud (Loki / Mimir)
+```
+
+## インフラ構成
+
+`infra/grafana/` に独立した Terraform root module として管理します。
+
+| ファイル | 役割 |
+|---|---|
+| `main.tf` | SA・IAM・SA キーの定義 |
+| `variables.tf` | `project_id`, `region` |
+| `outputs.tf` | `grafana_sa_key_json`（sensitive） |
+| `versions.tf` | Terraform / Provider バージョン、GCS backend |
+| `terraform.tfvars.example` | 設定サンプル |
+| `README.md` | 適用・接続手順 |
+
+### 作成される GCP リソース
+
+| リソース | 詳細 |
+|---|---|
+| Service Account | `grafana-cloud-reader@<PROJECT>.iam.gserviceaccount.com` |
+| IAM | `roles/logging.viewer` — Cloud Logging 閲覧権限 |
+| IAM | `roles/monitoring.viewer` — Cloud Monitoring 閲覧権限 |
+| SA Key | Grafana Cloud に登録する JSON キー（terraform output で取得） |
+
+## セットアップ手順
+
+### 1. Terraform 適用
+
+```bash
+cd infra/grafana
+cp terraform.tfvars.example terraform.tfvars
+# project_id を設定
+
+terraform init -backend-config="bucket=<GCS_BUCKET_NAME>"
+terraform apply
+
+# JSON キーを取得
+terraform output -raw grafana_sa_key_json > /tmp/grafana-sa-key.json
+```
+
+### 2. Grafana Cloud への接続
+
+1. Grafana Cloud にログイン
+2. **Connections → Add new connection → Google Cloud Logs** を開く
+3. JSON キーを貼り付けて認証
+4. ログフィルタを設定：
+
+```
+resource.type="cloud_run_revision"
+resource.labels.service_name="msbs-next-api-prod"
+```
+
+### 3. セキュリティ
+
+- JSON キーは使用後に `/tmp/` から削除する
+- サービスアカウントは読み取り専用権限（`viewer`）のみ付与
+- SA キーのローテーションは Terraform で管理（`terraform apply` で再生成）
+
+## Grafana Cloud Free Plan の制限
+
+| 項目 | 上限 |
+|---|---|
+| ログ取り込み | 50 GB / 月 |
+| ログ保持期間 | 14 日 |
+| メトリクス | 10,000 シリーズ |
+| アラート | 無制限 |
+
+## 関連ファイル
+
+- [infra/grafana/](../../infra/grafana/)
+- [infra/gcp-iam/](../../infra/gcp-iam/) — GitHub Actions WIF（別途管理）

--- a/infra/grafana/README.md
+++ b/infra/grafana/README.md
@@ -1,0 +1,62 @@
+# infra/grafana
+
+Cloud Run のログ・メトリクスを **Grafana Cloud Free Plan** に転送するための Terraform モジュールです。
+
+## 概要
+
+Grafana Cloud の [Google Cloud 統合](https://grafana.com/docs/grafana-cloud/monitor-infrastructure/integrations/integration-reference/integration-google-cloud-monitoring/) を使い、Cloud Logging からログをプル取得します。
+
+```
+Cloud Run → Cloud Logging（自動） → Grafana Cloud（SA キーで認証してプル）
+```
+
+## 作成されるリソース
+
+| リソース | 内容 |
+|---|---|
+| `google_service_account` | `grafana-cloud-reader` — 読み取り専用 SA |
+| `google_project_iam_member` | `roles/logging.viewer` — Cloud Logging 閲覧 |
+| `google_project_iam_member` | `roles/monitoring.viewer` — Cloud Monitoring 閲覧 |
+| `google_service_account_key` | Grafana Cloud に登録する JSON キー |
+
+## 適用手順
+
+### 1. 初期化
+
+```bash
+cd infra/grafana
+cp terraform.tfvars.example terraform.tfvars
+# project_id を編集
+
+terraform init -backend-config="bucket=<GCS_BUCKET_NAME>"
+terraform plan
+terraform apply
+```
+
+### 2. JSON キーの取得
+
+```bash
+terraform output -raw grafana_sa_key_json > /tmp/grafana-sa-key.json
+```
+
+> **注意:** `/tmp/grafana-sa-key.json` はセキュリティのため使用後に削除してください。
+
+### 3. Grafana Cloud への登録
+
+1. Grafana Cloud にログイン
+2. **Connections → Add new connection → Google Cloud Logs** を選択
+3. 手順に従い、取得した JSON キーを貼り付ける
+4. **Log filter** に以下を設定：
+
+```
+resource.type="cloud_run_revision"
+resource.labels.service_name="msbs-next-api-prod"
+```
+
+## Grafana Cloud Free Plan の制限
+
+| 項目 | 上限 |
+|---|---|
+| ログ取り込み | 50 GB / 月 |
+| ログ保持期間 | 14 日 |
+| メトリクス | 10,000 シリーズ |

--- a/infra/grafana/main.tf
+++ b/infra/grafana/main.tf
@@ -1,0 +1,24 @@
+# Grafana Cloud が Cloud Logging / Cloud Monitoring をプルするためのサービスアカウント
+
+resource "google_service_account" "grafana" {
+  account_id   = "grafana-cloud-reader"
+  display_name = "Grafana Cloud Reader"
+  description  = "Grafana Cloud が Cloud Logging と Cloud Monitoring をプル読み取りするための SA"
+}
+
+resource "google_project_iam_member" "grafana_logs" {
+  project = var.project_id
+  role    = "roles/logging.viewer"
+  member  = "serviceAccount:${google_service_account.grafana.email}"
+}
+
+resource "google_project_iam_member" "grafana_metrics" {
+  project = var.project_id
+  role    = "roles/monitoring.viewer"
+  member  = "serviceAccount:${google_service_account.grafana.email}"
+}
+
+# Grafana Cloud の Google Cloud 統合に登録する JSON キー
+resource "google_service_account_key" "grafana" {
+  service_account_id = google_service_account.grafana.name
+}

--- a/infra/grafana/outputs.tf
+++ b/infra/grafana/outputs.tf
@@ -1,0 +1,10 @@
+output "grafana_sa_email" {
+  description = "Grafana Cloud Reader サービスアカウントのメールアドレス"
+  value       = google_service_account.grafana.email
+}
+
+output "grafana_sa_key_json" {
+  description = "Grafana Cloud の Google Cloud 統合に登録する JSON キー（terraform output -raw grafana_sa_key_json で取得）"
+  value       = base64decode(google_service_account_key.grafana.private_key)
+  sensitive   = true
+}

--- a/infra/grafana/terraform.tfvars.example
+++ b/infra/grafana/terraform.tfvars.example
@@ -1,0 +1,2 @@
+project_id = "msbs-next"
+region     = "asia-northeast1"

--- a/infra/grafana/variables.tf
+++ b/infra/grafana/variables.tf
@@ -1,0 +1,10 @@
+variable "project_id" {
+  description = "GCP プロジェクト ID"
+  type        = string
+}
+
+variable "region" {
+  description = "GCP リージョン"
+  type        = string
+  default     = "asia-northeast1"
+}

--- a/infra/grafana/versions.tf
+++ b/infra/grafana/versions.tf
@@ -1,0 +1,20 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+
+  backend "gcs" {
+    # bucket は terraform init -backend-config="bucket=<BUCKET_NAME>" で渡す想定
+    prefix = "terraform/grafana"
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}


### PR DESCRIPTION
## 概要

- Cloud Run ログを Grafana Cloud Free Plan で閲覧するための Terraform モジュールを追加
- `infra/grafana/` として既存の `infra/gcp-iam/` とは分離した独立モジュールで管理

## 変更内容

### 追加ファイル
- `infra/grafana/main.tf` — SA・IAM・SA キーの定義
- `infra/grafana/variables.tf` — `project_id`, `region`
- `infra/grafana/outputs.tf` — `grafana_sa_key_json`（sensitive）
- `infra/grafana/versions.tf` — Terraform バージョン・GCS backend 設定
- `infra/grafana/terraform.tfvars.example` — 設定サンプル
- `infra/grafana/README.md` — 適用・接続手順
- `docs/features/grafana-cloud-integration.md` — 機能ドキュメント

## 動作確認手順

```bash
cd infra/grafana
cp terraform.tfvars.example terraform.tfvars
terraform init -backend-config="bucket=<BUCKET>"
terraform plan  # エラーなく差分が出ることを確認
terraform apply
terraform output -raw grafana_sa_key_json  # JSON キーが出力されることを確認
```

その後 Grafana Cloud → Connections → Google Cloud Logs で JSON キーを登録し、Cloud Run ログが表示されることを確認。

## 関連

Closes #371

🤖 Generated with [Claude Code](https://claude.ai/claude-code)