### PR TITLE
feat: 飛翔体エフェクト・Idleホバリング・3Dヒットエフェクトを追加 (Issue #367)

### DIFF
--- a/frontend/src/components/BattleViewer/index.tsx
+++ b/frontend/src/components/BattleViewer/index.tsx
@@ -90,6 +90,7 @@ export default function BattleViewer({
                 obstacles={obstacles}
                 losResults={losResults}
                 attackingUnitIds={attackingUnitIds}
+                currentTimestamp={currentTimestamp}
             />
             
             <BattleOverlay

--- a/frontend/src/components/BattleViewer/scene/BattleScene.tsx
+++ b/frontend/src/components/BattleViewer/scene/BattleScene.tsx
@@ -2,7 +2,7 @@
 
 "use client";
 
-import { useRef, useEffect, useMemo } from "react";
+import { useRef, useEffect, useMemo, useState } from "react";
 import { Canvas, useThree } from "@react-three/fiber";
 import { OrbitControls, Stars, Grid } from "@react-three/drei";
 import * as THREE from "three";
@@ -11,11 +11,35 @@ import { EnvironmentEffects } from "./EnvironmentEffects";
 import { MobileSuitMesh } from "./MobileSuitMesh";
 import { BattleEventDisplay } from "./BattleEventDisplay";
 import { ObstacleMesh } from "./ObstacleMesh";
+import { ProjectileMesh, isBeamWeapon } from "./ProjectileMesh";
+import { HitEffectMesh } from "./HitEffectMesh";
 import { BattleEventEffect, WarningType } from "../types";
 import { Obstacle } from "@/types/battle";
 
 // MobileSuitMesh と同じスケール定数（座標変換の一貫性）
 const POSITION_SCALE = 0.05;
+
+// 飛翔体・ヒットエフェクトの上限数と飛翔時間
+const MAX_PROJECTILES = 20;
+const MAX_HIT_EFFECTS = 15;
+const PROJECTILE_DURATION_MS = 800;
+
+/** 飛翔中の発射体の状態 (B-3) */
+interface ProjectileState {
+    id: string;
+    fromPos: { x: number; y: number; z: number };
+    toPos: { x: number; y: number; z: number };
+    weaponType: "BEAM" | "BULLET";
+    startTime: number;
+}
+
+/** 命中エフェクトの状態 (B-5) */
+interface HitEffectState {
+    id: string;
+    position: { x: number; y: number; z: number };
+    effectType: "hit" | "critical" | "miss";
+    startTime: number;
+}
 
 // モーダルオープン時に自機MSを中心にカメラを初期配置するコンポーネント
 // Canvas 内部で useThree を呼ぶため、Canvas の子として定義する必要がある
@@ -78,6 +102,8 @@ interface BattleSceneProps {
     losResults?: LosResult[];
     /** 現在タイムスタンプで攻撃アクション中のユニット ID セット（射撃反動アニメーション用）*/
     attackingUnitIds?: Set<string>;
+    /** 現在の再生タイムスタンプ（飛翔体・ヒットエフェクトのスポーン検出用） */
+    currentTimestamp: number;
 }
 
 /** 自機からターゲット敵MSへの照準線コンポーネント */
@@ -220,6 +246,7 @@ export function BattleScene({
     obstacles,
     losResults,
     attackingUnitIds,
+    currentTimestamp,
 }: BattleSceneProps) {
     // 自機MS初期Three.js座標をマウント時のみキャプチャ（MobileSuitMesh と同じ軸変換）
     const initialPos = useRef({
@@ -230,6 +257,70 @@ export function BattleScene({
     const { x: px, y: py, z: pz } = initialPos.current;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const controlsRef = useRef<any>(null);
+
+    // 飛翔体・ヒットエフェクトの状態管理 (B-3, B-5)
+    const [projectiles, setProjectiles] = useState<ProjectileState[]>([]);
+    const [hitEffects, setHitEffects] = useState<HitEffectState[]>([]);
+
+    // タイムスタンプ変化を検出して飛翔体・ヒットエフェクトをスポーン
+    useEffect(() => {
+        const now = Date.now();
+        const newProjectiles: ProjectileState[] = [];
+        const newHitEffects: HitEffectState[] = [];
+
+        // 自機の攻撃イベントを処理
+        if (playerEvent?.targetPos && playerEvent.hit !== undefined) {
+            const weaponType = isBeamWeapon(playerEvent.weaponName) ? "BEAM" : "BULLET";
+            newProjectiles.push({
+                id: `p-player-${now}`,
+                fromPos: playerState.pos,
+                toPos: playerEvent.targetPos,
+                weaponType,
+                startTime: now,
+            });
+            const effectType =
+                playerEvent.type === "critical" ? "critical" :
+                playerEvent.hit ? "hit" : "miss";
+            newHitEffects.push({
+                id: `h-player-${now}`,
+                position: playerEvent.targetPos,
+                effectType,
+                startTime: now + PROJECTILE_DURATION_MS,
+            });
+        }
+
+        // 敵ユニットの攻撃イベントを処理
+        enemyEvents.forEach(({ id, event }) => {
+            if (!event?.targetPos || event.hit === undefined) return;
+            const enemyData = enemyStates.find(e => e.enemy.id === id);
+            if (!enemyData || enemyData.state.hp <= 0) return;
+            const weaponType = isBeamWeapon(event.weaponName) ? "BEAM" : "BULLET";
+            newProjectiles.push({
+                id: `p-${id}-${now}`,
+                fromPos: enemyData.state.pos,
+                toPos: event.targetPos,
+                weaponType,
+                startTime: now,
+            });
+            const effectType =
+                event.type === "critical" ? "critical" :
+                event.hit ? "hit" : "miss";
+            newHitEffects.push({
+                id: `h-${id}-${now}`,
+                position: event.targetPos,
+                effectType,
+                startTime: now + PROJECTILE_DURATION_MS,
+            });
+        });
+
+        if (newProjectiles.length > 0) {
+            setProjectiles(prev => [...prev, ...newProjectiles].slice(-MAX_PROJECTILES));
+        }
+        if (newHitEffects.length > 0) {
+            setHitEffects(prev => [...prev, ...newHitEffects].slice(-MAX_HIT_EFFECTS));
+        }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [currentTimestamp]);
 
     // 自機のターゲット敵MSの状態（照準線・ハイライト用）
     const targetedEnemy = playerState.targetId
@@ -246,6 +337,22 @@ export function BattleScene({
         );
     }, [losResults]);
 
+    // クリティカルヒット被弾中かどうかをユニット ID で判定 (B-5)
+    // ターゲット側（テキストが damage 形式: "-xxx"）の critical イベントをフラッシュさせる
+    const flashingUnitIds = useMemo(() => {
+        const ids = new Set<string>();
+        if (playerEvent?.type === "critical" && !playerEvent.targetPos) {
+            // player が被弾側: targetPos なし = damage 表示側
+            ids.add(String(player.id));
+        }
+        enemyEvents.forEach(({ id, event }) => {
+            if (event?.type === "critical" && !event.targetPos) {
+                ids.add(id);
+            }
+        });
+        return ids;
+    }, [player.id, playerEvent, enemyEvents]);
+
     return (
         <Canvas
             camera={{ position: [50, 50, 50], fov: 60 }}
@@ -261,13 +368,13 @@ export function BattleScene({
             {environment === "SPACE" && (
                 <Stars radius={100} depth={50} count={2000} factor={4} fade speed={1} />
             )}
-            <Grid 
-                infiniteGrid 
-                sectionSize={10} 
-                cellSize={1} 
-                fadeDistance={100} 
-                sectionColor={environment === "COLONY" ? "#8a8aaa" : "#00ff00"} 
-                cellColor={environment === "COLONY" ? "#4a4a6a" : "#003300"} 
+            <Grid
+                infiniteGrid
+                sectionSize={10}
+                cellSize={1}
+                fadeDistance={100}
+                sectionColor={environment === "COLONY" ? "#8a8aaa" : "#00ff00"}
+                cellColor={environment === "COLONY" ? "#4a4a6a" : "#003300"}
             />
             <OrbitControls
                 ref={controlsRef}
@@ -302,6 +409,7 @@ export function BattleScene({
                 warnings={playerState.warnings}
                 heading={playerState.heading}
                 isAttacking={attackingUnitIds?.has(String(player.id))}
+                isFlashing={flashingUnitIds.has(String(player.id))}
             />
 
             {/* Enemies */}
@@ -318,6 +426,7 @@ export function BattleScene({
                     warnings={state.warnings}
                     isTargeted={enemy.id === playerState.targetId}
                     isAttacking={attackingUnitIds?.has(String(enemy.id))}
+                    isFlashing={flashingUnitIds.has(String(enemy.id))}
                 />
             ))}
 
@@ -328,7 +437,7 @@ export function BattleScene({
                     targetPos={targetedEnemy.state.pos}
                 />
             )}
-            
+
             {/* Battle Event Effects */}
             {playerEvent && (
                 <BattleEventDisplay position={playerState.pos} event={playerEvent} />
@@ -356,6 +465,30 @@ export function BattleScene({
                     </group>
                 );
             })}
+
+            {/* 飛翔体エフェクト (B-3) */}
+            {projectiles.map(p => (
+                <ProjectileMesh
+                    key={p.id}
+                    fromPos={p.fromPos}
+                    toPos={p.toPos}
+                    weaponType={p.weaponType}
+                    startTime={p.startTime}
+                    duration={PROJECTILE_DURATION_MS}
+                    onComplete={() => setProjectiles(prev => prev.filter(x => x.id !== p.id))}
+                />
+            ))}
+
+            {/* 3Dヒットエフェクト (B-5) */}
+            {hitEffects.map(h => (
+                <HitEffectMesh
+                    key={h.id}
+                    position={h.position}
+                    effectType={h.effectType}
+                    startTime={h.startTime}
+                    onComplete={() => setHitEffects(prev => prev.filter(x => x.id !== h.id))}
+                />
+            ))}
 
             {/* LOS 視線ライン（showLos が ON のときのみ表示） */}
             {losResults && losResults.map((result) => (

--- a/frontend/src/components/BattleViewer/scene/HitEffectMesh.tsx
+++ b/frontend/src/components/BattleViewer/scene/HitEffectMesh.tsx
@@ -1,0 +1,135 @@
+/* frontend/src/components/BattleViewer/scene/HitEffectMesh.tsx */
+
+"use client";
+
+import { useMemo, useRef } from "react";
+import { useFrame } from "@react-three/fiber";
+import * as THREE from "three";
+
+const POSITION_SCALE = 0.05;
+
+/** エフェクト種別ごとの設定 */
+const EFFECT_CONFIG = {
+    hit: { count: 8, color: "#ffcc00", duration: 300, spread: 2.5, opacity: 1.0, hasCriticalFlash: false },
+    critical: { count: 12, color: "#ff4400", duration: 500, spread: 4.0, opacity: 1.0, hasCriticalFlash: true },
+    miss: { count: 6, color: "#888888", duration: 250, spread: 2.0, opacity: 0.5, hasCriticalFlash: false },
+} as const;
+
+interface HitEffectMeshProps {
+    position: { x: number; y: number; z: number };
+    effectType: "hit" | "critical" | "miss";
+    /** スポーン開始時刻（Date.now()） */
+    startTime: number;
+    onComplete: () => void;
+}
+
+/** 3Dヒットエフェクト（B-5）: 命中位置にスプライトパーティクルを展開 */
+export function HitEffectMesh({
+    position,
+    effectType,
+    startTime,
+    onComplete,
+}: HitEffectMeshProps) {
+    const groupRef = useRef<THREE.Group>(null);
+    const flashRef = useRef<THREE.Mesh>(null);
+    const completedRef = useRef(false);
+    const config = EFFECT_CONFIG[effectType];
+
+    // ゲーム座標 → Three.js 座標変換
+    const center3D = new THREE.Vector3(
+        position.x * POSITION_SCALE,
+        position.z * POSITION_SCALE,
+        position.y * POSITION_SCALE,
+    );
+
+    // 各パーティクルの初期方向ベクトルを事前計算（球面上にランダム分布）
+    const directions = useMemo(() => {
+        const dirs: THREE.Vector3[] = [];
+        for (let i = 0; i < config.count; i++) {
+            // 均等分布: フィボナッチ球面サンプリング
+            const phi = Math.acos(1 - 2 * (i + 0.5) / config.count);
+            const theta = Math.PI * (1 + Math.sqrt(5)) * i;
+            dirs.push(new THREE.Vector3(
+                Math.sin(phi) * Math.cos(theta),
+                Math.cos(phi),
+                Math.sin(phi) * Math.sin(theta),
+            ).normalize());
+        }
+        return dirs;
+    }, [config.count]);
+
+    useFrame(() => {
+        if (completedRef.current) return;
+
+        const elapsed = Date.now() - startTime;
+        // 開始前は非表示
+        if (elapsed < 0) {
+            if (groupRef.current) groupRef.current.visible = false;
+            return;
+        }
+
+        const t = Math.min(elapsed / config.duration, 1);
+
+        if (groupRef.current) {
+            groupRef.current.visible = true;
+            // 各パーティクルを外側へ展開しながらフェードアウト
+            groupRef.current.children.forEach((child, i) => {
+                if (i >= config.count) return; // 閃光メッシュは別処理
+                const dir = directions[i];
+                if (!dir) return;
+                const mesh = child as THREE.Mesh;
+                mesh.position.copy(dir).multiplyScalar(t * config.spread);
+                const mat = mesh.material as THREE.MeshBasicMaterial;
+                mat.opacity = config.opacity * (1 - t);
+            });
+        }
+
+        // クリティカル閃光メッシュ（t が小さいうちだけ表示）
+        if (flashRef.current && config.hasCriticalFlash) {
+            const mat = flashRef.current.material as THREE.MeshBasicMaterial;
+            mat.opacity = t < 0.3 ? config.opacity * (1 - t / 0.3) : 0;
+            // 徐々に拡大
+            const flashScale = 1 + t * 3;
+            flashRef.current.scale.set(flashScale, flashScale, 1);
+        }
+
+        if (t >= 1 && !completedRef.current) {
+            completedRef.current = true;
+            onComplete();
+        }
+    });
+
+    return (
+        <group position={center3D}>
+            {/* クリティカル閃光: カメラ向きの大型プレーン */}
+            {config.hasCriticalFlash && (
+                <mesh ref={flashRef}>
+                    <planeGeometry args={[2, 2]} />
+                    <meshBasicMaterial
+                        color={config.color}
+                        transparent
+                        opacity={1}
+                        blending={THREE.AdditiveBlending}
+                        depthWrite={false}
+                        side={THREE.DoubleSide}
+                    />
+                </mesh>
+            )}
+            {/* パーティクル群 */}
+            <group ref={groupRef}>
+                {directions.map((_, i) => (
+                    <mesh key={i}>
+                        <sphereGeometry args={[effectType === "critical" ? 0.2 : 0.12, 4, 4]} />
+                        <meshBasicMaterial
+                            color={config.color}
+                            transparent
+                            opacity={config.opacity}
+                            blending={THREE.AdditiveBlending}
+                            depthWrite={false}
+                        />
+                    </mesh>
+                ))}
+            </group>
+        </group>
+    );
+}

--- a/frontend/src/components/BattleViewer/scene/MobileSuitMesh.tsx
+++ b/frontend/src/components/BattleViewer/scene/MobileSuitMesh.tsx
@@ -16,12 +16,14 @@ export function MobileSuitMesh({
     maxHp,
     currentHp,
     prevHp,
+    name,
     sensorRange,
     showSensorRange,
     warnings,
     heading,
     isTargeted,
     isAttacking,
+    isFlashing,
 }: {
     position: { x: number; y: number; z: number };
     maxHp: number;
@@ -37,24 +39,48 @@ export function MobileSuitMesh({
     isTargeted?: boolean;
     /** 現在攻撃中の場合 true — 射撃反動アニメーション用 (Issue #365) */
     isAttacking?: boolean;
+    /** クリティカルヒット被弾時 true — emissiveIntensity フラッシュ用 (Issue #367) */
+    isFlashing?: boolean;
 }) {
     const scale = 0.05;
     const vec = new THREE.Vector3(position.x * scale, position.z * scale, position.y * scale);
     const color = getHpColor(currentHp, maxHp);
+
+    // ホバリングアニメーション用グループ ref (B-4)
+    const hoverGroupRef = useRef<THREE.Group>(null);
+    // MS名称から固定シードを生成（各機がバラバラのタイミングで揺れる）
+    const seedOffset = useMemo(
+        () => Array.from(name).reduce((acc, c) => acc + c.charCodeAt(0), 0),
+        [name],
+    );
 
     // 射撃反動アニメーション用内側グループ ref と経過タイマー (Issue #365)
     const innerGroupRef = useRef<THREE.Group>(null);
     const recoilTimeRef = useRef(0);
     const RECOIL_DURATION = 0.25; // 反動アニメーション持続時間（秒）
 
-    useFrame((_, delta) => {
-        if (!innerGroupRef.current) return;
+    // クリティカルフラッシュ用球体 ref と経過タイマー (B-5)
+    const sphereMeshRef = useRef<THREE.Mesh>(null);
+    const flashTimeRef = useRef(0);
+    const FLASH_DURATION = 0.4;
 
-        if (isAttacking) {
-            // 攻撃イベント検出時にタイマーをリセット
-            recoilTimeRef.current = RECOIL_DURATION;
+    useFrame((state, delta) => {
+        // B-4: ホバリングアニメーション（宇宙浮遊感）
+        if (hoverGroupRef.current) {
+            const hpRatio = maxHp > 0 ? currentHp / maxHp : 1;
+            // HP 20% 以下: 振幅・周波数を大きくして被弾感を演出
+            const amplitude = hpRatio <= 0.2 ? 0.08 : 0.05;
+            const frequency = hpRatio <= 0.2 ? 1.2 : 0.8;
+            hoverGroupRef.current.position.y =
+                Math.sin(state.clock.elapsedTime * frequency + seedOffset) * amplitude;
         }
 
+        if (!innerGroupRef.current) return;
+
+        // 射撃反動アニメーション (Issue #365)
+        if (isAttacking) {
+            recoilTimeRef.current = RECOIL_DURATION;
+        }
         if (recoilTimeRef.current > 0) {
             recoilTimeRef.current = Math.max(0, recoilTimeRef.current - delta);
             const t = 1 - recoilTimeRef.current / RECOIL_DURATION; // 0 → 1
@@ -63,6 +89,21 @@ export function MobileSuitMesh({
             innerGroupRef.current.position.x = recoil;
         } else {
             innerGroupRef.current.position.x = 0;
+        }
+
+        // B-5: クリティカルフラッシュ（emissiveIntensity を瞬間的に上げて減衰）
+        if (isFlashing) flashTimeRef.current = FLASH_DURATION;
+        if (sphereMeshRef.current) {
+            const baseIntensity = isTargeted ? 1.2 : 0.3;
+            if (flashTimeRef.current > 0) {
+                flashTimeRef.current = Math.max(0, flashTimeRef.current - delta);
+                const decay = flashTimeRef.current / FLASH_DURATION; // 1 → 0
+                (sphereMeshRef.current.material as THREE.MeshStandardMaterial).emissiveIntensity =
+                    baseIntensity + 3.0 * decay;
+            } else {
+                (sphereMeshRef.current.material as THREE.MeshStandardMaterial).emissiveIntensity =
+                    baseIntensity;
+            }
         }
     });
 
@@ -106,9 +147,11 @@ export function MobileSuitMesh({
 
     return (
         <group position={vec}>
+            {/* B-4: ホバリングアニメーション用グループ (Issue #367) */}
+            <group ref={hoverGroupRef}>
             {/* 射撃反動アニメーション用内側グループ (Issue #365) */}
             <group ref={innerGroupRef}>
-                <mesh scale={[2, 2, 2]}>
+                <mesh ref={sphereMeshRef} scale={[2, 2, 2]}>
                     <sphereGeometry args={[0.5, 32, 32]} />
                     <meshStandardMaterial
                         color={color}
@@ -159,6 +202,7 @@ export function MobileSuitMesh({
                         </div>
                     </Html>
                 )}
+            </group>
             </group>
         </group>
     );

--- a/frontend/src/components/BattleViewer/scene/ProjectileMesh.tsx
+++ b/frontend/src/components/BattleViewer/scene/ProjectileMesh.tsx
@@ -1,0 +1,96 @@
+/* frontend/src/components/BattleViewer/scene/ProjectileMesh.tsx */
+
+"use client";
+
+import { useRef } from "react";
+import { useFrame } from "@react-three/fiber";
+import * as THREE from "three";
+
+const POSITION_SCALE = 0.05;
+
+/** ビーム武器かどうかを判定するヘルパー（weapon_name の文字列で区別） */
+export function isBeamWeapon(weaponName?: string): boolean {
+    if (!weaponName) return false;
+    const lower = weaponName.toLowerCase();
+    return lower.includes("beam") || weaponName.includes("ビーム") || lower.includes("mega particle");
+}
+
+interface ProjectileMeshProps {
+    fromPos: { x: number; y: number; z: number };
+    toPos: { x: number; y: number; z: number };
+    weaponType: "BEAM" | "BULLET";
+    /** スポーン時刻（Date.now()） */
+    startTime: number;
+    /** 飛翔アニメーション時間（ms） */
+    duration: number;
+    onComplete: () => void;
+}
+
+/** 飛翔体エフェクト（B-3）: 射手→目標座標へ lerp でアニメーション */
+export function ProjectileMesh({
+    fromPos,
+    toPos,
+    weaponType,
+    startTime,
+    duration,
+    onComplete,
+}: ProjectileMeshProps) {
+    const meshRef = useRef<THREE.Mesh>(null);
+    const completedRef = useRef(false);
+
+    // ゲーム座標 → Three.js 座標変換（BattleScene の軸変換と統一: x→X, z→Y, y→Z）
+    const from3D = new THREE.Vector3(
+        fromPos.x * POSITION_SCALE,
+        fromPos.z * POSITION_SCALE,
+        fromPos.y * POSITION_SCALE,
+    );
+    const to3D = new THREE.Vector3(
+        toPos.x * POSITION_SCALE,
+        toPos.z * POSITION_SCALE,
+        toPos.y * POSITION_SCALE,
+    );
+
+    useFrame(() => {
+        if (completedRef.current || !meshRef.current) return;
+
+        const elapsed = Date.now() - startTime;
+        const t = Math.min(elapsed / duration, 1);
+
+        // lerp で位置を更新
+        const pos = new THREE.Vector3().lerpVectors(from3D, to3D, t);
+        meshRef.current.position.copy(pos);
+
+        // ビームは末端でフェードアウト
+        if (weaponType === "BEAM" && meshRef.current.material) {
+            const mat = meshRef.current.material as THREE.MeshBasicMaterial;
+            mat.opacity = t > 0.75 ? (1 - t) / 0.25 : 1;
+        }
+
+        if (t >= 1 && !completedRef.current) {
+            completedRef.current = true;
+            onComplete();
+        }
+    });
+
+    if (weaponType === "BEAM") {
+        return (
+            <mesh ref={meshRef} position={from3D}>
+                <sphereGeometry args={[0.15, 8, 8]} />
+                <meshBasicMaterial
+                    color="#aaff44"
+                    transparent
+                    opacity={1}
+                    blending={THREE.AdditiveBlending}
+                    depthWrite={false}
+                />
+            </mesh>
+        );
+    }
+
+    return (
+        <mesh ref={meshRef} position={from3D}>
+            <sphereGeometry args={[0.2, 8, 8]} />
+            <meshBasicMaterial color="#aaaaaa" />
+        </mesh>
+    );
+}


### PR DESCRIPTION
## Summary

- **[B-3] 飛翔体エフェクト**: 遠距離 ATTACK ログ検出時に `ProjectileMesh.tsx` が射手→目標座標へ lerp アニメーション。ビーム武器は AdditiveBlending の黄緑球体、実弾武器はグレー球体で区別。MELEE は `targetPos` がないため自動除外。
- **[B-4] Idle ホバリング**: `MobileSuitMesh.tsx` に `useFrame` ホバーアニメーションを追加。MS 名から生成したシードで各機のタイミングをずらす。HP 20% 以下では振幅・周波数が増加して被弾感を演出。
- **[B-5] 3D ヒットエフェクト**: `HitEffectMesh.tsx` が命中位置でパーティクルを球面展開。hit（黄）/ critical（赤・大型閃光）/ miss（グレー煙）の 3 種別。クリティカル時は `MobileSuitMesh` の `emissiveIntensity` フラッシュも発生。

## 変更ファイル

| ファイル | 変更種別 |
|---------|---------|
| `scene/ProjectileMesh.tsx` | 新規作成 |
| `scene/HitEffectMesh.tsx` | 新規作成 |
| `scene/MobileSuitMesh.tsx` | 修正（hover + flash + ref 追加） |
| `scene/BattleScene.tsx` | 修正（projectile/hitEffect state + useEffect） |
| `index.tsx` | 修正（currentTimestamp prop 追加） |

## Test plan

- [ ] 遠距離 ATTACK ログで飛翔体が射手→目標へアニメーションする
- [ ] MELEE_COMBO ログでは飛翔体が表示されない
- [ ] 全 MS が停止中でもホバリングしている（各機タイミングがずれている）
- [ ] HP 20% 以下の MS は振幅・速度が増す
- [ ] 通常命中時に黄色パーティクルが展開してフェードアウトする
- [ ] クリティカルヒット時に赤い大型閃光＋パーティクル＋MS フラッシュが発生する
- [ ] ミス時にグレーの煙エフェクトが表示される
- [ ] 攻撃が集中するシーンでもフレームレートが安定している（MAX 上限: 飛翔体 20・エフェクト 15）
- [ ] TypeScript 型エラーなし・全 unit tests (261) パス

Closes #367

🤖 Generated with [Claude Code](https://claude.com/claude-code)