### PR TITLE
マスター機体管理画面にダメージ・命中率シミュレーションパネルを追加

### DIFF
--- a/admin-tool/src/app/mobile-suits/page.tsx
+++ b/admin-tool/src/app/mobile-suits/page.tsx
@@ -7,6 +7,7 @@ import { MasterMobileSuit, MasterMobileSuitCreate } from "@/types/admin";
 import MobileSuitTable from "@/components/admin/MobileSuitTable";
 import MobileSuitEditForm, { MobileSuitFormValues } from "@/components/admin/MobileSuitEditForm";
 import MobileSuitRadarChart from "@/components/admin/MobileSuitRadarChart";
+import CombatSimulationPanel from "@/components/admin/CombatSimulationPanel";
 import CloneDialog from "@/components/admin/CloneDialog";
 import { SciFiPanel, SciFiHeading, SciFiButton } from "@/components/ui";
 
@@ -172,6 +173,18 @@ export default function AdminMobileSuitsPage() {
                     selected={selectedMs}
                     allSuits={mobileSuits}
                   />
+                </div>
+              </SciFiPanel>
+            )}
+
+            {/* ダメージ・命中率シミュレーション */}
+            {selectedMs && mobileSuits && (
+              <SciFiPanel variant="accent" className="mt-4">
+                <div className="p-4">
+                  <SciFiHeading level={3} variant="accent" className="mb-3 text-base">
+                    ダメージ・命中率シミュレーション
+                  </SciFiHeading>
+                  <CombatSimulationPanel attacker={selectedMs} allSuits={mobileSuits} />
                 </div>
               </SciFiPanel>
             )}

--- a/admin-tool/src/components/admin/CombatSimulationPanel.tsx
+++ b/admin-tool/src/components/admin/CombatSimulationPanel.tsx
@@ -26,12 +26,12 @@ const SECTOR_OPTIONS: { value: AttackSector; label: string }[] = [
 ];
 
 const PILOT_STAT_FIELDS: { key: keyof PilotStatsInput; label: string }[] = [
-  { key: "sht", label: "SHT" },
-  { key: "mel", label: "MEL" },
-  { key: "intel", label: "INT" },
-  { key: "ref", label: "REF" },
-  { key: "tou", label: "TOU" },
-  { key: "luk", label: "LUK" },
+  { key: "sht", label: "射撃" },
+  { key: "mel", label: "格闘" },
+  { key: "intel", label: "直感" },
+  { key: "ref", label: "反応" },
+  { key: "tou", label: "耐久" },
+  { key: "luk", label: "幸運" },
 ];
 
 function PilotStatsInputRow({
@@ -130,7 +130,7 @@ export default function CombatSimulationPanel({ attacker, allSuits }: CombatSimu
           >
             {attacker.specs.weapons.map((w) => (
               <option key={w.id} value={w.id}>
-                {w.name}（{w.power}dmg / acc{w.accuracy}%）
+                {w.name} (攻撃力: {w.power} / 命中率: {w.accuracy}%)
               </option>
             ))}
           </select>
@@ -152,7 +152,7 @@ export default function CombatSimulationPanel({ attacker, allSuits }: CombatSimu
           >
             {defenderCandidates.map((ms) => (
               <option key={ms.id} value={ms.id}>
-                {ms.name}（装甲{ms.specs.armor} / 機動{ms.specs.mobility}）
+                {ms.name} (装甲: {ms.specs.armor} / 機動: {ms.specs.mobility})
               </option>
             ))}
           </select>

--- a/admin-tool/src/components/admin/CombatSimulationPanel.tsx
+++ b/admin-tool/src/components/admin/CombatSimulationPanel.tsx
@@ -1,0 +1,252 @@
+/* admin-tool/src/components/admin/CombatSimulationPanel.tsx */
+"use client";
+
+import { useMemo, useState } from "react";
+import { useCombatSimulation } from "@/hooks/useCombatSimulation";
+import {
+  AttackSector,
+  DEFAULT_PILOT_STATS,
+  MasterMobileSuit,
+  PilotStatsInput,
+} from "@/types/admin";
+import { SciFiButton, SciFiHeading } from "@/components/ui";
+
+interface CombatSimulationPanelProps {
+  /** 攻撃側（現在編集中の機体） */
+  attacker: MasterMobileSuit;
+  /** 選択可能な全機体（防御側の選択肢） */
+  allSuits: MasterMobileSuit[];
+}
+
+const SECTOR_OPTIONS: { value: AttackSector; label: string }[] = [
+  { value: "FRONT", label: "正面 (FRONT)" },
+  { value: "FRONT_SIDE", label: "側面前方 (FRONT_SIDE)" },
+  { value: "REAR_SIDE", label: "側面後方 (REAR_SIDE)" },
+  { value: "REAR", label: "背面 (REAR)" },
+];
+
+const PILOT_STAT_FIELDS: { key: keyof PilotStatsInput; label: string }[] = [
+  { key: "sht", label: "SHT" },
+  { key: "mel", label: "MEL" },
+  { key: "intel", label: "INT" },
+  { key: "ref", label: "REF" },
+  { key: "tou", label: "TOU" },
+  { key: "luk", label: "LUK" },
+];
+
+function PilotStatsInputRow({
+  values,
+  onChange,
+}: {
+  values: PilotStatsInput;
+  onChange: (values: PilotStatsInput) => void;
+}) {
+  return (
+    <div className="grid grid-cols-3 sm:grid-cols-6 gap-2">
+      {PILOT_STAT_FIELDS.map(({ key, label }) => (
+        <label key={String(key)} className="text-xs text-[#00ff41]/70">
+          {label}
+          <input
+            type="number"
+            value={values[key]}
+            onChange={(e) =>
+              onChange({ ...values, [key]: Number(e.target.value) || 0 })
+            }
+            className="mt-1 w-full bg-black border border-[#00ff41]/30 text-[#00ff41] px-1.5 py-1 text-sm font-mono focus:border-[#00ff41] focus:outline-none"
+          />
+        </label>
+      ))}
+    </div>
+  );
+}
+
+function StatDisplay({ label, value, unit = "" }: { label: string; value: string | number; unit?: string }) {
+  return (
+    <div className="border border-[#00ff41]/20 px-3 py-2">
+      <div className="text-[10px] text-[#00ff41]/50 uppercase">{label}</div>
+      <div className="text-lg font-bold text-[#00ff41]">
+        {value}
+        {unit}
+      </div>
+    </div>
+  );
+}
+
+export default function CombatSimulationPanel({ attacker, allSuits }: CombatSimulationPanelProps) {
+  const { result, isLoading, error, simulate } = useCombatSimulation();
+
+  const defenderCandidates = allSuits;
+  const [defenderId, setDefenderId] = useState<string>(
+    defenderCandidates.find((ms) => ms.id !== attacker.id)?.id ?? attacker.id
+  );
+  const defender = useMemo(
+    () => defenderCandidates.find((ms) => ms.id === defenderId) ?? attacker,
+    [defenderCandidates, defenderId, attacker]
+  );
+
+  const [weaponId, setWeaponId] = useState<string>(attacker.specs.weapons[0]?.id ?? "");
+  const weapon = attacker.specs.weapons.find((w) => w.id === weaponId) ?? attacker.specs.weapons[0];
+
+  const [attackerPilot, setAttackerPilot] = useState<PilotStatsInput>(DEFAULT_PILOT_STATS);
+  const [defenderPilot, setDefenderPilot] = useState<PilotStatsInput>(DEFAULT_PILOT_STATS);
+  const [distance, setDistance] = useState<number>(weapon?.optimal_range ?? 300);
+  const [attackSector, setAttackSector] = useState<AttackSector>("FRONT_SIDE");
+  const [trials, setTrials] = useState<number>(1000);
+
+  if (!weapon) {
+    return (
+      <div className="p-4 text-sm text-[#00ff41]/40">
+        武装が設定されていないためシミュレーションできません。
+      </div>
+    );
+  }
+
+  async function handleRun(withMonteCarlo: boolean) {
+    await simulate({
+      attacker_spec: attacker.specs,
+      attacker_weapon_id: weapon.id,
+      attacker_pilot: attackerPilot,
+      defender_spec: defender.specs,
+      defender_pilot: defenderPilot,
+      distance,
+      attack_sector: attackSector,
+      trials: withMonteCarlo ? trials : undefined,
+    });
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* 攻撃側 */}
+      <div>
+        <SciFiHeading level={4} className="mb-2 text-sm">
+          攻撃側: {attacker.name}
+        </SciFiHeading>
+        <label className="text-xs text-[#00ff41]/70 block mb-2">
+          使用武装
+          <select
+            value={weaponId || weapon.id}
+            onChange={(e) => setWeaponId(e.target.value)}
+            className="mt-1 w-full bg-black border border-[#00ff41]/30 text-[#00ff41] px-2 py-1.5 text-sm font-mono focus:border-[#00ff41] focus:outline-none"
+          >
+            {attacker.specs.weapons.map((w) => (
+              <option key={w.id} value={w.id}>
+                {w.name}（{w.power}dmg / acc{w.accuracy}%）
+              </option>
+            ))}
+          </select>
+        </label>
+        <PilotStatsInputRow values={attackerPilot} onChange={setAttackerPilot} />
+      </div>
+
+      {/* 防御側 */}
+      <div>
+        <SciFiHeading level={4} className="mb-2 text-sm">
+          防御側
+        </SciFiHeading>
+        <label className="text-xs text-[#00ff41]/70 block mb-2">
+          対象機体
+          <select
+            value={defenderId}
+            onChange={(e) => setDefenderId(e.target.value)}
+            className="mt-1 w-full bg-black border border-[#00ff41]/30 text-[#00ff41] px-2 py-1.5 text-sm font-mono focus:border-[#00ff41] focus:outline-none"
+          >
+            {defenderCandidates.map((ms) => (
+              <option key={ms.id} value={ms.id}>
+                {ms.name}（装甲{ms.specs.armor} / 機動{ms.specs.mobility}）
+              </option>
+            ))}
+          </select>
+        </label>
+        <PilotStatsInputRow values={defenderPilot} onChange={setDefenderPilot} />
+      </div>
+
+      {/* 距離・セクタ */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+        <label className="text-xs text-[#00ff41]/70">
+          距離 (m) — 最適射程: {weapon.optimal_range}m / 射程: {weapon.range}m
+          <input
+            type="range"
+            min={0}
+            max={weapon.range}
+            step={10}
+            value={distance}
+            onChange={(e) => setDistance(Number(e.target.value))}
+            className="mt-1 w-full"
+          />
+          <div className="text-right text-[#00ff41] text-sm">{distance}m</div>
+        </label>
+        <label className="text-xs text-[#00ff41]/70">
+          攻撃セクタ
+          <select
+            value={attackSector}
+            onChange={(e) => setAttackSector(e.target.value as AttackSector)}
+            className="mt-1 w-full bg-black border border-[#00ff41]/30 text-[#00ff41] px-2 py-1.5 text-sm font-mono focus:border-[#00ff41] focus:outline-none"
+          >
+            {SECTOR_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </label>
+      </div>
+
+      {/* 実行ボタン */}
+      <div className="flex flex-wrap gap-2">
+        <SciFiButton variant="primary" size="sm" disabled={isLoading} onClick={() => handleRun(false)}>
+          理論値を計算
+        </SciFiButton>
+        <div className="flex items-center gap-2">
+          <input
+            type="number"
+            min={1}
+            max={5000}
+            value={trials}
+            onChange={(e) => setTrials(Number(e.target.value) || 1)}
+            className="w-24 bg-black border border-[#ffb000]/30 text-[#ffb000] px-2 py-1.5 text-sm font-mono focus:border-[#ffb000] focus:outline-none"
+          />
+          <SciFiButton variant="secondary" size="sm" disabled={isLoading} onClick={() => handleRun(true)}>
+            N回試行
+          </SciFiButton>
+        </div>
+      </div>
+
+      {isLoading && <p className="text-[#ffb000] animate-pulse text-sm">計算中...</p>}
+      {error && <p className="text-red-400 text-sm">{error.message}</p>}
+
+      {/* 結果表示 */}
+      {result && (
+        <div className="space-y-3 pt-2 border-t border-[#00ff41]/20">
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+            <StatDisplay label="命中率(理論値)" value={result.hit_chance.toFixed(1)} unit="%" />
+            <StatDisplay label="クリティカル率(理論値)" value={result.crit_chance.toFixed(1)} unit="%" />
+            <StatDisplay label="ダメージ(非クリ)" value={result.resistance_applied_damage} />
+            <StatDisplay label="ダメージ(クリティカル)" value={result.crit_damage} />
+          </div>
+
+          {result.monte_carlo && (
+            <div>
+              <SciFiHeading level={4} className="mb-2 text-sm">
+                モンテカルロ試行結果（{result.monte_carlo.trials}回）
+              </SciFiHeading>
+              <div className="grid grid-cols-2 sm:grid-cols-4 gap-2">
+                <StatDisplay label="実測命中率" value={result.monte_carlo.actual_hit_rate.toFixed(1)} unit="%" />
+                <StatDisplay label="実測クリティカル率" value={result.monte_carlo.actual_crit_rate.toFixed(1)} unit="%" />
+                <StatDisplay label="平均ダメージ" value={result.monte_carlo.avg_damage.toFixed(1)} />
+                <StatDisplay
+                  label="ダメージ幅"
+                  value={`${result.monte_carlo.min_damage}〜${result.monte_carlo.max_damage}`}
+                />
+              </div>
+              {result.monte_carlo.perfect_evade_rate > 0 && (
+                <p className="text-xs text-[#00f0ff] mt-2">
+                  完全回避発生率: {result.monte_carlo.perfect_evade_rate.toFixed(2)}%
+                </p>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/admin-tool/src/hooks/useCombatSimulation.ts
+++ b/admin-tool/src/hooks/useCombatSimulation.ts
@@ -1,0 +1,54 @@
+/* admin-tool/src/hooks/useCombatSimulation.ts */
+"use client";
+
+import { useState } from "react";
+import { CombatSimulationRequest, CombatSimulationResponse } from "@/types/admin";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://127.0.0.1:8000";
+const ADMIN_API_KEY = process.env.NEXT_PUBLIC_ADMIN_API_KEY || "";
+
+const ENDPOINT = `${API_BASE_URL}/api/admin/simulate-combat`;
+
+/**
+ * 1対1 攻撃シミュレーションAPIを呼び出すフック
+ */
+export function useCombatSimulation() {
+  const [result, setResult] = useState<CombatSimulationResponse | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  async function simulate(payload: CombatSimulationRequest): Promise<CombatSimulationResponse> {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(ENDPOINT, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "X-API-Key": ADMIN_API_KEY,
+        },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        const detail = await res.json().catch(() => ({}));
+        throw new Error(detail.detail || `Simulation failed: ${res.status}`);
+      }
+      const data: CombatSimulationResponse = await res.json();
+      setResult(data);
+      return data;
+    } catch (e) {
+      const err = e instanceof Error ? e : new Error("Unknown error");
+      setError(err);
+      throw err;
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  function reset() {
+    setResult(null);
+    setError(null);
+  }
+
+  return { result, isLoading, error, simulate, reset };
+}

--- a/admin-tool/src/types/admin.ts
+++ b/admin-tool/src/types/admin.ts
@@ -58,3 +58,58 @@ export interface MasterWeaponUpdate {
     description?: string;
     weapon?: Weapon;
 }
+
+/** 攻撃セクタ（正面・側面・背面） */
+export type AttackSector = "FRONT" | "FRONT_SIDE" | "REAR_SIDE" | "REAR";
+
+/** シミュレーション用パイロットステータス入力 */
+export interface PilotStatsInput {
+    sht: number;
+    mel: number;
+    intel: number;
+    ref: number;
+    tou: number;
+    luk: number;
+}
+
+export const DEFAULT_PILOT_STATS: PilotStatsInput = {
+    sht: 0,
+    mel: 0,
+    intel: 0,
+    ref: 0,
+    tou: 0,
+    luk: 0,
+};
+
+/** 1対1 攻撃シミュレーションリクエスト */
+export interface CombatSimulationRequest {
+    attacker_spec: MasterMobileSuitSpec;
+    attacker_weapon_id: string;
+    attacker_pilot?: PilotStatsInput;
+    defender_spec: MasterMobileSuitSpec;
+    defender_pilot?: PilotStatsInput;
+    distance?: number;
+    attack_sector?: AttackSector;
+    trials?: number;
+}
+
+/** モンテカルロ試行の実測統計 */
+export interface MonteCarloCombatStats {
+    trials: number;
+    actual_hit_rate: number;
+    actual_crit_rate: number;
+    avg_damage: number;
+    min_damage: number;
+    max_damage: number;
+    perfect_evade_rate: number;
+}
+
+/** 1対1 攻撃シミュレーションレスポンス */
+export interface CombatSimulationResponse {
+    hit_chance: number;
+    crit_chance: number;
+    base_damage: number;
+    crit_damage: number;
+    resistance_applied_damage: number;
+    monte_carlo: MonteCarloCombatStats | null;
+}

--- a/backend/app/engine/combat_preview.py
+++ b/backend/app/engine/combat_preview.py
@@ -1,0 +1,199 @@
+# backend/app/engine/combat_preview.py
+"""管理画面向け 1対1 攻撃シミュレーション（Issue #381）.
+
+`BattleSimulator` インスタンス状態（player_skills / unit_resources / special_effects）に
+依存せず、機体スペック・武器・パイロットステータスのみから命中率・クリティカル率・
+ダメージを計算する。`combat.py` / `calculator.py` の計算式と完全に一致させ、実戦との
+乖離が生じないようにする。
+
+決定論モード: 乱数を振らず、命中率・クリティカル率・理論ダメージ値を返す。
+モンテカルロモード: 決定論値をもとに実際に random 判定を N 回試行し、統計値を返す。
+"""
+
+import random
+from dataclasses import dataclass
+
+from app.engine.calculator import (
+    PilotStats,
+    calculate_critical_chance,
+    calculate_damage_variance,
+    calculate_hit_chance,
+)
+from app.engine.combat import CombatMixin, _sigmoid_attack, _sigmoid_defense
+from app.engine.constants import SECTOR_ACCURACY_MODIFIERS, SECTOR_DAMAGE_MODIFIERS
+from app.models.models import MasterMobileSuitSpec, Weapon
+
+BASE_CRIT_RATE = 0.05
+
+
+@dataclass
+class DeterministicCombatResult:
+    """乱数を振らない理論値."""
+
+    hit_chance: float
+    crit_chance: float
+    base_damage: int
+    crit_damage: int
+    resistance_applied_damage: int
+
+
+@dataclass
+class MonteCarloCombatResult:
+    """N回試行した実測統計値."""
+
+    trials: int
+    actual_hit_rate: float
+    actual_crit_rate: float
+    avg_damage: float
+    min_damage: int
+    max_damage: int
+    perfect_evade_rate: float
+
+
+def _is_melee_weapon(weapon: Weapon) -> bool:
+    return weapon.weapon_type == "MELEE" or weapon.is_melee
+
+
+def calculate_deterministic_combat_stats(
+    attacker_spec: MasterMobileSuitSpec,
+    attacker_pilot: PilotStats,
+    weapon: Weapon,
+    defender_spec: MasterMobileSuitSpec,
+    defender_pilot: PilotStats,
+    distance: float,
+    attack_sector: str,
+) -> DeterministicCombatResult:
+    """命中率・クリティカル率・ダメージの理論値（乱数なし）を計算する.
+
+    `combat.py` の `_calculate_hit_chance` / `_calculate_hit_base_damage` /
+    `_apply_hit_damage_modifiers` と同一の計算式を使用する（スキル補正・障害物補正・
+    プレイヤー限定スキルは対象外。機体パラメータとパイロットステータスのみで完結する）。
+    """
+    is_melee = _is_melee_weapon(weapon)
+
+    # --- 命中率 ---
+    distance_from_optimal = abs(distance - weapon.optimal_range)
+    dist_penalty = distance_from_optimal * weapon.decay_rate
+    evasion_bonus = defender_spec.mobility * 10
+    hit_chance = float(weapon.accuracy - dist_penalty - evasion_bonus)
+
+    attacker_dex = attacker_pilot.mel if is_melee else attacker_pilot.sht
+    defender_int = defender_pilot.intel
+    hit_chance = calculate_hit_chance(
+        hit_chance,
+        distance_from_optimal=distance_from_optimal,
+        decay_rate=weapon.decay_rate,
+        attacker_dex=attacker_dex,
+        defender_int=defender_int,
+    )
+
+    weapon_type = "MELEE" if is_melee else weapon.weapon_type
+    accuracy_modifier = CombatMixin._get_accuracy_modifier(distance, weapon_type)
+    hit_chance *= accuracy_modifier
+    hit_chance *= SECTOR_ACCURACY_MODIFIERS[attack_sector]
+    hit_chance += attacker_spec.accuracy_bonus
+    hit_chance -= defender_spec.evasion_bonus
+    hit_chance = max(0.0, min(100.0, hit_chance))
+
+    # --- クリティカル率 ---
+    crit_chance = calculate_critical_chance(
+        BASE_CRIT_RATE,
+        attacker_int=attacker_pilot.intel,
+        defender_tou=defender_pilot.tou,
+    )
+
+    # --- 基礎ダメージ（シグモイド式） ---
+    total_atk = attacker_pilot.mel if is_melee else attacker_pilot.sht
+    attack_bonus = _sigmoid_attack(float(total_atk))
+    total_def = defender_spec.armor + defender_pilot.tou
+    defense_reduction = _sigmoid_defense(float(total_def))
+    base_damage = max(
+        1, int(weapon.power * (1.0 + attack_bonus) * (1.0 - defense_reduction))
+    )
+    base_damage = max(1, int(base_damage * SECTOR_DAMAGE_MODIFIERS[attack_sector]))
+
+    crit_damage = int(weapon.power * 1.2)
+
+    # --- 適性・耐性補正（クリティカル/非クリティカル共通） ---
+    aptitude = (
+        attacker_spec.melee_aptitude if is_melee else attacker_spec.shooting_aptitude
+    )
+    resistance_applied_damage = int(base_damage * aptitude)
+    if not is_melee:
+        if weapon.type == "BEAM":
+            resistance_applied_damage = int(
+                resistance_applied_damage * (1.0 - defender_spec.beam_resistance)
+            )
+        elif weapon.type == "PHYSICAL":
+            resistance_applied_damage = int(
+                resistance_applied_damage * (1.0 - defender_spec.physical_resistance)
+            )
+
+    return DeterministicCombatResult(
+        hit_chance=hit_chance,
+        crit_chance=crit_chance * 100.0,
+        base_damage=base_damage,
+        crit_damage=crit_damage,
+        resistance_applied_damage=resistance_applied_damage,
+    )
+
+
+def run_monte_carlo_combat_stats(
+    deterministic: DeterministicCombatResult,
+    attacker_pilot: PilotStats,
+    defender_pilot: PilotStats,
+    trials: int,
+) -> MonteCarloCombatResult:
+    """決定論値をもとに実際の乱数判定をN回試行し、統計を集計する.
+
+    `combat.py` の `_process_attack` / `_process_hit` と同一の判定順序
+    （命中判定 → クリティカル判定 → ダメージ乱数変動）で乱数を消費する。
+    """
+    hit_count = 0
+    crit_count = 0
+    perfect_evade_count = 0
+    damages: list[int] = []
+
+    for _ in range(trials):
+        roll = random.uniform(0, 100)
+        if roll > deterministic.hit_chance:
+            continue
+        hit_count += 1
+
+        is_crit = random.random() < (deterministic.crit_chance / 100.0)
+        base_damage = (
+            deterministic.crit_damage
+            if is_crit
+            else deterministic.resistance_applied_damage
+        )
+        if is_crit:
+            crit_count += 1
+
+        final_damage, perfect_evade = calculate_damage_variance(
+            base_damage,
+            attacker_luk=attacker_pilot.luk,
+            attacker_tou=attacker_pilot.tou,
+            defender_dex=0,
+            defender_tou=defender_pilot.tou,
+            defender_luk=defender_pilot.luk,
+        )
+        if perfect_evade:
+            perfect_evade_count += 1
+        damages.append(final_damage)
+
+    actual_hit_rate = (hit_count / trials * 100.0) if trials else 0.0
+    actual_crit_rate = (crit_count / hit_count * 100.0) if hit_count else 0.0
+    perfect_evade_rate = (perfect_evade_count / hit_count * 100.0) if hit_count else 0.0
+    avg_damage = (sum(damages) / len(damages)) if damages else 0.0
+    min_damage = min(damages) if damages else 0
+    max_damage = max(damages) if damages else 0
+
+    return MonteCarloCombatResult(
+        trials=trials,
+        actual_hit_rate=actual_hit_rate,
+        actual_crit_rate=actual_crit_rate,
+        avg_damage=avg_damage,
+        min_damage=min_damage,
+        max_damage=max_damage,
+        perfect_evade_rate=perfect_evade_rate,
+    )

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -423,6 +423,65 @@ class MasterWeaponUpdate(SQLModel):
     weapon: Weapon | None = None
 
 
+# --- Combat Simulation Models (管理画面用 1対1 攻撃シミュレーション, Issue #381) ---
+
+
+class PilotStatsInput(SQLModel):
+    """シミュレーション用パイロットステータス入力."""
+
+    sht: int = Field(default=0, description="射撃精度 (SHT)")
+    mel: int = Field(default=0, description="格闘技巧 (MEL)")
+    intel: int = Field(default=0, description="直感 (INT)")
+    ref: int = Field(default=0, description="反応 (REF)")
+    tou: int = Field(default=0, description="耐久 (TOU)")
+    luk: int = Field(default=0, description="幸運 (LUK)")
+
+
+class CombatSimulationRequest(SQLModel):
+    """1対1 攻撃シミュレーションリクエスト."""
+
+    attacker_spec: MasterMobileSuitSpec
+    attacker_weapon_id: str = Field(description="attacker_spec.weapons 内の武器ID")
+    attacker_pilot: PilotStatsInput = Field(default_factory=PilotStatsInput)
+    defender_spec: MasterMobileSuitSpec
+    defender_pilot: PilotStatsInput = Field(default_factory=PilotStatsInput)
+    distance: float | None = Field(
+        default=None, description="攻撃距離(m)。省略時は武器の optimal_range"
+    )
+    attack_sector: str = Field(
+        default="FRONT_SIDE", description="攻撃セクタ (FRONT/FRONT_SIDE/REAR_SIDE/REAR)"
+    )
+    trials: int | None = Field(
+        default=None,
+        ge=1,
+        le=5000,
+        description="モンテカルロ試行回数（省略時は理論値のみ）",
+    )
+
+
+class MonteCarloCombatStats(SQLModel):
+    """モンテカルロ試行の実測統計."""
+
+    trials: int
+    actual_hit_rate: float
+    actual_crit_rate: float
+    avg_damage: float
+    min_damage: int
+    max_damage: int
+    perfect_evade_rate: float
+
+
+class CombatSimulationResponse(SQLModel):
+    """1対1 攻撃シミュレーションレスポンス."""
+
+    hit_chance: float
+    crit_chance: float
+    base_damage: int
+    crit_damage: int
+    resistance_applied_damage: int
+    monte_carlo: MonteCarloCombatStats | None = None
+
+
 # --- Master Data Table Models (DBテーブル定義) ---
 
 

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -10,6 +10,8 @@ from sqlmodel import Session
 from app.core.auth import verify_admin_api_key
 from app.db import get_session
 from app.models.models import (
+    CombatSimulationRequest,
+    CombatSimulationResponse,
     MasterMobileSuitCreate,
     MasterMobileSuitEntry,
     MasterMobileSuitSpec,
@@ -19,6 +21,7 @@ from app.models.models import (
     MasterWeaponUpdate,
     Weapon,
 )
+from app.services.combat_simulation_service import CombatSimulationService
 from app.services.mobile_suit_service import MobileSuitService
 from app.services.weapon_service import WeaponService
 
@@ -31,6 +34,12 @@ router = APIRouter(
 weapon_router = APIRouter(
     prefix="/api/admin/weapons",
     tags=["admin-weapons"],
+    dependencies=[Depends(verify_admin_api_key)],
+)
+
+simulation_router = APIRouter(
+    prefix="/api/admin",
+    tags=["admin-simulation"],
     dependencies=[Depends(verify_admin_api_key)],
 )
 
@@ -231,3 +240,24 @@ def delete_master_weapon(
             status_code=status.HTTP_404_NOT_FOUND,
             detail=f"Master weapon '{weapon_id}' not found.",
         )
+
+
+# ===========================================================
+# 1対1 攻撃シミュレーション エンドポイント (Issue #381)
+# ===========================================================
+
+
+@simulation_router.post("/simulate-combat", response_model=CombatSimulationResponse)
+def simulate_combat(data: CombatSimulationRequest) -> CombatSimulationResponse:
+    """機体・武器・パイロットステータスから命中率・クリティカル率・ダメージを計算する.
+
+    - `trials` を指定すると、決定論値に加えてモンテカルロ試行の統計値を返す
+    - `attacker_weapon_id` が `attacker_spec.weapons` に存在しない場合は 422 を返す
+    - `attack_sector` が不正な値の場合は 422 を返す
+    """
+    try:
+        return CombatSimulationService.simulate(data)
+    except ValueError as e:
+        raise HTTPException(
+            status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)
+        ) from e

--- a/backend/app/services/combat_simulation_service.py
+++ b/backend/app/services/combat_simulation_service.py
@@ -1,0 +1,98 @@
+# backend/app/services/combat_simulation_service.py
+"""管理画面向け 1対1 攻撃シミュレーションサービス（Issue #381）."""
+
+from app.engine.calculator import PilotStats
+from app.engine.combat_preview import (
+    calculate_deterministic_combat_stats,
+    run_monte_carlo_combat_stats,
+)
+from app.engine.constants import SECTOR_ACCURACY_MODIFIERS
+from app.models.models import (
+    CombatSimulationRequest,
+    CombatSimulationResponse,
+    MonteCarloCombatStats,
+    PilotStatsInput,
+)
+
+
+def _to_pilot_stats(pilot_input: PilotStatsInput) -> PilotStats:
+    return PilotStats(
+        sht=pilot_input.sht,
+        mel=pilot_input.mel,
+        intel=pilot_input.intel,
+        ref=pilot_input.ref,
+        tou=pilot_input.tou,
+        luk=pilot_input.luk,
+    )
+
+
+class CombatSimulationService:
+    """1対1 攻撃シミュレーションを実行するサービス."""
+
+    @staticmethod
+    def simulate(request: CombatSimulationRequest) -> CombatSimulationResponse:
+        """機体・武器・パイロットステータスから命中率・ダメージを計算する.
+
+        Raises:
+            ValueError: 武器IDが見つからない、または attack_sector が不正な場合
+        """
+        if request.attack_sector not in SECTOR_ACCURACY_MODIFIERS:
+            valid_sectors = ", ".join(SECTOR_ACCURACY_MODIFIERS.keys())
+            raise ValueError(
+                f"Invalid attack_sector '{request.attack_sector}'. "
+                f"Valid values: {valid_sectors}"
+            )
+
+        weapon = next(
+            (
+                w
+                for w in request.attacker_spec.weapons
+                if w.id == request.attacker_weapon_id
+            ),
+            None,
+        )
+        if weapon is None:
+            raise ValueError(
+                f"Weapon '{request.attacker_weapon_id}' not found in attacker_spec.weapons"
+            )
+
+        distance = (
+            request.distance if request.distance is not None else weapon.optimal_range
+        )
+
+        deterministic = calculate_deterministic_combat_stats(
+            attacker_spec=request.attacker_spec,
+            attacker_pilot=_to_pilot_stats(request.attacker_pilot),
+            weapon=weapon,
+            defender_spec=request.defender_spec,
+            defender_pilot=_to_pilot_stats(request.defender_pilot),
+            distance=distance,
+            attack_sector=request.attack_sector,
+        )
+
+        monte_carlo: MonteCarloCombatStats | None = None
+        if request.trials:
+            mc_result = run_monte_carlo_combat_stats(
+                deterministic,
+                attacker_pilot=_to_pilot_stats(request.attacker_pilot),
+                defender_pilot=_to_pilot_stats(request.defender_pilot),
+                trials=request.trials,
+            )
+            monte_carlo = MonteCarloCombatStats(
+                trials=mc_result.trials,
+                actual_hit_rate=mc_result.actual_hit_rate,
+                actual_crit_rate=mc_result.actual_crit_rate,
+                avg_damage=mc_result.avg_damage,
+                min_damage=mc_result.min_damage,
+                max_damage=mc_result.max_damage,
+                perfect_evade_rate=mc_result.perfect_evade_rate,
+            )
+
+        return CombatSimulationResponse(
+            hit_chance=deterministic.hit_chance,
+            crit_chance=deterministic.crit_chance,
+            base_damage=deterministic.base_damage,
+            crit_damage=deterministic.crit_damage,
+            resistance_applied_damage=deterministic.resistance_applied_damage,
+            monte_carlo=monte_carlo,
+        )

--- a/backend/main.py
+++ b/backend/main.py
@@ -79,6 +79,7 @@ app.include_router(friends.router)
 app.include_router(teams.router)
 app.include_router(admin.router)
 app.include_router(admin.weapon_router)
+app.include_router(admin.simulation_router)
 app.include_router(player_weapons.router)
 
 # --- Response Schemas ---

--- a/backend/tests/unit/test_admin_combat_simulation.py
+++ b/backend/tests/unit/test_admin_combat_simulation.py
@@ -1,0 +1,241 @@
+"""管理者用 1対1 攻撃シミュレーション API のユニットテスト（Issue #381）."""
+
+import os
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+
+os.environ["ADMIN_API_KEY"] = "test_admin_key_12345"
+
+from main import app
+
+ADMIN_KEY = "test_admin_key_12345"
+HEADERS = {"X-API-Key": ADMIN_KEY}
+
+BEAM_RIFLE = {
+    "id": "beam_rifle",
+    "name": "Beam Rifle",
+    "power": 150,
+    "range": 500,
+    "accuracy": 75,
+    "type": "BEAM",
+    "weapon_type": "RANGED",
+    "optimal_range": 320.0,
+    "decay_rate": 0.09,
+    "is_melee": False,
+}
+
+HEAT_HAWK = {
+    "id": "heat_hawk",
+    "name": "Heat Hawk",
+    "power": 130,
+    "range": 50,
+    "accuracy": 80,
+    "type": "PHYSICAL",
+    "weapon_type": "MELEE",
+    "optimal_range": 0.0,
+    "decay_rate": 0.05,
+    "is_melee": True,
+}
+
+
+def _spec(armor=80, mobility=1.2, weapons=None, **overrides):
+    base = {
+        "max_hp": 1000,
+        "armor": armor,
+        "mobility": mobility,
+        "sensor_range": 500.0,
+        "beam_resistance": 0.0,
+        "physical_resistance": 0.0,
+        "melee_aptitude": 1.0,
+        "shooting_aptitude": 1.0,
+        "accuracy_bonus": 0.0,
+        "evasion_bonus": 0.0,
+        "acceleration_bonus": 1.0,
+        "turning_bonus": 1.0,
+        "weapons": weapons if weapons is not None else [BEAM_RIFLE],
+    }
+    base.update(overrides)
+    return base
+
+
+@pytest.fixture(name="client")
+def client_fixture():
+    """テスト用APIクライアント."""
+    client = TestClient(app)
+    yield client
+
+
+# ===================== 認証テスト =====================
+
+
+def test_simulate_requires_auth(client):
+    """認証ヘッダーなしでは 401 または 422 が返ること."""
+    response = client.post(
+        "/api/admin/simulate-combat",
+        json={
+            "attacker_spec": _spec(),
+            "attacker_weapon_id": "beam_rifle",
+            "defender_spec": _spec(),
+        },
+    )
+    assert response.status_code in (status.HTTP_401_UNAUTHORIZED, 422)
+
+
+def test_simulate_wrong_key(client):
+    """不正なAPIキーで 401 が返ること."""
+    response = client.post(
+        "/api/admin/simulate-combat",
+        headers={"X-API-Key": "wrong_key"},
+        json={
+            "attacker_spec": _spec(),
+            "attacker_weapon_id": "beam_rifle",
+            "defender_spec": _spec(),
+        },
+    )
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+# ===================== 決定論値のテスト =====================
+
+
+def test_simulate_deterministic_values(client):
+    """乱数を振らない理論値が計算式どおりに返ること."""
+    response = client.post(
+        "/api/admin/simulate-combat",
+        headers=HEADERS,
+        json={
+            "attacker_spec": _spec(armor=80, mobility=0.0),
+            "attacker_weapon_id": "beam_rifle",
+            "defender_spec": _spec(armor=100, mobility=0.0),
+        },
+    )
+    assert response.status_code == status.HTTP_200_OK
+    body = response.json()
+
+    # weapon.accuracy(75) - dist_penalty(0, optimal距離なので) - evasion_bonus(mobility*10=0)
+    assert body["hit_chance"] == pytest.approx(75.0)
+    # base_crit_rate = 0.05, ステータス補正なし
+    assert body["crit_chance"] == pytest.approx(5.0)
+    # クリティカル倍率 weapon.power * 1.2
+    assert body["crit_damage"] == int(150 * 1.2)
+    assert body["base_damage"] >= 1
+    assert body["resistance_applied_damage"] >= 1
+    assert body["monte_carlo"] is None
+
+
+def test_simulate_pilot_stats_affect_hit_and_crit(client):
+    """パイロットステータス（SHT/INT/TOU）が命中率・クリティカル率に反映されること."""
+    baseline = client.post(
+        "/api/admin/simulate-combat",
+        headers=HEADERS,
+        json={
+            "attacker_spec": _spec(),
+            "attacker_weapon_id": "beam_rifle",
+            "defender_spec": _spec(),
+        },
+    ).json()
+
+    boosted = client.post(
+        "/api/admin/simulate-combat",
+        headers=HEADERS,
+        json={
+            "attacker_spec": _spec(),
+            "attacker_weapon_id": "beam_rifle",
+            "attacker_pilot": {"sht": 50, "intel": 20},
+            "defender_spec": _spec(),
+        },
+    ).json()
+
+    assert boosted["hit_chance"] > baseline["hit_chance"]
+    assert boosted["crit_chance"] > baseline["crit_chance"]
+
+
+def test_simulate_melee_weapon_skips_resistance(client):
+    """格闘武器は耐性計算をスキップする現行仕様に合わせていること."""
+    response = client.post(
+        "/api/admin/simulate-combat",
+        headers=HEADERS,
+        json={
+            "attacker_spec": _spec(weapons=[HEAT_HAWK]),
+            "attacker_weapon_id": "heat_hawk",
+            "defender_spec": _spec(physical_resistance=0.5),
+        },
+    )
+    assert response.status_code == status.HTTP_200_OK
+    body = response.json()
+    # 耐性50%が無視されるため、適性(1.0)適用のみで base_damage と一致する
+    assert body["resistance_applied_damage"] == body["base_damage"]
+
+
+# ===================== モンテカルロ試行のテスト =====================
+
+
+def test_simulate_monte_carlo_converges_to_deterministic(client):
+    """モンテカルロ試行の実測命中率が理論値に近似すること（大数の法則）."""
+    response = client.post(
+        "/api/admin/simulate-combat",
+        headers=HEADERS,
+        json={
+            "attacker_spec": _spec(),
+            "attacker_weapon_id": "beam_rifle",
+            "defender_spec": _spec(),
+            "trials": 3000,
+        },
+    )
+    assert response.status_code == status.HTTP_200_OK
+    body = response.json()
+    mc = body["monte_carlo"]
+    assert mc is not None
+    assert mc["trials"] == 3000
+    assert abs(mc["actual_hit_rate"] - body["hit_chance"]) < 10.0
+    assert abs(mc["actual_crit_rate"] - body["crit_chance"]) < 10.0
+    assert mc["min_damage"] <= mc["avg_damage"] <= mc["max_damage"]
+
+
+def test_simulate_trials_out_of_range_rejected(client):
+    """Trials が範囲外（1〜5000）の場合 422 が返ること."""
+    response = client.post(
+        "/api/admin/simulate-combat",
+        headers=HEADERS,
+        json={
+            "attacker_spec": _spec(),
+            "attacker_weapon_id": "beam_rifle",
+            "defender_spec": _spec(),
+            "trials": 10000,
+        },
+    )
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+# ===================== エラーケース =====================
+
+
+def test_simulate_unknown_weapon_id_returns_422(client):
+    """attacker_weapon_id が attacker_spec.weapons に存在しない場合 422 が返ること."""
+    response = client.post(
+        "/api/admin/simulate-combat",
+        headers=HEADERS,
+        json={
+            "attacker_spec": _spec(),
+            "attacker_weapon_id": "nonexistent_weapon",
+            "defender_spec": _spec(),
+        },
+    )
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+def test_simulate_invalid_attack_sector_returns_422(client):
+    """attack_sector が不正な値の場合 422 が返ること."""
+    response = client.post(
+        "/api/admin/simulate-combat",
+        headers=HEADERS,
+        json={
+            "attacker_spec": _spec(),
+            "attacker_weapon_id": "beam_rifle",
+            "defender_spec": _spec(),
+            "attack_sector": "DIAGONAL",
+        },
+    )
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY

--- a/docs/features/admin-mobile-suits.md
+++ b/docs/features/admin-mobile-suits.md
@@ -19,6 +19,7 @@
 | `POST` | `/api/admin/mobile-suits` | 新規機体追加 |
 | `PUT` | `/api/admin/mobile-suits/{ms_id}` | 既存機体の更新 |
 | `DELETE` | `/api/admin/mobile-suits/{ms_id}` | 機体削除 |
+| `POST` | `/api/admin/simulate-combat` | 1対1 攻撃シミュレーション（ダメージ・命中率）（Issue #381） |
 
 ### 認証
 
@@ -105,6 +106,84 @@ Content-Type: application/json
   "description": "改良型仕様。"
 }
 ```
+
+---
+
+## ダメージ・命中率シミュレーション API（Issue #381）
+
+`POST /api/admin/simulate-combat` は、機体スペック・武器・パイロットステータスを入力として、
+実戦（`backend/app/engine/combat.py`）と同一の計算式で命中率・クリティカル率・ダメージを算出する。
+
+### 計算の実装
+
+`backend/app/engine/combat_preview.py` に `BattleSimulator` インスタンス状態に依存しない純粋関数として実装。
+シグモイドダメージ式（[`docs/features/sigmoid-damage-calculation.md`](./sigmoid-damage-calculation.md)）や
+`calculator.py` のパイロットステータス補正関数をそのまま再利用しており、実戦の挙動と乖離しない。
+
+### 乱数を含む計算への対応
+
+命中判定・クリティカル判定・ダメージ分散は本来 `random` モジュールに依存するため、同一入力でも結果が毎回変わる。
+これに対応するため、本APIは2種類の値を返す:
+
+- **決定論値**（常に返す）: 乱数を振らず、命中率(%)・クリティカル率(%)・理論ダメージ値を返す
+- **モンテカルロ試行**（`trials` 指定時のみ）: サーバー側で実際に乱数判定をN回（最大5000回）試行し、
+  実測命中率・平均/最小/最大ダメージ・クリティカル発生率・完全回避発生率（LUKステータス由来）を集計して返す
+
+### リクエスト例
+
+```json
+POST /api/admin/simulate-combat
+X-API-Key: <key>
+Content-Type: application/json
+
+{
+  "attacker_spec": { "...": "MasterMobileSuitSpec と同形" },
+  "attacker_weapon_id": "beam_rifle",
+  "attacker_pilot": { "sht": 50, "mel": 0, "intel": 0, "ref": 0, "tou": 0, "luk": 0 },
+  "defender_spec": { "...": "MasterMobileSuitSpec と同形" },
+  "defender_pilot": { "sht": 0, "mel": 0, "intel": 0, "ref": 0, "tou": 20, "luk": 0 },
+  "distance": 320,
+  "attack_sector": "FRONT_SIDE",
+  "trials": 1000
+}
+```
+
+### レスポンス例
+
+```json
+{
+  "hit_chance": 65.0,
+  "crit_chance": 5.0,
+  "base_damage": 116,
+  "crit_damage": 180,
+  "resistance_applied_damage": 116,
+  "monte_carlo": {
+    "trials": 1000,
+    "actual_hit_rate": 66.2,
+    "actual_crit_rate": 5.4,
+    "avg_damage": 119.1,
+    "min_damage": 104,
+    "max_damage": 197,
+    "perfect_evade_rate": 0.0
+  }
+}
+```
+
+`trials` を省略した場合は `monte_carlo` が `null` になり、決定論値のみが返る。
+
+### バリデーション
+
+| ケース | ステータスコード |
+|---|---|
+| `attacker_weapon_id` が `attacker_spec.weapons` に存在しない | `422` |
+| `attack_sector` が `FRONT`/`FRONT_SIDE`/`REAR_SIDE`/`REAR` 以外 | `422` |
+| `trials` が範囲外（1〜5000）| `422` |
+
+### 管理画面UI
+
+マスター機体編集画面の「ダメージ・命中率シミュレーション」パネル（`CombatSimulationPanel`）から利用できる。
+攻撃側は選択中の機体、防御側はマスター機体一覧から選択する。距離・攻撃セクタ・双方のパイロットステータスを
+調整しながら「理論値を計算」（決定論値のみ）・「N回試行」（モンテカルロ統計付き）を実行できる。
 
 ---
 
@@ -215,10 +294,12 @@ admin-tool/src/
 │   │   ├── MobileSuitTable.tsx    # 機体一覧テーブル（ソート・フィルタ付き）
 │   │   ├── MobileSuitEditForm.tsx # 全パラメータ編集フォーム（Zod バリデーション）
 │   │   ├── MobileSuitRadarChart.tsx # バランス比較レーダーチャート（recharts）
+│   │   ├── CombatSimulationPanel.tsx # ダメージ・命中率シミュレーションパネル（Issue #381）
 │   │   └── CloneDialog.tsx        # Clone & Edit ダイアログ
 │   └── ui/                        # SciFiPanel / SciFiButton / SciFiHeading（frontendから移植）
 └── hooks/
-    └── useAdminMobileSuits.ts     # SWR を用いた CRUD フック
+    ├── useAdminMobileSuits.ts     # SWR を用いた CRUD フック
+    └── useCombatSimulation.ts     # シミュレーションAPI呼び出しフック（Issue #381）
 ```
 
 ### 機能詳細
@@ -249,6 +330,14 @@ admin-tool/src/
 - 選択中の機体をコピーして新しい ID を付けて新規追加
 - ID バリデーション（スネークケース英数字のみ）
 
+#### ダメージ・命中率シミュレーション (`CombatSimulationPanel`, Issue #381)
+
+- 攻撃側（選択中の機体・武装・パイロットステータス）と防御側（機体一覧から選択・パイロットステータス）を入力
+- 距離スライダー・攻撃セクタ選択で条件を調整可能
+- 「理論値を計算」で決定論値（命中率・クリティカル率・非クリ/クリダメージ）を表示
+- 「N回試行」でモンテカルロ試行を実行し、実測統計値を理論値と並べて表示
+- バックエンドAPI: `POST /api/admin/simulate-combat`（詳細は本ドキュメント上部「ダメージ・命中率シミュレーション API」セクション参照）
+
 #### 楽観的更新とロールバック
 
 `useAdminMobileSuits` フックで SWR の `mutate` を使用し、API 呼び出し前にキャッシュを先行更新。
@@ -272,6 +361,19 @@ NEON_DATABASE_URL="sqlite:///test.db" ADMIN_API_KEY="test_key" python -m pytest 
 - PUT 更新（正常 / 404 / weapons 空 422）
 - DELETE 削除（正常 / 404 / 在庫参照 409）
 - DB 永続化確認
+
+```bash
+cd backend
+NEON_DATABASE_URL="sqlite:///test.db" ADMIN_API_KEY="test_key" python -m pytest tests/unit/test_admin_combat_simulation.py -v
+```
+
+テスト内容 (`tests/unit/test_admin_combat_simulation.py`, Issue #381):
+- 認証チェック（キーなし / 不正キー）
+- 決定論値の計算式検証（命中率・クリティカル率・クリダメージ倍率）
+- パイロットステータス（SHT/INT/TOU）が命中率・クリティカル率に反映されること
+- 格闘武器は耐性計算をスキップする現行仕様との整合性
+- モンテカルロ試行の実測値が理論値に近似すること（大数の法則）
+- 武器ID不正・攻撃セクタ不正・試行回数範囲外の 422 エラー
 
 ### admin-tool
 
@@ -298,5 +400,10 @@ npx vitest run tests/unit/
 - `backend/alembic/versions/r1s2t3u4v5w6_add_master_mobile_suits_and_weapons_tables.py` — マイグレーション
 - `admin-tool/src/app/mobile-suits/page.tsx` — 管理画面（独立アプリ、ポート3100）
 - `admin-tool/src/hooks/useAdminMobileSuits.ts` — CRUD フック
+- `backend/app/engine/combat_preview.py` — 1対1 攻撃シミュレーション計算ロジック（決定論値・モンテカルロ）（Issue #381）
+- `backend/app/services/combat_simulation_service.py` — シミュレーションサービス（Issue #381）
+- `backend/tests/unit/test_admin_combat_simulation.py` — シミュレーションAPIテスト（Issue #381）
+- `admin-tool/src/components/admin/CombatSimulationPanel.tsx` — シミュレーションパネルUI（Issue #381）
+- `admin-tool/src/hooks/useCombatSimulation.ts` — シミュレーションAPI呼び出しフック（Issue #381）
 - `scripts/dev-admin.sh` — admin-tool 起動スクリプト
 


### PR DESCRIPTION
## Summary
- 実戦の計算ロジック（`backend/app/engine/combat.py` / `calculator.py`）を再利用した1対1攻撃シミュレーションAPI `POST /api/admin/simulate-combat` を新設
- 命中判定・クリティカル判定・ダメージ分散は乱数依存のため、決定論値（理論値）とモンテカルロ試行（N回試行の実測統計）の両方を返す設計に
- マスター機体管理画面（`admin-tool`）に `CombatSimulationPanel` を追加し、攻撃側/防御側の機体・武器・パイロットステータス・距離・攻撃セクタを指定して結果を確認可能

## 実装内容
- **Backend**
  - `backend/app/engine/combat_preview.py`: `BattleSimulator` インスタンス状態に依存しない純粋関数として、命中率・クリティカル率・シグモイドダメージ式の決定論計算とモンテカルロ試行を実装
  - `backend/app/services/combat_simulation_service.py`: リクエストのバリデーション（武器ID存在チェック・attack_sector検証）とサービス層
  - `backend/app/models/models.py`: `CombatSimulationRequest` / `CombatSimulationResponse` / `PilotStatsInput` / `MonteCarloCombatStats` を追加
  - `backend/app/routers/admin.py`: `POST /api/admin/simulate-combat` エンドポイント追加（既存の `X-API-Key` 認証を適用）
- **Frontend (`admin-tool`)**
  - `useCombatSimulation` フック、`CombatSimulationPanel` コンポーネントを新規追加し `mobile-suits/page.tsx` に組み込み
- **Docs**
  - `docs/features/admin-mobile-suits.md` にAPI仕様・UI説明・テスト内容を追記

Closes #381

## Test plan
- [x] Backend: `pytest tests/unit --tb=short`（全件パス、新規テスト `test_admin_combat_simulation.py` 9件含む）
- [x] Frontend: `npx tsc --noEmit`（新規コードにエラーなし。既存の `weaponEditFormValidation.test.ts` の型エラーは本PR無関係のmain既存問題）
- [x] Frontend: `npx vitest run tests/unit/`（既存52件パス、リグレッションなし）
- [x] ブラウザ実機確認（Playwright）: 機体選択→パネル表示→「理論値を計算」→「N回試行」の一連の操作でエラーなく動作し、モンテカルロ実測値が理論値に収束することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)