### PR TITLE
マスタ機体に型番・日本語名・武器スロット数・ビームジェネレータLvを追加

### DIFF
--- a/admin-tool/src/components/admin/MobileSuitEditForm.tsx
+++ b/admin-tool/src/components/admin/MobileSuitEditForm.tsx
@@ -24,33 +24,58 @@ export const weaponSchema = z.object({
   max_ammo: z.number().int().nonnegative().nullable().optional(),
   en_cost: z.number().int().nonnegative().optional(),
   cool_down_turn: z.number().int().nonnegative().optional(),
+  required_beam_generator_lv: z.number({ message: "Must be a number" }).int().nonnegative().optional(),
 });
 
-export const masterMobileSuitSchema = z.object({
-  id: z
-    .string()
-    .min(1, "ID is required")
-    .regex(/^[a-z0-9_]+$/, "ID must be lowercase alphanumeric with underscores (snake_case)"),
-  name: z.string().min(1, "Name is required"),
-  price: z.number({ message: "Must be a number" }).int().nonnegative("Must be ≥ 0"),
-  faction: z.string(),
-  description: z.string(),
-  specs: z.object({
-    max_hp: z.number({ message: "Must be a number" }).int().positive("Must be > 0"),
-    armor: z.number({ message: "Must be a number" }).int().nonnegative(),
-    mobility: z.number({ message: "Must be a number" }).positive("Must be > 0"),
-    sensor_range: z.number({ message: "Must be a number" }).positive(),
-    beam_resistance: z.number({ message: "Must be a number" }).min(0).max(1),
-    physical_resistance: z.number({ message: "Must be a number" }).min(0).max(1),
-    melee_aptitude: z.number({ message: "Must be a number" }).positive(),
-    shooting_aptitude: z.number({ message: "Must be a number" }).positive(),
-    accuracy_bonus: z.number({ message: "Must be a number" }),
-    evasion_bonus: z.number({ message: "Must be a number" }),
-    acceleration_bonus: z.number({ message: "Must be a number" }).positive(),
-    turning_bonus: z.number({ message: "Must be a number" }).positive(),
-    weapons: z.array(weaponSchema).min(1, "At least one weapon is required"),
-  }),
-});
+export const masterMobileSuitSchema = z
+  .object({
+    id: z
+      .string()
+      .min(1, "ID is required")
+      .regex(/^[a-z0-9_]+$/, "ID must be lowercase alphanumeric with underscores (snake_case)"),
+    name: z.string().min(1, "Name is required"),
+    name_ja: z.string(),
+    model_number: z.string(),
+    price: z.number({ message: "Must be a number" }).int().nonnegative("Must be ≥ 0"),
+    faction: z.string(),
+    description: z.string(),
+    weapon_slot_count: z.number({ message: "Must be a number" }).int().min(1, "Must be ≥ 1"),
+    beam_generator_lv: z.number({ message: "Must be a number" }).int().nonnegative("Must be ≥ 0"),
+    specs: z.object({
+      max_hp: z.number({ message: "Must be a number" }).int().positive("Must be > 0"),
+      armor: z.number({ message: "Must be a number" }).int().nonnegative(),
+      mobility: z.number({ message: "Must be a number" }).positive("Must be > 0"),
+      sensor_range: z.number({ message: "Must be a number" }).positive(),
+      beam_resistance: z.number({ message: "Must be a number" }).min(0).max(1),
+      physical_resistance: z.number({ message: "Must be a number" }).min(0).max(1),
+      melee_aptitude: z.number({ message: "Must be a number" }).positive(),
+      shooting_aptitude: z.number({ message: "Must be a number" }).positive(),
+      accuracy_bonus: z.number({ message: "Must be a number" }),
+      evasion_bonus: z.number({ message: "Must be a number" }),
+      acceleration_bonus: z.number({ message: "Must be a number" }).positive(),
+      turning_bonus: z.number({ message: "Must be a number" }).positive(),
+      weapons: z.array(weaponSchema).min(1, "At least one weapon is required"),
+    }),
+  })
+  .superRefine((data, ctx) => {
+    if (data.specs.weapons.length > data.weapon_slot_count) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `Number of weapons (${data.specs.weapons.length}) exceeds weapon slot count (${data.weapon_slot_count})`,
+        path: ["weapon_slot_count"],
+      });
+    }
+    data.specs.weapons.forEach((w, index) => {
+      const requiredLv = w.required_beam_generator_lv ?? 0;
+      if (w.type === "BEAM" && requiredLv > data.beam_generator_lv) {
+        ctx.addIssue({
+          code: z.ZodIssueCode.custom,
+          message: `Requires beam generator Lv ${requiredLv}, but mobile suit's Lv is ${data.beam_generator_lv}`,
+          path: ["specs", "weapons", index, "required_beam_generator_lv"],
+        });
+      }
+    });
+  });
 
 export type MobileSuitFormValues = z.infer<typeof masterMobileSuitSchema>;
 
@@ -80,14 +105,19 @@ const defaultWeapon: MobileSuitFormValues["specs"]["weapons"][0] = {
   is_melee: false,
   en_cost: 0,
   cool_down_turn: 0,
+  required_beam_generator_lv: 0,
 };
 
 const defaultValues: MobileSuitFormValues = {
   id: "",
   name: "",
+  name_ja: "",
+  model_number: "",
   price: 500,
   faction: "",
   description: "",
+  weapon_slot_count: 1,
+  beam_generator_lv: 0,
   specs: {
     max_hp: 800,
     armor: 50,
@@ -109,9 +139,13 @@ function toFormValues(ms: MasterMobileSuit): MobileSuitFormValues {
   return {
     id: ms.id,
     name: ms.name,
+    name_ja: ms.name_ja ?? "",
+    model_number: ms.model_number ?? "",
     price: ms.price,
     faction: ms.faction ?? "",
     description: ms.description,
+    weapon_slot_count: ms.weapon_slot_count ?? 1,
+    beam_generator_lv: ms.beam_generator_lv ?? 0,
     specs: {
       max_hp: ms.specs.max_hp,
       armor: ms.specs.armor,
@@ -138,6 +172,7 @@ function toFormValues(ms: MasterMobileSuit): MobileSuitFormValues {
         max_ammo: w.max_ammo ?? null,
         en_cost: w.en_cost ?? 0,
         cool_down_turn: w.cool_down_turn ?? 0,
+        required_beam_generator_lv: w.required_beam_generator_lv ?? 0,
       })),
     },
   };
@@ -211,12 +246,40 @@ export default function MobileSuitEditForm({
             <FieldError msg={errors.name?.message} />
           </div>
           <div>
+            <Label>日本語名</Label>
+            <Input {...register("name_ja")} placeholder="ガンダム" />
+            <FieldError msg={errors.name_ja?.message} />
+          </div>
+          <div>
+            <Label>型番</Label>
+            <Input {...register("model_number")} placeholder="RGM-79" />
+            <FieldError msg={errors.model_number?.message} />
+          </div>
+          <div>
             <Label>価格 (C)</Label>
             <Input
               type="number"
               {...register("price", { valueAsNumber: true })}
             />
             <FieldError msg={errors.price?.message} />
+          </div>
+          <div>
+            <Label>武器スロット数</Label>
+            <Input
+              type="number"
+              min={1}
+              {...register("weapon_slot_count", { valueAsNumber: true })}
+            />
+            <FieldError msg={errors.weapon_slot_count?.message} />
+          </div>
+          <div>
+            <Label>ビームジェネレータLv</Label>
+            <Input
+              type="number"
+              min={0}
+              {...register("beam_generator_lv", { valueAsNumber: true })}
+            />
+            <FieldError msg={errors.beam_generator_lv?.message} />
           </div>
           <div>
             <Label>勢力</Label>
@@ -380,6 +443,15 @@ export default function MobileSuitEditForm({
                 <div>
                   <Label>減衰係数</Label>
                   <Input type="number" step="0.01" {...register(`specs.weapons.${index}.decay_rate`, { valueAsNumber: true })} />
+                </div>
+                <div>
+                  <Label>要求ビームジェネレータLv</Label>
+                  <Input
+                    type="number"
+                    min={0}
+                    {...register(`specs.weapons.${index}.required_beam_generator_lv`, { valueAsNumber: true })}
+                  />
+                  <FieldError msg={errors.specs?.weapons?.[index]?.required_beam_generator_lv?.message} />
                 </div>
                 <div className="flex items-center gap-2 mt-3">
                   <Controller

--- a/admin-tool/src/components/admin/MobileSuitTable.tsx
+++ b/admin-tool/src/components/admin/MobileSuitTable.tsx
@@ -11,7 +11,7 @@ interface MobileSuitTableProps {
   onDelete: (ms: MasterMobileSuit) => void;
 }
 
-type SortKey = "id" | "name" | "faction" | "price" | "max_hp" | "armor" | "mobility";
+type SortKey = "id" | "model_number" | "name" | "faction" | "price" | "max_hp" | "armor" | "mobility";
 type SortDir = "asc" | "desc";
 
 export default function MobileSuitTable({
@@ -36,6 +36,8 @@ export default function MobileSuitTable({
   const filtered = mobileSuits.filter(
     (ms) =>
       ms.name.toLowerCase().includes(filter.toLowerCase()) ||
+      ms.name_ja?.toLowerCase().includes(filter.toLowerCase()) ||
+      ms.model_number?.toLowerCase().includes(filter.toLowerCase()) ||
       ms.id.toLowerCase().includes(filter.toLowerCase()) ||
       ms.faction.toLowerCase().includes(filter.toLowerCase())
   );
@@ -86,6 +88,9 @@ export default function MobileSuitTable({
               <th className={thClass} onClick={() => handleSort("id")}>
                 ID <SortIcon k="id" />
               </th>
+              <th className={thClass} onClick={() => handleSort("model_number")}>
+                型番 <SortIcon k="model_number" />
+              </th>
               <th className={thClass} onClick={() => handleSort("name")}>
                 名前 <SortIcon k="name" />
               </th>
@@ -121,6 +126,7 @@ export default function MobileSuitTable({
                   }`}
                 >
                   <td className={`${tdClass} text-[#00ff41]/60`}>{ms.id}</td>
+                  <td className={`${tdClass} text-[#00ff41]/60`}>{ms.model_number || "—"}</td>
                   <td className={`${tdClass} font-bold ${isSelected ? "text-[#ffb000]" : ""}`}>
                     {ms.name}
                   </td>
@@ -154,7 +160,7 @@ export default function MobileSuitTable({
             })}
             {sorted.length === 0 && (
               <tr>
-                <td colSpan={8} className="text-center text-[#00ff41]/40 py-8 text-sm">
+                <td colSpan={9} className="text-center text-[#00ff41]/40 py-8 text-sm">
                   機体データが見つかりません
                 </td>
               </tr>

--- a/admin-tool/src/types/admin.ts
+++ b/admin-tool/src/types/admin.ts
@@ -21,9 +21,17 @@ export interface MasterMobileSuitSpec {
 export interface MasterMobileSuit {
     id: string;
     name: string;
+    /** 日本語表示名 */
+    name_ja: string;
+    /** 型番 (例: RGM-79) */
+    model_number: string;
     price: number;
     faction: string;
     description: string;
+    /** 武器スロット数 (1以上) */
+    weapon_slot_count: number;
+    /** ビームジェネレータLv (0以上) */
+    beam_generator_lv: number;
     specs: MasterMobileSuitSpec;
 }
 
@@ -33,9 +41,13 @@ export type MasterMobileSuitCreate = MasterMobileSuit;
 /** マスター機体の部分更新リクエスト */
 export interface MasterMobileSuitUpdate {
     name?: string;
+    name_ja?: string;
+    model_number?: string;
     price?: number;
     faction?: string;
     description?: string;
+    weapon_slot_count?: number;
+    beam_generator_lv?: number;
     specs?: MasterMobileSuitSpec;
 }
 

--- a/admin-tool/src/types/weapon.ts
+++ b/admin-tool/src/types/weapon.ts
@@ -13,6 +13,8 @@ export interface Weapon {
     en_cost?: number;
     cool_down_turn?: number;
     is_melee?: boolean;
+    /** 装備に必要なビームジェネレータLv (BEAM属性武器のみ有効) */
+    required_beam_generator_lv?: number;
     /** 威力ランク (S〜E) - APIから付与される */
     power_rank?: string;
     /** 射程ランク (S〜E) - APIから付与される */

--- a/admin-tool/tests/unit/mobileSuitEditFormValidation.test.ts
+++ b/admin-tool/tests/unit/mobileSuitEditFormValidation.test.ts
@@ -23,9 +23,13 @@ const validWeapon = {
 const validMobileSuit = {
   id: "rx_78_2",
   name: "RX-78-2 Gundam",
+  name_ja: "ガンダム",
+  model_number: "RX-78-2",
   price: 1500,
   faction: "FEDERATION",
   description: "宇宙世紀を代表するモビルスーツ。",
+  weapon_slot_count: 2,
+  beam_generator_lv: 1,
   specs: {
     max_hp: 1000,
     armor: 80,
@@ -224,6 +228,66 @@ describe("masterMobileSuitSchema", () => {
     const result = masterMobileSuitSchema.safeParse({
       ...validMobileSuit,
       specs: { ...validMobileSuit.specs, accuracy_bonus: -5.0 },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("weapon_slot_count が 0 以下の場合はエラー", () => {
+    const result = masterMobileSuitSchema.safeParse({ ...validMobileSuit, weapon_slot_count: 0 });
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.some((i) => i.path.includes("weapon_slot_count"))).toBe(true);
+  });
+
+  it("beam_generator_lv が負の値の場合はエラー", () => {
+    const result = masterMobileSuitSchema.safeParse({ ...validMobileSuit, beam_generator_lv: -1 });
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.some((i) => i.path.includes("beam_generator_lv"))).toBe(true);
+  });
+
+  it("beam_generator_lv が 0 は許可される", () => {
+    const result = masterMobileSuitSchema.safeParse({ ...validMobileSuit, beam_generator_lv: 0 });
+    expect(result.success).toBe(true);
+  });
+
+  it("武器数が weapon_slot_count を超える場合はエラー", () => {
+    const result = masterMobileSuitSchema.safeParse({
+      ...validMobileSuit,
+      weapon_slot_count: 1,
+      specs: {
+        ...validMobileSuit.specs,
+        weapons: [
+          validWeapon,
+          { ...validWeapon, id: "beam_saber", name: "Beam Saber", type: "PHYSICAL", is_melee: true },
+        ],
+      },
+    });
+    expect(result.success).toBe(false);
+    expect(result.error?.issues.some((i) => i.path.includes("weapon_slot_count"))).toBe(true);
+  });
+
+  it("BEAM武器の要求Lvがbeam_generator_lvを超える場合はエラー", () => {
+    const result = masterMobileSuitSchema.safeParse({
+      ...validMobileSuit,
+      beam_generator_lv: 0,
+      specs: {
+        ...validMobileSuit.specs,
+        weapons: [{ ...validWeapon, required_beam_generator_lv: 2 }],
+      },
+    });
+    expect(result.success).toBe(false);
+    expect(
+      result.error?.issues.some((i) => i.path.includes("required_beam_generator_lv"))
+    ).toBe(true);
+  });
+
+  it("PHYSICAL武器はrequired_beam_generator_lvがbeam_generator_lvを超えても許可される", () => {
+    const result = masterMobileSuitSchema.safeParse({
+      ...validMobileSuit,
+      beam_generator_lv: 0,
+      specs: {
+        ...validMobileSuit.specs,
+        weapons: [{ ...validWeapon, type: "PHYSICAL", required_beam_generator_lv: 5 }],
+      },
     });
     expect(result.success).toBe(true);
   });

--- a/backend/alembic/versions/u4v5w6x7y8z9_add_model_number_name_ja_slots_beam_lv.py
+++ b/backend/alembic/versions/u4v5w6x7y8z9_add_model_number_name_ja_slots_beam_lv.py
@@ -1,0 +1,78 @@
+"""add_model_number_name_ja_slots_beam_lv.
+
+Revision ID: u4v5w6x7y8z9
+Revises: t3u4v5w6x7y8
+Create Date: 2026-07-19
+
+Note:
+    MasterMobileSuit に以下のカラムを追加する (issue #383)。
+    - model_number: 型番 (例: RGM-79)
+    - name_ja: 日本語表示名
+    - weapon_slot_count: 武器スロット数 (1以上)。既存機体は specs.weapons の件数で初期化
+    - beam_generator_lv: ビームジェネレータLv (0以上、デフォルト0)
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "u4v5w6x7y8z9"
+down_revision: str | None = "t3u4v5w6x7y8"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add model_number/name_ja/weapon_slot_count/beam_generator_lv columns."""
+    op.add_column(
+        "master_mobile_suits",
+        sa.Column("name_ja", sa.String(), nullable=False, server_default=""),
+    )
+    op.add_column(
+        "master_mobile_suits",
+        sa.Column("model_number", sa.String(), nullable=False, server_default=""),
+    )
+    op.add_column(
+        "master_mobile_suits",
+        sa.Column(
+            "weapon_slot_count", sa.Integer(), nullable=False, server_default="1"
+        ),
+    )
+    op.add_column(
+        "master_mobile_suits",
+        sa.Column(
+            "beam_generator_lv", sa.Integer(), nullable=False, server_default="0"
+        ),
+    )
+
+    # 既存機体の weapon_slot_count を specs.weapons の件数で初期化する
+    bind = op.get_bind()
+    master_mobile_suits = sa.table(
+        "master_mobile_suits",
+        sa.column("id", sa.String),
+        sa.column("specs", sa.JSON),
+        sa.column("weapon_slot_count", sa.Integer),
+    )
+    rows = bind.execute(
+        sa.select(master_mobile_suits.c.id, master_mobile_suits.c.specs)
+    ).fetchall()
+    for row in rows:
+        specs = row.specs or {}
+        weapons = specs.get("weapons", []) if isinstance(specs, dict) else []
+        slot_count = max(1, len(weapons))
+        bind.execute(
+            master_mobile_suits.update()
+            .where(master_mobile_suits.c.id == row.id)
+            .values(weapon_slot_count=slot_count)
+        )
+
+
+def downgrade() -> None:
+    """Remove model_number/name_ja/weapon_slot_count/beam_generator_lv columns."""
+    op.drop_column("master_mobile_suits", "beam_generator_lv")
+    op.drop_column("master_mobile_suits", "weapon_slot_count")
+    op.drop_column("master_mobile_suits", "model_number")
+    op.drop_column("master_mobile_suits", "name_ja")

--- a/backend/app/core/gamedata.py
+++ b/backend/app/core/gamedata.py
@@ -249,9 +249,13 @@ def get_master_mobile_suits(session: Session) -> list[dict]:
         {
             "id": r.id,
             "name": r.name,
+            "name_ja": r.name_ja,
+            "model_number": r.model_number,
             "price": r.price,
             "faction": r.faction,
             "description": r.description,
+            "weapon_slot_count": r.weapon_slot_count,
+            "beam_generator_lv": r.beam_generator_lv,
             "specs": r.specs,
         }
         for r in records
@@ -290,9 +294,13 @@ def save_master_mobile_suits(session: Session, data: list[dict]) -> None:
         if item_id in existing:
             record = existing[item_id]
             record.name = item["name"]
+            record.name_ja = item.get("name_ja", "")
+            record.model_number = item.get("model_number", "")
             record.price = item["price"]
             record.faction = item.get("faction", "")
             record.description = item["description"]
+            record.weapon_slot_count = item.get("weapon_slot_count", 1)
+            record.beam_generator_lv = item.get("beam_generator_lv", 0)
             record.specs = specs
             record.updated_at = datetime.now(UTC)
             session.add(record)
@@ -300,9 +308,13 @@ def save_master_mobile_suits(session: Session, data: list[dict]) -> None:
             record = MasterMobileSuit(
                 id=item_id,
                 name=item["name"],
+                name_ja=item.get("name_ja", ""),
+                model_number=item.get("model_number", ""),
                 price=item["price"],
                 faction=item.get("faction", ""),
                 description=item["description"],
+                weapon_slot_count=item.get("weapon_slot_count", 1),
+                beam_generator_lv=item.get("beam_generator_lv", 0),
                 specs=specs,
             )
             session.add(record)

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -43,6 +43,10 @@ class Weapon(SQLModel):
     optimal_range: float = Field(default=300.0, description="最適射程距離")
     decay_rate: float = Field(default=0.05, description="距離による命中率減衰係数")
     is_melee: bool = Field(default=False, description="近接武器かどうか")
+    required_beam_generator_lv: int = Field(
+        default=0,
+        description="装備に必要なビームジェネレータLv (BEAM属性武器のみ有効。機体のビームジェネレータLv以下でのみ装備可能)",
+    )
     max_ammo: int | None = Field(
         default=None, description="最大弾数 (Noneまたは0の場合は無限/EN兵器)"
     )
@@ -364,9 +368,13 @@ class MasterMobileSuitEntry(SQLModel):
 
     id: str
     name: str
+    name_ja: str = ""
+    model_number: str = ""
     price: int
     faction: str = ""
     description: str
+    weapon_slot_count: int = 1
+    beam_generator_lv: int = 0
     specs: MasterMobileSuitSpec
 
 
@@ -375,9 +383,13 @@ class MasterMobileSuitCreate(SQLModel):
 
     id: str
     name: str
+    name_ja: str = ""
+    model_number: str = ""
     price: int
     faction: str = ""
     description: str
+    weapon_slot_count: int = Field(default=1, ge=1)
+    beam_generator_lv: int = Field(default=0, ge=0)
     specs: MasterMobileSuitSpec
 
 
@@ -385,9 +397,13 @@ class MasterMobileSuitUpdate(SQLModel):
     """マスター機体更新リクエスト."""
 
     name: str | None = None
+    name_ja: str | None = None
+    model_number: str | None = None
     price: int | None = None
     faction: str | None = None
     description: str | None = None
+    weapon_slot_count: int | None = Field(default=None, ge=1)
+    beam_generator_lv: int | None = Field(default=None, ge=0)
     specs: MasterMobileSuitSpec | None = None
 
 
@@ -492,9 +508,15 @@ class MasterMobileSuit(SQLModel, table=True):
 
     id: str = Field(primary_key=True, description="スネークケースID (例: rx_78_2)")
     name: str = Field(description="機体名")
+    name_ja: str = Field(default="", description="日本語表示名")
+    model_number: str = Field(default="", description="型番 (例: RGM-79)")
     price: int = Field(description="購入価格")
     faction: str = Field(default="", description="勢力 (FEDERATION/ZEON/空文字=共通)")
     description: str = Field(description="機体説明文")
+    weapon_slot_count: int = Field(default=1, description="武器スロット数 (1以上)")
+    beam_generator_lv: int = Field(
+        default=0, description="ビームジェネレータLv (0以上)"
+    )
     specs: dict = Field(
         sa_column=Column(JSON),
         description="機体スペック (MasterMobileSuitSpec の全フィールド)",

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -68,9 +68,13 @@ def _raw_to_entry(raw: dict) -> MasterMobileSuitEntry:
     return MasterMobileSuitEntry(
         id=raw["id"],
         name=raw["name"],
+        name_ja=raw.get("name_ja", ""),
+        model_number=raw.get("model_number", ""),
         price=raw["price"],
         faction=raw.get("faction", ""),
         description=raw["description"],
+        weapon_slot_count=raw.get("weapon_slot_count", 1),
+        beam_generator_lv=raw.get("beam_generator_lv", 0),
         specs=specs,
     )
 

--- a/backend/app/services/mobile_suit_service.py
+++ b/backend/app/services/mobile_suit_service.py
@@ -86,6 +86,10 @@ class MobileSuitService:
         if not data.specs.weapons:
             raise ValueError("specs.weapons must have at least one weapon.")
 
+        MobileSuitService._validate_weapon_constraints(
+            data.specs.weapons, data.weapon_slot_count, data.beam_generator_lv
+        )
+
         # 重複チェック
         existing = session.get(MasterMobileSuit, data.id)
         if existing is not None:
@@ -99,9 +103,13 @@ class MobileSuitService:
         record = MasterMobileSuit(
             id=data.id,
             name=data.name,
+            name_ja=data.name_ja,
+            model_number=data.model_number,
             price=data.price,
             faction=data.faction,
             description=data.description,
+            weapon_slot_count=data.weapon_slot_count,
+            beam_generator_lv=data.beam_generator_lv,
             specs=specs_dict,
         )
         session.add(record)
@@ -114,11 +122,50 @@ class MobileSuitService:
         return {
             "id": data.id,
             "name": data.name,
+            "name_ja": data.name_ja,
+            "model_number": data.model_number,
             "price": data.price,
             "faction": data.faction,
             "description": data.description,
+            "weapon_slot_count": data.weapon_slot_count,
+            "beam_generator_lv": data.beam_generator_lv,
             "specs": specs_dict,
         }
+
+    @staticmethod
+    def _validate_weapon_constraints(
+        weapons: list, weapon_slot_count: int, beam_generator_lv: int
+    ) -> None:
+        """武器スロット数・ビームジェネレータLvの制約を検証する.
+
+        Args:
+            weapons: 検証対象の武器リスト (Weapon または dict)
+            weapon_slot_count: 装備可能な武器スロット数
+            beam_generator_lv: 機体のビームジェネレータLv
+
+        Raises:
+            ValueError: 武器数がスロット数を超える、または要求ビームLvが
+                機体のビームジェネレータLvを超えるビーム属性武器が含まれる場合
+        """
+        if len(weapons) > weapon_slot_count:
+            raise ValueError(
+                f"Number of weapons ({len(weapons)}) exceeds weapon_slot_count "
+                f"({weapon_slot_count})."
+            )
+        for w in weapons:
+            w_type = w.type if hasattr(w, "type") else w.get("type", "PHYSICAL")
+            required_lv = (
+                w.required_beam_generator_lv
+                if hasattr(w, "required_beam_generator_lv")
+                else w.get("required_beam_generator_lv", 0)
+            )
+            if w_type == "BEAM" and required_lv > beam_generator_lv:
+                w_name = w.name if hasattr(w, "name") else w.get("name", "?")
+                raise ValueError(
+                    f"Weapon '{w_name}' requires beam_generator_lv "
+                    f"{required_lv}, but the mobile suit's beam_generator_lv "
+                    f"is {beam_generator_lv}."
+                )
 
     @staticmethod
     def update_master_mobile_suit(
@@ -163,6 +210,16 @@ class MobileSuitService:
             record.specs = existing_specs
             update_dict.pop("specs")
 
+        weapon_slot_count = update_dict.get(
+            "weapon_slot_count", record.weapon_slot_count
+        )
+        beam_generator_lv = update_dict.get(
+            "beam_generator_lv", record.beam_generator_lv
+        )
+        MobileSuitService._validate_weapon_constraints(
+            record.specs.get("weapons", []), weapon_slot_count, beam_generator_lv
+        )
+
         for key, value in update_dict.items():
             setattr(record, key, value)
 
@@ -177,9 +234,13 @@ class MobileSuitService:
         return {
             "id": record.id,
             "name": record.name,
+            "name_ja": record.name_ja,
+            "model_number": record.model_number,
             "price": record.price,
             "faction": record.faction,
             "description": record.description,
+            "weapon_slot_count": record.weapon_slot_count,
+            "beam_generator_lv": record.beam_generator_lv,
             "specs": record.specs,
         }
 

--- a/backend/tests/unit/test_admin_mobile_suits.py
+++ b/backend/tests/unit/test_admin_mobile_suits.py
@@ -298,3 +298,133 @@ def test_delete_persists_to_db(client_admin, session):
         select(MasterMobileSuit).where(MasterMobileSuit.id == "test_gm")
     ).first()
     assert record is None
+
+
+# ===================== 型番/日本語名/武器スロット数/ビームジェネレータLv =====================
+
+
+def test_create_with_new_fields(client_admin):
+    """POST で model_number/name_ja/weapon_slot_count/beam_generator_lv を保存できること."""
+    payload = {
+        **SAMPLE_MS,
+        "name_ja": "ジム",
+        "model_number": "RGM-79",
+        "weapon_slot_count": 2,
+        "beam_generator_lv": 1,
+    }
+    response = client_admin.post(
+        "/api/admin/mobile-suits", json=payload, headers=HEADERS
+    )
+    assert response.status_code == status.HTTP_201_CREATED
+    data = response.json()
+    assert data["name_ja"] == "ジム"
+    assert data["model_number"] == "RGM-79"
+    assert data["weapon_slot_count"] == 2
+    assert data["beam_generator_lv"] == 1
+
+
+def test_create_defaults_for_new_fields(client_admin):
+    """新フィールドを指定しない場合、既定値 (name_ja='', model_number='', weapon_slot_count=1, beam_generator_lv=0) が使われること."""
+    response = client_admin.post(
+        "/api/admin/mobile-suits", json=SAMPLE_MS, headers=HEADERS
+    )
+    assert response.status_code == status.HTTP_201_CREATED
+    data = response.json()
+    assert data["name_ja"] == ""
+    assert data["model_number"] == ""
+    assert data["weapon_slot_count"] == 1
+    assert data["beam_generator_lv"] == 0
+
+
+def test_create_weapon_count_exceeds_slot_returns_422(client_admin):
+    """武器数が weapon_slot_count を超える場合は 422 が返ること."""
+    payload = json.loads(json.dumps(SAMPLE_MS))
+    payload["id"] = "too_many_weapons_ms"
+    payload["weapon_slot_count"] = 1
+    payload["specs"]["weapons"].append(
+        {
+            "id": "test_beam_saber",
+            "name": "Test Beam Saber",
+            "power": 200,
+            "range": 50,
+            "accuracy": 90,
+            "type": "PHYSICAL",
+            "optimal_range": 30.0,
+            "decay_rate": 0.0,
+            "is_melee": True,
+        }
+    )
+    response = client_admin.post(
+        "/api/admin/mobile-suits", json=payload, headers=HEADERS
+    )
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+def test_create_beam_weapon_exceeds_generator_lv_returns_422(client_admin):
+    """BEAM武器の要求Lvが beam_generator_lv を超える場合は 422 が返ること."""
+    payload = json.loads(json.dumps(SAMPLE_MS))
+    payload["id"] = "beam_lv_over_ms"
+    payload["beam_generator_lv"] = 0
+    payload["specs"]["weapons"][0]["required_beam_generator_lv"] = 2
+    response = client_admin.post(
+        "/api/admin/mobile-suits", json=payload, headers=HEADERS
+    )
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+def test_create_beam_weapon_within_generator_lv_succeeds(client_admin):
+    """BEAM武器の要求Lvが beam_generator_lv 以下の場合は成功すること."""
+    payload = json.loads(json.dumps(SAMPLE_MS))
+    payload["id"] = "beam_lv_ok_ms"
+    payload["beam_generator_lv"] = 2
+    payload["specs"]["weapons"][0]["required_beam_generator_lv"] = 2
+    response = client_admin.post(
+        "/api/admin/mobile-suits", json=payload, headers=HEADERS
+    )
+    assert response.status_code == status.HTTP_201_CREATED
+
+
+def test_update_weapon_slot_count_below_current_weapon_count_returns_422(
+    client_admin,
+):
+    """既存の武器数を下回る weapon_slot_count への更新は 422 が返ること."""
+    payload = json.loads(json.dumps(SAMPLE_MS))
+    payload["weapon_slot_count"] = 2
+    payload["specs"]["weapons"].append(
+        {
+            "id": "test_beam_saber",
+            "name": "Test Beam Saber",
+            "power": 200,
+            "range": 50,
+            "accuracy": 90,
+            "type": "PHYSICAL",
+            "optimal_range": 30.0,
+            "decay_rate": 0.0,
+            "is_melee": True,
+        }
+    )
+    client_admin.post("/api/admin/mobile-suits", json=payload, headers=HEADERS)
+
+    response = client_admin.put(
+        "/api/admin/mobile-suits/test_gm",
+        json={"weapon_slot_count": 1},
+        headers=HEADERS,
+    )
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
+
+
+def test_update_beam_generator_lv_below_existing_weapon_requirement_returns_422(
+    client_admin,
+):
+    """既存のBEAM武器の要求Lvを上回れないbeam_generator_lvへの更新は 422 が返ること."""
+    payload = json.loads(json.dumps(SAMPLE_MS))
+    payload["beam_generator_lv"] = 3
+    payload["specs"]["weapons"][0]["required_beam_generator_lv"] = 3
+    client_admin.post("/api/admin/mobile-suits", json=payload, headers=HEADERS)
+
+    response = client_admin.put(
+        "/api/admin/mobile-suits/test_gm",
+        json={"beam_generator_lv": 1},
+        headers=HEADERS,
+    )
+    assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY

--- a/docs/features/admin-mobile-suits.md
+++ b/docs/features/admin-mobile-suits.md
@@ -5,6 +5,11 @@
 マスター機体データを Web UI 上で直接編集・追加・削除できる管理者専用画面。
 データは `master_mobile_suits` PostgreSQL テーブルに永続化されるため、デプロイ後も変更が失われない。
 
+> [!NOTE]
+> Issue #383 で `name_ja`（日本語表示名）を追加したが、ゲーム側フロントエンド（`frontend/`）に
+> 言語切替UI・国際化（i18n）フレームワークは未導入のため、現状は管理画面での編集・保存までがスコープ。
+> 言語選択に応じた表示切替は別途対応が必要。
+
 ---
 
 ## Backend API
@@ -47,6 +52,8 @@ X-API-Key: <ADMIN_API_KEY>
 
 - 機体 `id`: スネークケース英数字のみ（例: `rx_78_2`）。正規表現 `^[a-z0-9_]+$`
 - `specs.weapons`: 最低1件必須
+- `weapon_slot_count`: 1以上の整数。`specs.weapons` の件数が `weapon_slot_count` を超える場合は `422`（Issue #383）
+- `beam_generator_lv`: 0以上の整数。`specs.weapons` 内に `type == "BEAM"` かつ `required_beam_generator_lv` が `beam_generator_lv` を超える武器が含まれる場合は `422`（Issue #383）
 - DELETE 時: 同名機体がプレイヤー所有の mobile_suits テーブルに存在する場合は `409`
 
 ### リクエスト例
@@ -61,9 +68,13 @@ Content-Type: application/json
 {
   "id": "rx_78_2",
   "name": "RX-78-2 Gundam",
+  "name_ja": "ガンダム",
+  "model_number": "RX-78-2",
   "price": 1500,
   "faction": "FEDERATION",
   "description": "宇宙世紀を代表する機体。",
+  "weapon_slot_count": 2,
+  "beam_generator_lv": 1,
   "specs": {
     "max_hp": 1000,
     "armor": 80,
@@ -87,12 +98,16 @@ Content-Type: application/json
         "type": "BEAM",
         "optimal_range": 320,
         "decay_rate": 0.09,
-        "is_melee": false
+        "is_melee": false,
+        "required_beam_generator_lv": 1
       }
     ]
   }
 }
 ```
+
+> `name_ja` / `model_number` / `weapon_slot_count` / `beam_generator_lv` を省略した場合、それぞれ既定値
+> (`""` / `""` / `1` / `0`) が使われる（Issue #383）。
 
 #### PUT — 既存機体の部分更新
 
@@ -193,16 +208,22 @@ Content-Type: application/json
 
 ```sql
 CREATE TABLE master_mobile_suits (
-    id          TEXT PRIMARY KEY,       -- スネークケース (例: rx_78_2)
-    name        TEXT NOT NULL,
-    price       INTEGER NOT NULL,
-    faction     TEXT NOT NULL DEFAULT '',
-    description TEXT NOT NULL,
-    specs       JSONB NOT NULL,         -- MasterMobileSuitSpec の全フィールド
-    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
-    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+    id                 TEXT PRIMARY KEY,       -- スネークケース (例: rx_78_2)
+    name               TEXT NOT NULL,
+    name_ja            TEXT NOT NULL DEFAULT '',  -- 日本語表示名（Issue #383）
+    model_number       TEXT NOT NULL DEFAULT '',  -- 型番 例: RGM-79（Issue #383）
+    price              INTEGER NOT NULL,
+    faction            TEXT NOT NULL DEFAULT '',
+    description        TEXT NOT NULL,
+    weapon_slot_count  INTEGER NOT NULL DEFAULT 1,  -- 武器スロット数、1以上（Issue #383）
+    beam_generator_lv  INTEGER NOT NULL DEFAULT 0,  -- ビームジェネレータLv、0以上（Issue #383）
+    specs              JSONB NOT NULL,         -- MasterMobileSuitSpec の全フィールド
+    created_at         TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at         TIMESTAMPTZ NOT NULL DEFAULT now()
 );
 ```
+
+`Weapon`（`specs.weapons` 内の各要素）には `required_beam_generator_lv`（装備に必要なビームジェネレータLv、`type == "BEAM"` の武器のみ有効、既定値0）が追加されている（Issue #383）。
 
 ### マイグレーション
 
@@ -306,17 +327,18 @@ admin-tool/src/
 
 #### 機体一覧テーブル (`MobileSuitTable`)
 
-- 名前・勢力・価格・HP・装甲・機動性を表示
+- ID・型番・名前・勢力・価格・HP・装甲・機動性を表示（型番列は Issue #383 で追加）
 - 各列ヘッダークリックでソート（昇順/降順）
-- テキストフィルタ（name / id / faction で絞り込み）
+- テキストフィルタ（name / name_ja / model_number / id / faction で絞り込み、Issue #383 で name_ja / model_number を追加）
 - 編集中の機体は行がハイライト表示
 
 #### 詳細編集フォーム (`MobileSuitEditForm`)
 
 - `react-hook-form` + `zod` によるバリデーション
-- 全スペック・武装パラメータを編集可能
+- 全スペック・武装パラメータを編集可能（型番・日本語名・武器スロット数・ビームジェネレータLvを含む、Issue #383）
 - フィールド横にインラインエラーメッセージ表示
 - 武装リストの動的追加・削除
+- 武器数が武器スロット数を超える場合、およびBEAM武器の要求ビームジェネレータLvが機体のビームジェネレータLvを超える場合はクライアント側 (`zod.superRefine`) でもエラー表示（Issue #383）
 
 #### バランス比較チャート (`MobileSuitRadarChart`)
 
@@ -361,6 +383,9 @@ NEON_DATABASE_URL="sqlite:///test.db" ADMIN_API_KEY="test_key" python -m pytest 
 - PUT 更新（正常 / 404 / weapons 空 422）
 - DELETE 削除（正常 / 404 / 在庫参照 409）
 - DB 永続化確認
+- `name_ja` / `model_number` / `weapon_slot_count` / `beam_generator_lv` の保存・既定値（Issue #383）
+- 武器数が `weapon_slot_count` を超える場合の 422（新規追加・更新の両方）（Issue #383）
+- BEAM武器の `required_beam_generator_lv` が `beam_generator_lv` を超える場合の 422（Issue #383）
 
 ```bash
 cd backend
@@ -398,6 +423,7 @@ npx vitest run tests/unit/
 - `backend/data/master/mobile_suits.json` — シードデータ（Git 管理継続）
 - `backend/scripts/seed/seed_master_data.py` — シードスクリプト
 - `backend/alembic/versions/r1s2t3u4v5w6_add_master_mobile_suits_and_weapons_tables.py` — マイグレーション
+- `backend/alembic/versions/u4v5w6x7y8z9_add_model_number_name_ja_slots_beam_lv.py` — 型番/日本語名/武器スロット数/ビームジェネレータLv追加マイグレーション（Issue #383）
 - `admin-tool/src/app/mobile-suits/page.tsx` — 管理画面（独立アプリ、ポート3100）
 - `admin-tool/src/hooks/useAdminMobileSuits.ts` — CRUD フック
 - `backend/app/engine/combat_preview.py` — 1対1 攻撃シミュレーション計算ロジック（決定論値・モンテカルロ）（Issue #381）


### PR DESCRIPTION
## Summary
- マスタ機体テーブル (`master_mobile_suits`) に `model_number`(型番)、`name_ja`(日本語表示名)、`weapon_slot_count`(武器スロット数、1以上)、`beam_generator_lv`(ビームジェネレータLv、0以上)を追加
- 武器スロット数を超える武器登録、ビームジェネレータLvを超えるBEAM属性武器(`Weapon.required_beam_generator_lv`)の登録をサービス層でバリデーション(422)
- マスタ機体編集画面(admin-tool)で上記4項目を編集可能に。フォーム側もzodでクライアントバリデーション、一覧テーブルに型番列を追加
- `docs/features/admin-mobile-suits.md` を更新(スキーマ・バリデーションルール・UI変更・i18n未対応の注記)

## 補足
- 日本語名(`name_ja`)追加は管理画面での編集・保存までがスコープ。ゲーム側フロントエンドに国際化(i18n)フレームワーク・言語切替UIが未導入のため、表示切替は別Issue対応とする(ドキュメントに注記済み)
- 既存機体の `weapon_slot_count` はマイグレーションで `specs.weapons` の件数から自動初期化

Closes #383

## Test plan
- [x] `cd backend && .venv/bin/python -m pytest tests/unit/test_admin_mobile_suits.py --tb=short` (22 passed)
- [x] `cd backend && .venv/bin/python -m pytest tests/unit --tb=short`(新規追加テストは全件成功。既存の一部戦闘シミュレーション系テストは乱数依存のflakyな失敗がmainブランチでも再現することを確認済み。別Issueで起票)
- [x] `cd admin-tool && npx vitest run`(58 passed)
- [x] `cd admin-tool && npx tsc --noEmit`(新規追加コードに起因するエラーなし)
- [x] `cd backend && .venv/bin/ruff check` / pre-commit hook (ruff format / mypy) 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)