### PR TITLE
fix: マスター機体編集フォームでReact Compilerが非制御inputのDOM更新を阻害する不具合を修正

### DIFF
--- a/admin-tool/src/components/admin/MobileSuitEditForm.tsx
+++ b/admin-tool/src/components/admin/MobileSuitEditForm.tsx
@@ -206,6 +206,7 @@ export default function MobileSuitEditForm({
   onCancel,
   isSubmitting = false,
 }: MobileSuitEditFormProps) {
+  "use no memo";
   const {
     register,
     handleSubmit,

--- a/docs/features/admin-mobile-suits.md
+++ b/docs/features/admin-mobile-suits.md
@@ -340,6 +340,14 @@ admin-tool/src/
 - 武装リストの動的追加・削除
 - 武器数が武器スロット数を超える場合、およびBEAM武器の要求ビームジェネレータLvが機体のビームジェネレータLvを超える場合はクライアント側 (`zod.superRefine`) でもエラー表示（Issue #383）
 
+> [!NOTE]
+> `MobileSuitEditForm` は React Compiler（`next.config.ts` の `reactCompiler: true`）対象外の
+> `"use no memo"` ディレクティブ付きで実装している。React Compiler の自動メモ化が、
+> `react-hook-form` の `register()` でバインドした非制御 `<input>` に対する `reset()` のDOM反映を
+> 阻害し、機体選択切り替え時に「勢力」以外のフィールドが前の機体の値のまま更新されない不具合が
+> あったため（Issue #388）。同様に非制御inputを`register()`でバインドするフォームを新規実装する
+> 場合は同じ問題が起きうる点に注意すること。
+
 #### バランス比較チャート (`MobileSuitRadarChart`)
 
 - `recharts` の `RadarChart` を使用


### PR DESCRIPTION
## Summary
- admin-tool のマスター機体編集ページで、機体選択を切り替えても「勢力」以外のフィールド（ID・名前・価格・スペック・武装など）が前に選択していた機体の値を保持し続ける不具合を修正
- 原因: React Compiler（`reactCompiler: true`）の自動メモ化が、`react-hook-form` の `register()` でバインドした非制御 `<input>` に対する `reset()` のDOM反映を阻害していた（`Controller` で制御コンポーネント化されている「勢力」だけは正しく更新されていた）
- `MobileSuitEditForm` コンポーネントに `"use no memo"` ディレクティブを追加し、この1コンポーネントのみReact Compilerの最適化対象から除外することで解決（アプリ全体のコンパイラ設定は維持）
- `docs/features/admin-mobile-suits.md` に原因と注意点を追記

Closes #388

## Test plan
- [x] `npx tsc --noEmit` / `npx eslint` エラーなしを確認
- [x] バックエンド（uvicorn）+ admin-tool（`npm run dev`）をローカル起動し、Playwrightで実機検証
  - 修正前: 機体を切り替えても ID / 名前 / 価格などが前の機体の値のまま（再現確認）
  - 修正後: 機体を切り替えると全フィールドが正しく新しい機体の値に更新されることを確認