### PR TITLE
feat: バトルログに使用武器ID(weapon_id)とクリティカル判定フラグ(is_crit)を追加

### DIFF
--- a/backend/app/engine/combat.py
+++ b/backend/app/engine/combat.py
@@ -673,6 +673,8 @@ class CombatMixin:
                 message=f"{log_base}{hit_text}{damage_message}",
                 position_snapshot=snapshot,
                 weapon_name=weapon.name if weapon else None,
+                weapon_id=weapon.id if weapon else None,
+                is_crit=is_crit,
                 chatter=attack_chatter or hit_chatter,
                 skill_activated=True if skill_activated else None,
                 heading=self.unit_resources[str(actor.id)].get("body_heading_deg"),  # type: ignore[attr-defined]

--- a/backend/app/engine/combat.py
+++ b/backend/app/engine/combat.py
@@ -580,7 +580,7 @@ class CombatMixin:
         attack_sector: str = "FRONT_SIDE",
     ) -> None:
         """命中時の処理."""
-        base_damage, log_msg = self._calculate_hit_base_damage(
+        base_damage, _log_msg, is_crit = self._calculate_hit_base_damage(
             actor, target, weapon, log_base, attack_sector=attack_sector
         )
         base_damage, resistance_msg = self._apply_hit_damage_modifiers(
@@ -633,7 +633,6 @@ class CombatMixin:
         hit_chatter = self._generate_chatter(target, "hit")  # type: ignore[attr-defined]
 
         # 命中状況テキスト
-        is_crit = "クリティカルヒット" in log_msg
         if is_crit:
             hit_text = " -> ★★ クリティカルヒット！！"
         elif is_optimal_distance:
@@ -777,8 +776,8 @@ class CombatMixin:
         weapon: Weapon,
         log_base: str,
         attack_sector: str = "FRONT_SIDE",
-    ) -> tuple[int, str]:
-        """命中時の基礎ダメージとログメッセージを算出する."""
+    ) -> tuple[int, str, bool]:
+        """命中時の基礎ダメージとログメッセージ、クリティカル判定を算出する."""
         base_crit_rate = 0.05
 
         if actor.side == "PLAYER":
@@ -819,9 +818,9 @@ class CombatMixin:
             base_damage = max(
                 1, int(base_damage * SECTOR_DAMAGE_MODIFIERS[attack_sector])
             )
-            return base_damage, f"{log_base} -> 命中！"
+            return base_damage, f"{log_base} -> 命中！", False
         # クリティカルヒット: 防御軽減率・セクタ補正を無視（現行仕様維持）
-        return int(weapon.power * 1.2), f"{log_base} -> クリティカルヒット！！"
+        return int(weapon.power * 1.2), f"{log_base} -> クリティカルヒット！！", True
 
     def _apply_hit_damage_modifiers(
         self,

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -661,6 +661,8 @@ class BattleLog(SQLModel):
     attack_sector: str | None = (
         None  # "FRONT" / "FRONT_SIDE" / "REAR_SIDE" / "REAR" (Phase E-3)
     )
+    weapon_id: str | None = None  # 使用した武器のID（フロントエンドの武器特定用）
+    is_crit: bool = False  # クリティカルヒット判定（構造化フラグ）
 
 
 class BattleLogRecord(SQLModel, table=True):

--- a/backend/tests/unit/test_phase_e1_sigmoid_damage.py
+++ b/backend/tests/unit/test_phase_e1_sigmoid_damage.py
@@ -308,7 +308,7 @@ class TestCalculateHitBaseDamageNewFormula:
 
         # 非クリティカルを強制
         with patch("app.engine.combat.random.random", return_value=1.0):
-            base_damage, msg = sim._calculate_hit_base_damage(
+            base_damage, msg, _ = sim._calculate_hit_base_damage(
                 player, enemy, weapon, log_base
             )
 
@@ -327,7 +327,9 @@ class TestCalculateHitBaseDamageNewFormula:
         weapon = _make_weapon(power=200)
 
         with patch("app.engine.combat.random.random", return_value=1.0):
-            base_damage, _ = sim._calculate_hit_base_damage(player, enemy, weapon, "")
+            base_damage, _, _ = sim._calculate_hit_base_damage(
+                player, enemy, weapon, ""
+            )
 
         # defense_reduction の上限は MAX_DEFENSE_REDUCTION = 0.50
         # よって damage >= weapon.power * (1 - 0.50) = 100 (attack_bonus により実際はさらに高い)
@@ -340,7 +342,9 @@ class TestCalculateHitBaseDamageNewFormula:
         weapon = _make_weapon(power=50)
 
         with patch("app.engine.combat.random.random", return_value=1.0):
-            base_damage, _ = sim._calculate_hit_base_damage(player, enemy, weapon, "")
+            base_damage, _, _ = sim._calculate_hit_base_damage(
+                player, enemy, weapon, ""
+            )
 
         # 新式は必ず > 1
         assert base_damage > 1
@@ -352,7 +356,9 @@ class TestCalculateHitBaseDamageNewFormula:
 
         # クリティカルを強制
         with patch("app.engine.combat.random.random", return_value=0.0):
-            base_damage, msg = sim._calculate_hit_base_damage(player, enemy, weapon, "")
+            base_damage, msg, _ = sim._calculate_hit_base_damage(
+                player, enemy, weapon, ""
+            )
 
         assert "クリティカル" in msg
         assert base_damage == int(100 * 1.2)
@@ -382,7 +388,9 @@ class TestCalculateHitBaseDamageNewFormula:
         # 非クリティカルでメレー武器を使用
         melee_w = _make_weapon(power=100, weapon_type="MELEE")
         with patch("app.engine.combat.random.random", return_value=1.0):
-            base_damage, _ = sim._calculate_hit_base_damage(player, enemy, melee_w, "")
+            base_damage, _, _ = sim._calculate_hit_base_damage(
+                player, enemy, melee_w, ""
+            )
 
         melee_bonus = resources["cached_melee_attack_bonus"]
         target_def = sim.unit_resources[str(enemy.id)]["cached_defense_reduction"]
@@ -395,7 +403,9 @@ class TestCalculateHitBaseDamageNewFormula:
         weapon = _make_weapon(power=1)
 
         with patch("app.engine.combat.random.random", return_value=1.0):
-            base_damage, _ = sim._calculate_hit_base_damage(player, enemy, weapon, "")
+            base_damage, _, _ = sim._calculate_hit_base_damage(
+                player, enemy, weapon, ""
+            )
 
         assert base_damage >= 1
 
@@ -411,8 +421,12 @@ class TestCalculateHitBaseDamageNewFormula:
         )
 
         with patch("app.engine.combat.random.random", return_value=1.0):
-            dmg_low, _ = sim_low._calculate_hit_base_damage(player, enemy, weapon, "")
-            dmg_high, _ = sim_high._calculate_hit_base_damage(player, enemy, weapon, "")
+            dmg_low, _, _ = sim_low._calculate_hit_base_damage(
+                player, enemy, weapon, ""
+            )
+            dmg_high, _, _ = sim_high._calculate_hit_base_damage(
+                player, enemy, weapon, ""
+            )
 
         assert dmg_high > dmg_low
 

--- a/docs/features/battle-viewer-feature.md
+++ b/docs/features/battle-viewer-feature.md
@@ -243,6 +243,16 @@ interface UnitSnapshot {
 }
 ```
 
+### 実際に使用した武器の特定（EN/弾薬消費計算）
+
+`getBattleSnapshot`（`useBattleSnapshot.ts`）は ATTACK ログの EN/弾薬消費を計算する際、
+`BattleLog.weapon_id` から `initialMs.weapons` 内の該当武器を検索して使用する。
+
+- `log.weapon_id` が存在する場合: 一致する武器を `initialMs.weapons` から検索
+- `log.weapon_id` が存在しない場合（旧バトルログとの後方互換）、または一致する武器が見つからない場合: 先頭武器（`initialMs.weapons[0]`）にフォールバック
+
+`BattleLog` には `is_crit`（クリティカルヒット判定）も含まれる（バックエンドの `combat.py` で判定済みのbool値をそのまま保持）。
+
 ---
 
 ## 関連ファイル一覧

--- a/frontend/src/components/BattleViewer/hooks/useBattleSnapshot.ts
+++ b/frontend/src/components/BattleViewer/hooks/useBattleSnapshot.ts
@@ -87,10 +87,12 @@ export function getBattleSnapshot(
             hp -= log.damage;
         }
         
-        // リソース消費の推測（簡易版）
-        // 注意: ログデータに武器情報が含まれていないため、最初の武器を使用したと仮定しています
+        // リソース消費: log.weapon_id から実際に使用した武器を特定する
+        // weapon_id が無い古いログについては後方互換のため先頭武器を使用したと仮定する
         if (log.action_type === "ATTACK" && log.actor_id === targetId) {
-            const weapon = initialMs.weapons[0]; // 簡略化: 最初の武器を使用と仮定
+            const weapon = log.weapon_id
+                ? initialMs.weapons.find(w => w.id === log.weapon_id) ?? initialMs.weapons[0]
+                : initialMs.weapons[0];
             if (weapon) {
                 if (weapon.en_cost) {
                     en = Math.max(0, en - weapon.en_cost);

--- a/frontend/src/types/battleCore.ts
+++ b/frontend/src/types/battleCore.ts
@@ -12,6 +12,10 @@ export interface BattleLog {
     position_snapshot: Vector3;
     chatter?: string;
     weapon_name?: string;
+    /** 使用した武器のID（フロントエンドでの武器特定用） */
+    weapon_id?: string;
+    /** クリティカルヒット判定 */
+    is_crit?: boolean;
     target_max_hp?: number;
     /** スキルが命中/回避の判定を変えた場合 true */
     skill_activated?: boolean;


### PR DESCRIPTION
## Summary
- `BattleLog` スキーマに `weapon_id: str | None` と `is_crit: bool` を追加(単一JSONカラム格納のためマイグレーション不要)
- `combat.py` のATTACKログ生成箇所で `weapon_id`(使用武器のID)と `is_crit`(既存の文字列マッチ判定結果)を渡すよう変更
- フロントエンド `BattleLog` 型に `weapon_id?`, `is_crit?` を追加
- `useBattleSnapshot.ts` の EN/弾薬消費計算を `log.weapon_id` ベースに変更。`weapon_id` が無い(または一致武器が見つからない)古いログは現行通り先頭武器にフォールバック
- `docs/features/battle-viewer-feature.md` に武器特定ロジックの説明を追記

## Test plan
- [x] `cd backend && python -m pytest tests/unit --tb=short` — 全件パス
- [x] `cd frontend && ./node_modules/.bin/tsc --noEmit` — エラーなし
- [x] `cd frontend && npx vitest run tests/unit/` — 全件パス

Closes #395

🤖 Generated with [Claude Code](https://claude.com/claude-code)