### PR TITLE
fix: master_weapons のid/name二重管理を解消しテーブルカラムを正とする

### DIFF
--- a/admin-tool/src/app/weapons/page.tsx
+++ b/admin-tool/src/app/weapons/page.tsx
@@ -92,7 +92,6 @@ export default function AdminWeaponsPage() {
     await createWeapon({
       ...cloneSource,
       id: newId,
-      weapon: { ...cloneSource.weapon, id: newId },
     });
     showToast(`${cloneSource.name} を ID "${newId}" でクローンしました`, "success");
     setCloneSource(null);

--- a/admin-tool/src/components/admin/WeaponEditForm.tsx
+++ b/admin-tool/src/components/admin/WeaponEditForm.tsx
@@ -89,8 +89,8 @@ function toFormValues(w: MasterWeapon): WeaponFormValues {
       is_melee: w.weapon.is_melee ?? false,
       max_ammo: w.weapon.max_ammo ?? null,
       en_cost: w.weapon.en_cost ?? 0,
-      cooldown_sec: (w.weapon as { cooldown_sec?: number }).cooldown_sec ?? 1.0,
-      fire_arc_deg: (w.weapon as { fire_arc_deg?: number }).fire_arc_deg ?? 30.0,
+      cooldown_sec: w.weapon.cooldown_sec ?? 1.0,
+      fire_arc_deg: w.weapon.fire_arc_deg ?? 30.0,
     },
   };
 }

--- a/admin-tool/src/components/admin/WeaponEditForm.tsx
+++ b/admin-tool/src/components/admin/WeaponEditForm.tsx
@@ -20,11 +20,6 @@ export const masterWeaponSchema = z.object({
   price: z.number({ message: "Must be a number" }).int().nonnegative("Must be ≥ 0"),
   description: z.string(),
   weapon: z.object({
-    id: z
-      .string()
-      .min(1, "Weapon ID is required")
-      .regex(/^[a-z0-9_]+$/, "Weapon ID must be snake_case alphanumeric"),
-    name: z.string().min(1, "Weapon name is required"),
     power: z.number({ message: "Must be a number" }).int().positive("Must be > 0"),
     range: z.number({ message: "Must be a number" }).positive("Must be > 0"),
     accuracy: z.number({ message: "Must be a number" }).min(0).max(100, "Must be 0-100"),
@@ -62,8 +57,6 @@ const defaultValues: WeaponFormValues = {
   price: 300,
   description: "",
   weapon: {
-    id: "",
-    name: "",
     power: 150,
     range: 400,
     accuracy: 70,
@@ -86,8 +79,6 @@ function toFormValues(w: MasterWeapon): WeaponFormValues {
     price: w.price,
     description: w.description,
     weapon: {
-      id: w.weapon.id,
-      name: w.weapon.name,
       power: w.weapon.power,
       range: w.weapon.range,
       accuracy: w.weapon.accuracy,
@@ -140,8 +131,6 @@ export default function WeaponEditForm({
     handleSubmit,
     control,
     reset,
-    watch,
-    setValue,
     formState: { errors },
   } = useForm<WeaponFormValues>({
     resolver: zodResolver(masterWeaponSchema),
@@ -151,14 +140,6 @@ export default function WeaponEditForm({
   useEffect(() => {
     reset(initialData ? toFormValues(initialData) : defaultValues);
   }, [initialData, reset]);
-
-  // エントリー ID と武器 ID を同期する（新規作成時のみ）
-  const watchId = watch("id");
-  useEffect(() => {
-    if (!lockId) {
-      setValue("weapon.id", watchId);
-    }
-  }, [watchId, lockId, setValue]);
 
   const sectionTitle =
     "text-xs font-bold text-[#ffb000] uppercase tracking-wider mb-2 border-b border-[#ffb000]/20 pb-1";
@@ -206,16 +187,6 @@ export default function WeaponEditForm({
       <div>
         <p className={sectionTitle}>武器スペック</p>
         <div className="grid grid-cols-3 gap-3">
-          <div>
-            <Label>武器 ID</Label>
-            <Input {...register("weapon.id")} disabled placeholder="beam_rifle" />
-            <FieldError msg={errors.weapon?.id?.message} />
-          </div>
-          <div className="col-span-2">
-            <Label>武器名</Label>
-            <Input {...register("weapon.name")} placeholder="Beam Rifle" />
-            <FieldError msg={errors.weapon?.name?.message} />
-          </div>
           <div>
             <Label>威力</Label>
             <Input type="number" {...register("weapon.power", { valueAsNumber: true })} />

--- a/admin-tool/src/types/admin.ts
+++ b/admin-tool/src/types/admin.ts
@@ -1,4 +1,4 @@
-import { Weapon } from "./weapon";
+import { Weapon, WeaponSpec } from "./weapon";
 
 /** 管理者用マスター機体のスペック定義 */
 export interface MasterMobileSuitSpec {
@@ -51,13 +51,14 @@ export interface MasterMobileSuitUpdate {
     specs?: MasterMobileSuitSpec;
 }
 
-/** 管理者用マスター武器エントリー（武器ショップの元データ） */
+/** 管理者用マスター武器エントリー（武器ショップの元データ）。
+ *  id/name はテーブルカラムが正のため、weapon(JSON) 側は WeaponSpec (id/nameなし) を使う */
 export interface MasterWeapon {
     id: string;
     name: string;
     price: number;
     description: string;
-    weapon: Weapon;
+    weapon: WeaponSpec;
 }
 
 /** マスター武器の新規追加リクエスト（MasterWeaponと同形） */
@@ -68,7 +69,7 @@ export interface MasterWeaponUpdate {
     name?: string;
     price?: number;
     description?: string;
-    weapon?: Weapon;
+    weapon?: WeaponSpec;
 }
 
 /** 攻撃セクタ（正面・側面・背面） */

--- a/admin-tool/src/types/weapon.ts
+++ b/admin-tool/src/types/weapon.ts
@@ -1,7 +1,5 @@
-/** 武器のスペック定義（機体に装備するマスターデータと同形式） */
-export interface Weapon {
-    id: string;
-    name: string;
+/** 武器のスペック定義のうち id/name を除いた部分（マスター武器の weapon(JSON)列と同形式） */
+export interface WeaponSpec {
     power: number;
     range: number;
     accuracy: number;
@@ -21,6 +19,12 @@ export interface Weapon {
     range_rank?: string;
     /** 命中率ランク (S〜E) - APIから付与される */
     accuracy_rank?: string;
+}
+
+/** 武器のスペック定義（機体に装備するマスターデータと同形式）。id/name は機体武器スロット内での識別に使う */
+export interface Weapon extends WeaponSpec {
+    id: string;
+    name: string;
 }
 
 /** 機体の戦術設定（ターゲット優先度と交戦距離の方針） */

--- a/admin-tool/src/types/weapon.ts
+++ b/admin-tool/src/types/weapon.ts
@@ -10,6 +10,8 @@ export interface WeaponSpec {
     max_ammo?: number | null;
     en_cost?: number;
     cool_down_turn?: number;
+    cooldown_sec?: number;
+    fire_arc_deg?: number;
     is_melee?: boolean;
     /** 装備に必要なビームジェネレータLv (BEAM属性武器のみ有効) */
     required_beam_generator_lv?: number;

--- a/admin-tool/tests/unit/weaponEditFormValidation.test.ts
+++ b/admin-tool/tests/unit/weaponEditFormValidation.test.ts
@@ -7,8 +7,6 @@ import { masterWeaponSchema } from "@/components/admin/WeaponEditForm";
 // ============================================================
 
 const validWeaponSpec = {
-  id: "beam_rifle",
-  name: "Beam Rifle",
   power: 300,
   range: 600,
   accuracy: 80,
@@ -90,21 +88,16 @@ describe("masterWeaponSchema — weapon スペック", () => {
     return { ...validMasterWeapon, weapon: { ...validWeaponSpec, ...patch } };
   }
 
-  it("weapon.id が空の場合はエラー", () => {
-    const result = masterWeaponSchema.safeParse(withWeapon({ id: "" }));
-    expect(result.success).toBe(false);
-    expect(result.error?.issues.some((i) => i.path.includes("id"))).toBe(true);
-  });
-
-  it("weapon.id がスネークケース以外の場合はエラー", () => {
-    const result = masterWeaponSchema.safeParse(withWeapon({ id: "Beam-Rifle" }));
-    expect(result.success).toBe(false);
-  });
-
-  it("weapon.name が空の場合はエラー", () => {
-    const result = masterWeaponSchema.safeParse(withWeapon({ name: "" }));
-    expect(result.success).toBe(false);
-    expect(result.error?.issues.some((i) => i.path.includes("name"))).toBe(true);
+  it("weapon に id/name を含めても出力からは除去される（Issue #400: id/nameはテーブルカラムが正）", () => {
+    const result = masterWeaponSchema.safeParse({
+      ...validMasterWeapon,
+      weapon: { ...validWeaponSpec, id: "other_id", name: "Other Name" },
+    });
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.weapon).not.toHaveProperty("id");
+      expect(result.data.weapon).not.toHaveProperty("name");
+    }
   });
 
   it("weapon.power が 0 以下の場合はエラー", () => {

--- a/backend/app/core/gamedata.py
+++ b/backend/app/core/gamedata.py
@@ -202,7 +202,13 @@ def _load_weapons_from_db() -> list[dict]:
 
     listings = []
     for record in records:
-        weapon = Weapon(**record.weapon)
+        # weapon(JSON)列は id/name を持たない前提（テーブルカラムが正。Issue #400）で
+        # record.id/record.name から合成する。旧データが id/name を残している場合に
+        # 二重指定エラーにならないよう、念のため取り除いてから展開する。
+        weapon_spec = {
+            k: v for k, v in record.weapon.items() if k not in ("id", "name")
+        }
+        weapon = Weapon(id=record.id, name=record.name, **weapon_spec)
         listings.append(
             {
                 "id": record.id,
@@ -376,6 +382,8 @@ def save_master_weapons(session: Session, data: list[dict]) -> None:
         weapon_data = item.get("weapon", {})
         if hasattr(weapon_data, "model_dump"):
             weapon_data = weapon_data.model_dump()
+        # id/name は master_weapons テーブルのカラムを正とするため除去する（Issue #400）
+        weapon_data = {k: v for k, v in weapon_data.items() if k not in ("id", "name")}
 
         if item_id in existing:
             record = existing[item_id]

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -27,11 +27,14 @@ class Vector3(SQLModel):
         return cls(x=float(arr[0]), y=float(arr[1]), z=float(arr[2]))
 
 
-class Weapon(SQLModel):
-    """武装データ."""
+class WeaponSpecBase(SQLModel):
+    """武装データのうち id/name を除いたスペック部分.
 
-    id: str
-    name: str
+    マスター武器（MasterWeapon）の weapon(JSON)列はこのクラスの形で保存する。
+    id/name は master_weapons テーブルのカラムを正とし、JSON側には持たせない
+    （二重管理によるデータ不整合を防ぐため。Issue #400）。
+    """
+
     power: int = Field(description="威力")
     range: float = Field(description="射程距離")
     accuracy: float = Field(description="基本命中率(%)")
@@ -62,6 +65,17 @@ class Weapon(SQLModel):
         default=30.0,
         description="射撃可能弧（胴体正面からの片側角度、度）。格闘武器は 360 を設定",
     )
+
+
+class MasterWeaponSpec(WeaponSpecBase):
+    """マスター武器の weapon(JSON)列に保存するスペック（id/nameを含まない）."""
+
+
+class Weapon(WeaponSpecBase):
+    """武装データ（機体の武器スロット・武器インスタンス等、id/nameが必要な文脈で使用）."""
+
+    id: str
+    name: str
 
 
 class WeaponResponse(Weapon):
@@ -448,7 +462,7 @@ class MasterWeaponEntry(SQLModel):
     name: str
     price: int
     description: str
-    weapon: Weapon
+    weapon: MasterWeaponSpec
 
 
 class MasterWeaponCreate(SQLModel):
@@ -458,7 +472,7 @@ class MasterWeaponCreate(SQLModel):
     name: str
     price: int
     description: str
-    weapon: Weapon
+    weapon: MasterWeaponSpec
 
 
 class MasterWeaponUpdate(SQLModel):
@@ -467,7 +481,7 @@ class MasterWeaponUpdate(SQLModel):
     name: str | None = None
     price: int | None = None
     description: str | None = None
-    weapon: Weapon | None = None
+    weapon: MasterWeaponSpec | None = None
 
 
 # --- Combat Simulation Models (管理画面用 1対1 攻撃シミュレーション, Issue #381) ---

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -18,6 +18,7 @@ from app.models.models import (
     MasterMobileSuitUpdate,
     MasterWeaponCreate,
     MasterWeaponEntry,
+    MasterWeaponSpec,
     MasterWeaponUpdate,
     Weapon,
 )
@@ -166,7 +167,9 @@ def delete_master_mobile_suit(
 def _raw_weapon_to_entry(raw: dict) -> MasterWeaponEntry:
     """生JSON辞書を MasterWeaponEntry モデルに変換する."""
     weapon_raw = raw["weapon"]
-    weapon = Weapon(**weapon_raw) if isinstance(weapon_raw, dict) else weapon_raw
+    weapon = (
+        MasterWeaponSpec(**weapon_raw) if isinstance(weapon_raw, dict) else weapon_raw
+    )
     return MasterWeaponEntry(
         id=raw["id"],
         name=raw["name"],

--- a/backend/data/master/weapons.json
+++ b/backend/data/master/weapons.json
@@ -5,8 +5,6 @@
     "price": 200,
     "description": "ザク用マシンガン。連射性能に優れた実弾兵器。",
     "weapon": {
-      "id": "zaku_mg",
-      "name": "Zaku Machine Gun",
       "power": 100,
       "range": 400,
       "accuracy": 60,
@@ -22,8 +20,6 @@
     "price": 400,
     "description": "高火力バズーカ。装甲貫通力に優れる。",
     "weapon": {
-      "id": "giant_bazooka",
-      "name": "Giant Bazooka",
       "power": 180,
       "range": 450,
       "accuracy": 55,
@@ -39,8 +35,6 @@
     "price": 350,
     "description": "ヒートロッド。近距離戦闘に特化した武器。",
     "weapon": {
-      "id": "heat_rod",
-      "name": "Heat Rod",
       "power": 140,
       "range": 300,
       "accuracy": 70,
@@ -56,8 +50,6 @@
     "price": 800,
     "description": "ガンダム用ビームライフル。高威力・高精度のビーム兵器。",
     "weapon": {
-      "id": "beam_rifle",
-      "name": "Beam Rifle",
       "power": 300,
       "range": 600,
       "accuracy": 80,
@@ -73,8 +65,6 @@
     "price": 700,
     "description": "ゲルググ用ビームライフル。バランスの取れたビーム兵器。",
     "weapon": {
-      "id": "beam_rifle_gelgoog",
-      "name": "Beam Rifle",
       "power": 280,
       "range": 580,
       "accuracy": 75,
@@ -90,8 +80,6 @@
     "price": 600,
     "description": "超高火力バズーカ。単発威力に優れる重武装。",
     "weapon": {
-      "id": "hyper_bazooka",
-      "name": "Hyper Bazooka",
       "power": 250,
       "range": 500,
       "accuracy": 50,
@@ -109,8 +97,6 @@
     "price": 450,
     "description": "ビームサーベル。近接戦闘用の高出力ビーム兵器。",
     "weapon": {
-      "id": "beam_saber",
-      "name": "Beam Saber",
       "power": 200,
       "range": 150,
       "accuracy": 85,

--- a/backend/tests/test_weapon_shop.py
+++ b/backend/tests/test_weapon_shop.py
@@ -55,6 +55,12 @@ def test_get_weapon_listings_tolerates_legacy_weapon_json_with_id_name(client, s
     session.add(legacy_record)
     session.commit()
 
+    # 直前のテストでキャッシュされた武器ショップ一覧が残っていても
+    # 今追加したレコードが確実に反映されるようにキャッシュを明示的にクリアする
+    import app.core.gamedata as gd
+
+    gd._weapon_shop_listings_cache = None
+
     response = client.get("/api/shop/weapons")
     assert response.status_code == status.HTTP_200_OK
 

--- a/backend/tests/test_weapon_shop.py
+++ b/backend/tests/test_weapon_shop.py
@@ -3,7 +3,7 @@
 from fastapi import status
 
 from app.core.auth import get_current_user
-from app.models.models import MobileSuit, Pilot, PlayerWeapon
+from app.models.models import MasterWeapon, MobileSuit, Pilot, PlayerWeapon
 from main import app
 
 
@@ -31,6 +31,38 @@ def test_get_weapon_listings(client):
     assert "range" in weapon
     assert "accuracy" in weapon
     assert "type" in weapon
+
+
+def test_get_weapon_listings_tolerates_legacy_weapon_json_with_id_name(client, session):
+    """レガシー行(weapon列にid/nameを含む)でも一覧取得がエラーにならないことをテスト.
+
+    Issue #400 以前に作られたデータを想定。テーブルカラムのid/nameを優先して合成する。
+    """
+    legacy_record = MasterWeapon(
+        id="legacy_weapon",
+        name="Legacy Weapon",
+        price=100,
+        description="Issue #400 以前の形式（weapon列にid/nameを含む）",
+        weapon={
+            "id": "legacy_weapon",
+            "name": "Legacy Weapon",
+            "power": 50,
+            "range": 100,
+            "accuracy": 50,
+            "type": "PHYSICAL",
+        },
+    )
+    session.add(legacy_record)
+    session.commit()
+
+    response = client.get("/api/shop/weapons")
+    assert response.status_code == status.HTTP_200_OK
+
+    listings = response.json()
+    legacy_item = next((w for w in listings if w["id"] == "legacy_weapon"), None)
+    assert legacy_item is not None
+    assert legacy_item["weapon"]["id"] == "legacy_weapon"
+    assert legacy_item["weapon"]["name"] == "Legacy Weapon"
 
 
 def test_purchase_weapon_success(client, session):

--- a/backend/tests/unit/test_admin_weapons.py
+++ b/backend/tests/unit/test_admin_weapons.py
@@ -21,8 +21,6 @@ SAMPLE_WEAPON = {
     "price": 600,
     "description": "テスト用ビームカノン。",
     "weapon": {
-        "id": "test_beam_cannon",
-        "name": "Test Beam Cannon",
         "power": 250,
         "range": 550,
         "accuracy": 70,
@@ -107,6 +105,9 @@ def test_list_master_weapons(client_admin):
     assert "power" in first["weapon"]
     assert "range" in first["weapon"]
     assert "accuracy" in first["weapon"]
+    # weapon(JSON)側に id/name は含まれない（テーブルカラムが正。Issue #400）
+    assert "id" not in first["weapon"]
+    assert "name" not in first["weapon"]
 
 
 # ===================== POST 新規追加 =====================
@@ -122,6 +123,8 @@ def test_create_master_weapon(client_admin):
     assert data["id"] == "test_beam_cannon"
     assert data["name"] == "Test Beam Cannon"
     assert data["weapon"]["power"] == 250
+    assert "id" not in data["weapon"]
+    assert "name" not in data["weapon"]
 
     # GET で確認
     list_response = client_admin.get("/api/admin/weapons", headers=HEADERS)

--- a/docs/features/admin-weapons.md
+++ b/docs/features/admin-weapons.md
@@ -24,8 +24,6 @@
     "price": 800,
     "description": "ガンダム用ビームライフル。高威力・高精度のビーム兵器。",
     "weapon": {
-      "id": "beam_rifle",
-      "name": "Beam Rifle",
       "power": 300,
       "range": 600,
       "accuracy": 80,
@@ -48,6 +46,7 @@
 新規マスター武器を追加する。
 
 **リクエスト:** `MasterWeaponCreate` オブジェクト（`id`, `name`, `price`, `description`, `weapon` を含む）
+- `weapon`(`MasterWeaponSpec`) は `id`/`name` を含まない。武器の `id`/`name` は `master_weapons` テーブルのカラム（トップレベルの `id`/`name`）を正とする（Issue #400）
 
 **バリデーション:**
 - `id` はスネークケース英数字のみ許可（`^[a-z0-9_]+$`）
@@ -100,7 +99,7 @@ CREATE TABLE master_weapons (
     name        TEXT NOT NULL,
     price       INTEGER NOT NULL,
     description TEXT NOT NULL,
-    weapon      JSONB NOT NULL,         -- Weapon モデルの全フィールド
+    weapon      JSONB NOT NULL,         -- MasterWeaponSpec の全フィールド (id/nameは含まない。テーブルのid/nameが正)
     created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
     updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
 );
@@ -154,7 +153,7 @@ cd admin-tool && npm run dev   # http://localhost:3100
 |------|------|
 | **武器一覧テーブル** | 名前・価格・武器種別（BEAM/PHYSICAL）・近接フラグ・威力・射程・命中率を表示。ソート・フィルタ対応 |
 | **詳細編集フォーム** | 全パラメータ（`power`, `range`, `accuracy`, `type`, `weapon_type`, `optimal_range`, `decay_rate`, `is_melee`, `max_ammo`, `en_cost`, `cooldown_sec`, `fire_arc_deg`）を編集 |
-| **新規追加フォーム** | 新規武器の追加。ID は自動で weapon.id にも同期 |
+| **新規追加フォーム** | 新規武器の追加。`id`/`name` は基本情報欄のみで入力し、`weapon`(スペック)側には持たせない（Issue #400） |
 | **Clone & Edit** | 選択中の武器をベースに新しい ID でコピーを作成 |
 | **バランス比較チャート** | 選択中の武器と全武器平均を **レーダーチャート（威力・射程・命中率・最適射程・減衰率の5軸）** で表示。全武器最大値で正規化し、減衰率は反転表示 |
 | **トースト通知** | 保存成功・失敗をトーストで通知 |


### PR DESCRIPTION
## Summary
- `master_weapons` テーブルの `id`/`name` カラムと、`weapon`(JSON)列内の `Weapon.id`/`Weapon.name` が二重管理になっていた問題を解消（Issue #400）。
- `id`/`name` を含まない `MasterWeaponSpec` を新設し、`MasterWeaponEntry`/`Create`/`Update` の `weapon` フィールドをこれに変更。`weapon`(JSON)列はテーブルカラムの `id`/`name` を正として、以後 id/name を含まない形で保存する。
- 実データで既に不整合が発生していたことを確認（`beam_rifle_gelgoog` の `weapon.name` が `"Beam Rifle"` のまま `name`(`"Beam Rifle (Gelgoog)"`) とズレていた）。`backend/data/master/weapons.json` からも重複を除去。
- 既存DBに残る可能性のあるレガシー形式（`weapon`列にid/nameが残ったままの行）を読み込んでも壊れないよう、`gamedata._load_weapons_from_db` で明示的に除去してから合成するようにした（実装中にレガシー形式だと `TypeError: got multiple values for keyword argument 'id'` になるバグを発見し修正）。
- admin-tool の `WeaponEditForm.tsx` から `weapon.id`/`weapon.name` の入力欄・同期ロジックを削除（`id`/`name` は基本情報欄のみで編集）。

## Test plan
- [x] `cd backend && python -m pytest tests --tb=short -q` 全件パス（新規追加のレガシーデータ互換テスト含む）
- [x] `cd backend && python -m ruff check app tests` / `python -m mypy app` エラーなし
- [x] `cd admin-tool && npx vitest run` 全件パス（`weapon`にid/nameを含めても出力から除去されることを検証するテストを追加）
- [x] `cd admin-tool && npx eslint` 対象ファイルでエラーなし
- [x] `docs/features/admin-weapons.md` を更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)