### PR TITLE
feat: マスター武器編集画面にrequired_beam_generator_lv設定機能を追加 (#399)

### DIFF
--- a/admin-tool/src/components/admin/WeaponEditForm.tsx
+++ b/admin-tool/src/components/admin/WeaponEditForm.tsx
@@ -151,7 +151,7 @@ export default function WeaponEditForm({
 
   useEffect(() => {
     if (isPhysical) {
-      setValue("weapon.required_beam_generator_lv", 0);
+      setValue("weapon.required_beam_generator_lv", 0, { shouldValidate: true });
     }
   }, [isPhysical, setValue]);
 

--- a/admin-tool/src/components/admin/WeaponEditForm.tsx
+++ b/admin-tool/src/components/admin/WeaponEditForm.tsx
@@ -32,6 +32,7 @@ export const masterWeaponSchema = z.object({
     en_cost: z.number({ message: "Must be a number" }).int().nonnegative().optional(),
     cooldown_sec: z.number({ message: "Must be a number" }).nonnegative().optional(),
     fire_arc_deg: z.number({ message: "Must be a number" }).nonnegative().optional(),
+    required_beam_generator_lv: z.number({ message: "Must be a number" }).int().nonnegative().optional(),
   }),
 });
 
@@ -69,6 +70,7 @@ const defaultValues: WeaponFormValues = {
     en_cost: 0,
     cooldown_sec: 1.0,
     fire_arc_deg: 30.0,
+    required_beam_generator_lv: 0,
   },
 };
 
@@ -91,6 +93,7 @@ function toFormValues(w: MasterWeapon): WeaponFormValues {
       en_cost: w.weapon.en_cost ?? 0,
       cooldown_sec: w.weapon.cooldown_sec ?? 1.0,
       fire_arc_deg: w.weapon.fire_arc_deg ?? 30.0,
+      required_beam_generator_lv: w.weapon.required_beam_generator_lv ?? 0,
     },
   };
 }
@@ -131,6 +134,8 @@ export default function WeaponEditForm({
     handleSubmit,
     control,
     reset,
+    watch,
+    setValue,
     formState: { errors },
   } = useForm<WeaponFormValues>({
     resolver: zodResolver(masterWeaponSchema),
@@ -140,6 +145,15 @@ export default function WeaponEditForm({
   useEffect(() => {
     reset(initialData ? toFormValues(initialData) : defaultValues);
   }, [initialData, reset]);
+
+  const weaponType = watch("weapon.type");
+  const isPhysical = weaponType === "PHYSICAL";
+
+  useEffect(() => {
+    if (isPhysical) {
+      setValue("weapon.required_beam_generator_lv", 0);
+    }
+  }, [isPhysical, setValue]);
 
   const sectionTitle =
     "text-xs font-bold text-[#ffb000] uppercase tracking-wider mb-2 border-b border-[#ffb000]/20 pb-1";
@@ -303,6 +317,19 @@ export default function WeaponEditForm({
               {...register("weapon.fire_arc_deg", { valueAsNumber: true })}
             />
             <FieldError msg={errors.weapon?.fire_arc_deg?.message} />
+          </div>
+          <div>
+            <Label>要求ビームジェネレータLv</Label>
+            <Input
+              type="number"
+              min={0}
+              disabled={isPhysical}
+              {...register("weapon.required_beam_generator_lv", { valueAsNumber: true })}
+            />
+            {isPhysical && (
+              <p className="mt-0.5 text-xs text-[#00ff41]/40">PHYSICAL属性では無効です</p>
+            )}
+            <FieldError msg={errors.weapon?.required_beam_generator_lv?.message} />
           </div>
         </div>
       </div>

--- a/admin-tool/src/components/admin/WeaponTable.tsx
+++ b/admin-tool/src/components/admin/WeaponTable.tsx
@@ -105,6 +105,7 @@ export default function WeaponTable({
               <th className={thClass} onClick={() => handleSort("accuracy")}>
                 命中 <SortIcon k="accuracy" />
               </th>
+              <th className={`${thClass} cursor-default`}>要求Lv</th>
               <th className={`${thClass} cursor-default`}>操作</th>
             </tr>
           </thead>
@@ -147,6 +148,15 @@ export default function WeaponTable({
                   <td className={tdClass}>{w.weapon.power}</td>
                   <td className={tdClass}>{w.weapon.range}</td>
                   <td className={tdClass}>{w.weapon.accuracy}%</td>
+                  <td className={tdClass}>
+                    {w.weapon.type === "BEAM" ? (
+                      <span className="text-blue-300 text-xs">
+                        Lv{w.weapon.required_beam_generator_lv ?? 0}
+                      </span>
+                    ) : (
+                      <span className="text-[#00ff41]/30 text-xs">—</span>
+                    )}
+                  </td>
                   <td className={tdClass} onClick={(e) => e.stopPropagation()}>
                     <button
                       onClick={() => onDelete(w)}
@@ -160,7 +170,7 @@ export default function WeaponTable({
             })}
             {sorted.length === 0 && (
               <tr>
-                <td colSpan={8} className="text-center text-[#00ff41]/40 py-8 text-sm">
+                <td colSpan={9} className="text-center text-[#00ff41]/40 py-8 text-sm">
                   武器データが見つかりません
                 </td>
               </tr>

--- a/admin-tool/tests/unit/weaponEditFormValidation.test.ts
+++ b/admin-tool/tests/unit/weaponEditFormValidation.test.ts
@@ -19,6 +19,7 @@ const validWeaponSpec = {
   en_cost: 0,
   cooldown_sec: 1.5,
   fire_arc_deg: 30.0,
+  required_beam_generator_lv: 2,
 };
 
 const validMasterWeapon = {
@@ -187,6 +188,31 @@ describe("masterWeaponSchema — weapon スペック", () => {
 
   it("weapon.fire_arc_deg が 360 は許可される（全方位）", () => {
     const result = masterWeaponSchema.safeParse(withWeapon({ fire_arc_deg: 360 }));
+    expect(result.success).toBe(true);
+  });
+
+  it("weapon.required_beam_generator_lv が 0 は許可される", () => {
+    const result = masterWeaponSchema.safeParse(withWeapon({ required_beam_generator_lv: 0 }));
+    expect(result.success).toBe(true);
+  });
+
+  it("weapon.required_beam_generator_lv が正整数は許可される", () => {
+    const result = masterWeaponSchema.safeParse(withWeapon({ required_beam_generator_lv: 3 }));
+    expect(result.success).toBe(true);
+  });
+
+  it("weapon.required_beam_generator_lv が負の値の場合はエラー", () => {
+    const result = masterWeaponSchema.safeParse(withWeapon({ required_beam_generator_lv: -1 }));
+    expect(result.success).toBe(false);
+    expect(
+      result.error?.issues.some((i) => i.path.includes("required_beam_generator_lv"))
+    ).toBe(true);
+  });
+
+  it("weapon.required_beam_generator_lv が未指定でも許可される（省略可）", () => {
+    const rest: Partial<typeof validWeaponSpec> = { ...validWeaponSpec };
+    delete rest.required_beam_generator_lv;
+    const result = masterWeaponSchema.safeParse({ ...validMasterWeapon, weapon: rest });
     expect(result.success).toBe(true);
   });
 });

--- a/docs/features/admin-weapons.md
+++ b/docs/features/admin-weapons.md
@@ -151,8 +151,8 @@ cd admin-tool && npm run dev   # http://localhost:3100
 
 | 機能 | 説明 |
 |------|------|
-| **武器一覧テーブル** | 名前・価格・武器種別（BEAM/PHYSICAL）・近接フラグ・威力・射程・命中率を表示。ソート・フィルタ対応 |
-| **詳細編集フォーム** | 全パラメータ（`power`, `range`, `accuracy`, `type`, `weapon_type`, `optimal_range`, `decay_rate`, `is_melee`, `max_ammo`, `en_cost`, `cooldown_sec`, `fire_arc_deg`）を編集 |
+| **武器一覧テーブル** | 名前・価格・武器種別（BEAM/PHYSICAL）・近接フラグ・威力・射程・命中率・要求ビームジェネレータLvを表示。ソート・フィルタ対応 |
+| **詳細編集フォーム** | 全パラメータ（`power`, `range`, `accuracy`, `type`, `weapon_type`, `optimal_range`, `decay_rate`, `is_melee`, `max_ammo`, `en_cost`, `cooldown_sec`, `fire_arc_deg`, `required_beam_generator_lv`）を編集。`required_beam_generator_lv` は `type` が `BEAM` の武器のみ意味を持つため、`PHYSICAL` 選択時は入力欄を無効化し値を0にリセットする（Issue #399） |
 | **新規追加フォーム** | 新規武器の追加。`id`/`name` は基本情報欄のみで入力し、`weapon`(スペック)側には持たせない（Issue #400） |
 | **Clone & Edit** | 選択中の武器をベースに新しい ID でコピーを作成 |
 | **バランス比較チャート** | 選択中の武器と全武器平均を **レーダーチャート（威力・射程・命中率・最適射程・減衰率の5軸）** で表示。全武器最大値で正規化し、減衰率は反転表示 |
@@ -222,5 +222,5 @@ cd admin-tool && npx vitest run tests/unit/weaponEditFormValidation.test.ts
 
 テスト項目:
 - エントリー ID・名前・価格のバリデーション
-- weapon スペック（power・range・accuracy・type・weapon_type・is_melee など）のバリデーション
+- weapon スペック（power・range・accuracy・type・weapon_type・is_melee・required_beam_generator_lv など）のバリデーション
 


### PR DESCRIPTION
## Summary
- `WeaponEditForm.tsx` の `masterWeaponSchema` / `defaultValues` / `toFormValues()` に `required_beam_generator_lv` を追加し、新規作成・編集の両方で設定・保存可能にした
- `type` が `PHYSICAL` の場合は入力欄を無効化し値を0にリセット（`MobileSuitEditForm.tsx` の運用と整合）
- `WeaponTable.tsx` の一覧に「要求Lv」列を追加（BEAM武器のみ表示、PHYSICALは`—`）
- `docs/features/admin-weapons.md` を更新

Closes #399

## Test plan
- [x] `cd admin-tool && npx vitest run tests/unit/weaponEditFormValidation.test.ts` — 30件パス（`required_beam_generator_lv` 関連4件追加）
- [x] `cd backend && python -m pytest tests/unit/test_admin_weapons.py tests/unit/test_admin_mobile_suits.py` — 既存テスト回帰なし
- [x] `npx tsc --noEmit` — 新規追加コードで型エラーなし（既存の未関連エラーのみ残存）
- [x] `npx eslint` — 新規追加コードにlintエラーなし

🤖 Generated with [Claude Code](https://claude.com/claude-code)