### PR TITLE
feat: アバター/ボトムナビのUI統一(グラデーション廃止・Tablerアイコン統一・下線インジケータ)

### DIFF
--- a/docs/features/nav-avatar-ui-unification.md
+++ b/docs/features/nav-avatar-ui-unification.md
@@ -1,0 +1,44 @@
+# アバター/ボトムナビ UI統一
+
+**バージョン**: 1.0.0
+**作成日**: 2026-08-02
+**最終更新**: 2026-08-02
+**ステータス**: 実装済み（Issue #406）
+**対象ファイル**: `frontend/src/components/Header.tsx`, `frontend/src/components/Avatar.tsx`, `frontend/src/components/BottomNav.tsx`, `frontend/src/components/icons/TablerIcons.tsx`
+
+---
+
+## 1. 概要と目的
+
+ヘッダーのアバター表示とボトムナビゲーションの見た目に一貫性がなかった問題を解消する。
+
+- アバターはClerkの`UserButton`に依存しており、画像未設定時はClerk側のデフォルト生成アバター（グラデーション背景のイニシャル画像）がそのまま表示されていた
+- ボトムナビはアイコンが絵文字で、アクティブ項目（Garage）のみ視覚的な強調ルールが他と揃っておらず中途半端に見えていた
+
+これらを「装飾」ではなく「ステータス表示の一部」として、緑モノクロ基調のルールに統一した。
+
+## 2. 変更内容
+
+### 2.1 共有アイコンセット（`frontend/src/components/icons/TablerIcons.tsx`）
+
+[Tabler Icons](https://tabler.io/icons)（outline, MIT License）のSVGパスをローカルに複製し、`IconHome` / `IconTool` / `IconShoppingCart` / `IconHistory` / `IconUsers` / `IconUser` / `IconMenu2` として集約。Header・BottomNavなど複数コンポーネントで共有するグローバルアイコンは、以後このファイルに追記して同一セットのみを使う（`frontend/CLAUDE.md`「アイコンの扱い」参照）。
+
+### 2.2 アバター（`Avatar.tsx`）
+
+- `UserButton`の`appearance`で`avatarBox`を線幅1pxの緑アウトライン円（`border border-[#00ff41] bg-transparent`）に変更
+- `useUser()`の`hasImage`フラグでユーザーが独自の画像をアップロード済みかを判定
+  - 未設定時: Clerkのデフォルト生成アバター（`avatarImage`）を`opacity-0`で非表示にし、代わりに`IconUser`（緑モノクロ）を`pointer-events-none`でオーバーレイ表示
+  - 設定済み時: そのままユーザーの画像を表示
+- グラデーションは一切使用しない
+
+### 2.3 ボトムナビ（`BottomNav.tsx`）
+
+- アイコンを絵文字からTabler outlineアイコンに統一
+- 「アクティブ=塗り、非アクティブ=線画」の強弱ルールを廃止し、全項目を線画（outline）で統一
+- アクティブ状態は「文字色を明るい緑（`text-[#00ff41]`）にする＋下線インジケータ（`border-b-2 border-[#00ff41]`）」のみで表現。非アクティブは`text-[#00ff41]/40`＋透明ボーダー（レイアウトシフト防止）
+- ラベルの有無・フォントサイズは変更前と同一
+
+## 3. 既知の制約
+
+- Clerkの`UserButton`はメニュー（アカウント管理・サインアウト）機能をそのまま利用しているため、トリガー部分の見た目のみをオーバーレイで差し替えている。Clerk側の内部DOM構造が変わった場合、オーバーレイの位置がずれる可能性がある
+- ログイン状態でのアバター表示の目視確認は、リポジトリにClerkテストトークンを使ったE2E環境がないため未実施（`tsc` / `vitest` / 未ログイン時のブラウザ確認のみ）

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -265,7 +265,10 @@ luk: number;
 
 ## アイコンの扱い
 
-プロジェクトにアイコンライブラリ（lucide-react, react-icons, heroicons等）は**導入されていない**。UIにアイコンが必要な場合は依存追加を避け、`stroke="currentColor"` ベースの最小限のインラインSVGをコンポーネントファイル内にローカル関数として定義する（例: `WeaponInventoryList.tsx` の `FilterIcon` / `TypeIcon` / `SortIcon` / `EmptyBoxIcon`）。テキスト絵文字（`✕`など）で足りる場合はそちらでも可。
+プロジェクトにアイコンライブラリ（lucide-react, react-icons, heroicons等）は**導入されていない**。UIにアイコンが必要な場合は依存追加を避け、`stroke="currentColor"` ベースの最小限のインラインSVGをコンポーネント内にローカル関数として定義する。テキスト絵文字（`✕`など）で足りる場合はそちらでも可。
+
+- 単一コンポーネント内でしか使わない一時的なアイコン: そのファイル内にローカル関数として定義する（例: `WeaponInventoryList.tsx` の `FilterIcon` / `TypeIcon` / `SortIcon` / `EmptyBoxIcon`）
+- 複数コンポーネントで共有するアイコン: `frontend/src/components/icons/TablerIcons.tsx` に集約する。Header/BottomNav等のグローバルUIは[Tabler Icons](https://tabler.io/icons)（outline, MIT License）のSVGパスをここに複製して使う。**新しいグローバルアイコンが必要になった場合も、このファイルに追記し、他のアイコンセットと混在させないこと**（`BottomNav.tsx`, `Avatar.tsx` が利用例）
 
 ## SWRフックはコンポーネント側で直接呼んでよい（プロップドリリング不要）
 

--- a/frontend/src/components/Avatar.tsx
+++ b/frontend/src/components/Avatar.tsx
@@ -1,0 +1,37 @@
+/* frontend/src/components/Avatar.tsx */
+"use client";
+
+import { UserButton, useUser } from "@clerk/nextjs";
+import { IconUser } from "@/components/icons/TablerIcons";
+
+type AvatarProps = {
+  size?: string;
+};
+
+/*
+ * ヘッダー用アバター表示
+ * - 装飾ではなくステータス表示の一部として扱い、グラデーションは使用しない
+ * - Clerkのデフォルト生成アバター(未設定時にグラデーション背景で描画される)は
+ *   avatarImageを非表示にした上で、緑1pxアウトライン円+緑モノクロアイコンに差し替える
+ * - ユーザーが独自の画像をアップロード済み(hasImage)の場合はその画像をそのまま表示する
+ */
+export default function Avatar({ size = "w-10 h-10" }: AvatarProps) {
+  const { user } = useUser();
+  const hasCustomImage = user?.hasImage ?? false;
+
+  return (
+    <div className={`relative ${size}`} suppressHydrationWarning>
+      <UserButton
+        appearance={{
+          elements: {
+            avatarBox: `${size} border border-[#00ff41] bg-transparent`,
+            avatarImage: hasCustomImage ? "" : "opacity-0",
+          },
+        }}
+      />
+      {!hasCustomImage && (
+        <IconUser className="absolute inset-0 m-auto w-5 h-5 text-[#00ff41] pointer-events-none" />
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/Avatar.tsx
+++ b/frontend/src/components/Avatar.tsx
@@ -12,7 +12,10 @@ type AvatarProps = {
  * ヘッダー用アバター表示
  * - 装飾ではなくステータス表示の一部として扱い、グラデーションは使用しない
  * - Clerkのデフォルト生成アバター(未設定時にグラデーション背景で描画される)は
- *   avatarImageを非表示にした上で、緑1pxアウトライン円+緑モノクロアイコンに差し替える
+ *   userButtonAvatarImageを非表示にした上で、緑1pxアウトライン円+緑モノクロアイコンに差し替える
+ * - UserButtonのトリガー部分は avatarBox/avatarImage ではなく
+ *   userButtonAvatarBox/userButtonAvatarImage というappearanceキーで制御する
+ *   (avatarBox/avatarImageはUserProfile側のアバター編集UIに適用されるキーで、トリガーには効かない)
  * - ユーザーが独自の画像をアップロード済み(hasImage)の場合はその画像をそのまま表示する
  */
 export default function Avatar({ size = "w-10 h-10" }: AvatarProps) {
@@ -24,8 +27,8 @@ export default function Avatar({ size = "w-10 h-10" }: AvatarProps) {
       <UserButton
         appearance={{
           elements: {
-            avatarBox: `${size} border border-[#00ff41] bg-transparent`,
-            avatarImage: hasCustomImage ? "" : "opacity-0",
+            userButtonAvatarBox: `${size} border border-[#00ff41] bg-transparent`,
+            userButtonAvatarImage: hasCustomImage ? "" : "opacity-0",
           },
         }}
       />

--- a/frontend/src/components/Avatar.tsx
+++ b/frontend/src/components/Avatar.tsx
@@ -25,7 +25,7 @@ export default function Avatar({ sizePx = 40 }: AvatarProps) {
 
   return (
     <div
-      className="relative"
+      className="relative inline-flex items-center justify-center"
       style={{ width: sizePx, height: sizePx }}
       suppressHydrationWarning
     >

--- a/frontend/src/components/Avatar.tsx
+++ b/frontend/src/components/Avatar.tsx
@@ -5,35 +5,49 @@ import { UserButton, useUser } from "@clerk/nextjs";
 import { IconUser } from "@/components/icons/TablerIcons";
 
 type AvatarProps = {
-  size?: string;
+  sizePx?: number;
 };
 
 /*
  * ヘッダー用アバター表示
  * - 装飾ではなくステータス表示の一部として扱い、グラデーションは使用しない
- * - Clerkのデフォルト生成アバター(未設定時にグラデーション背景で描画される)は
- *   userButtonAvatarImageを非表示にした上で、緑1pxアウトライン円+緑モノクロアイコンに差し替える
  * - UserButtonのトリガー部分は avatarBox/avatarImage ではなく
  *   userButtonAvatarBox/userButtonAvatarImage というappearanceキーで制御する
  *   (avatarBox/avatarImageはUserProfile側のアバター編集UIに適用されるキーで、トリガーには効かない)
+ * - ClerkはデフォルトアバターをCSS-in-JS(emotion)のinline styleで描画しており、
+ *   className文字列(通常の詳細度)では上書きできない。appearance.elementsにはCSSプロパティの
+ *   オブジェクトも渡せる(emotionのcssとして後勝ちでマージされる)ため、そちらで確実に上書きする
  * - ユーザーが独自の画像をアップロード済み(hasImage)の場合はその画像をそのまま表示する
  */
-export default function Avatar({ size = "w-10 h-10" }: AvatarProps) {
+export default function Avatar({ sizePx = 40 }: AvatarProps) {
   const { user } = useUser();
   const hasCustomImage = user?.hasImage ?? false;
 
   return (
-    <div className={`relative ${size}`} suppressHydrationWarning>
+    <div
+      className="relative"
+      style={{ width: sizePx, height: sizePx }}
+      suppressHydrationWarning
+    >
       <UserButton
         appearance={{
           elements: {
-            userButtonAvatarBox: `${size} border border-[#00ff41] bg-transparent`,
-            userButtonAvatarImage: hasCustomImage ? "" : "opacity-0",
+            userButtonAvatarBox: {
+              width: sizePx,
+              height: sizePx,
+              border: "1px solid #00ff41",
+              backgroundColor: "transparent",
+              backgroundImage: "none",
+              boxShadow: "none",
+            },
+            userButtonAvatarImage: hasCustomImage
+              ? {}
+              : { opacity: 0, visibility: "hidden" },
           },
         }}
       />
       {!hasCustomImage && (
-        <IconUser className="absolute inset-0 m-auto w-5 h-5 text-[#00ff41] pointer-events-none" />
+        <IconUser className="absolute inset-0 m-auto w-5 h-5 text-[#00ff41] pointer-events-none z-10" />
       )}
     </div>
   );

--- a/frontend/src/components/BottomNav.tsx
+++ b/frontend/src/components/BottomNav.tsx
@@ -4,17 +4,26 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useState, useCallback, useEffect } from "react";
+import {
+  IconHome,
+  IconTool,
+  IconShoppingCart,
+  IconHistory,
+  IconUsers,
+  IconUser,
+  IconMenu2,
+} from "@/components/icons/TablerIcons";
 
 const mainNavItems = [
-  { href: "/", label: "Home", icon: "🏠" },
-  { href: "/garage", label: "Garage", icon: "🔧" },
-  { href: "/shop", label: "Shop", icon: "🛒" },
-  { href: "/history", label: "History", icon: "📜" },
+  { href: "/", label: "Home", Icon: IconHome },
+  { href: "/garage", label: "Garage", Icon: IconTool },
+  { href: "/shop", label: "Shop", Icon: IconShoppingCart },
+  { href: "/history", label: "History", Icon: IconHistory },
 ];
 
 const menuItems = [
-  { href: "/team", label: "Team", icon: "👥" },
-  { href: "/pilot", label: "Pilot", icon: "🧑‍✈️" },
+  { href: "/team", label: "Team", Icon: IconUsers },
+  { href: "/pilot", label: "Pilot", Icon: IconUser },
 ];
 
 /*
@@ -58,7 +67,7 @@ export default function BottomNav() {
             aria-labelledby="bottom-nav-menu-button"
             className="absolute bottom-full z-50 m-1 bg-[#0a0a0a] border-2 border-[#00ff41]/50 p-1 min-w-[180px] sf-scanline"
           >
-            {menuItems.map(({ href, label, icon }) => (
+            {menuItems.map(({ href, label, Icon }) => (
               <Link
                 key={href}
                 href={href}
@@ -66,7 +75,7 @@ export default function BottomNav() {
                 onClick={() => setIsMenuOpen(false)}
                 className="flex items-center gap-3 py-2.5 px-4 text-sm font-mono text-[#00ff41]/70 hover:text-[#00ff41] hover:bg-[#00ff41]/10 transition-colors no-min-size"
               >
-                <span className="text-base leading-none">{icon}</span>
+                <Icon className="w-4 h-4 shrink-0" />
                 <span>{label}</span>
               </Link>
             ))}
@@ -79,19 +88,19 @@ export default function BottomNav() {
           aria-label="Bottom navigation"
         >
           <div className="flex h-16">
-            {mainNavItems.map(({ href, label, icon }) => {
+            {mainNavItems.map(({ href, label, Icon }) => {
               const isActive = pathname === href;
               return (
                 <Link
                   key={href}
                   href={href}
-                  className={`flex flex-col items-center justify-center flex-1 gap-0.5 text-[10px] no-min-size transition-colors ${
+                  className={`flex flex-col items-center justify-center flex-1 gap-0.5 text-[10px] no-min-size border-b-2 transition-colors ${
                     isActive
-                      ? "text-[#00ff41] border-t-2 border-[#00ff41]"
-                      : "text-[#00ff41]/40 hover:text-[#00ff41]/70"
+                      ? "text-[#00ff41] border-[#00ff41]"
+                      : "text-[#00ff41]/40 border-transparent hover:text-[#00ff41]/70"
                   }`}
                 >
-                  <span className="text-lg leading-none">{icon}</span>
+                  <Icon className="w-5 h-5" />
                   <span>{label}</span>
                 </Link>
               );
@@ -101,15 +110,15 @@ export default function BottomNav() {
             <button
               id="bottom-nav-menu-button"
               onClick={() => setIsMenuOpen(!isMenuOpen)}
-              className={`flex flex-col items-center justify-center flex-1 gap-0.5 text-[10px] no-min-size transition-colors ${
+              className={`flex flex-col items-center justify-center flex-1 gap-0.5 text-[10px] no-min-size border-b-2 transition-colors ${
                 isMenuOpen
-                  ? "text-[#00ff41] border-t-2 border-[#00ff41]"
-                  : "text-[#00ff41]/40 hover:text-[#00ff41]/70"
+                  ? "text-[#00ff41] border-[#00ff41]"
+                  : "text-[#00ff41]/40 border-transparent hover:text-[#00ff41]/70"
               }`}
               aria-label="メニューを開く"
               aria-expanded={isMenuOpen}
             >
-              <span className="text-xl leading-none">≡</span>
+              <IconMenu2 className="w-5 h-5" />
               <span>Menu</span>
             </button>
           </div>

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -2,10 +2,11 @@
 "use client";
 
 import { useCallback } from "react";
-import { SignedIn, SignedOut, UserButton } from "@clerk/nextjs";
+import { SignedIn, SignedOut } from "@clerk/nextjs";
 import Link from "next/link";
 import { usePilot, resetAccount } from "@/services/api";
 import { SciFiButton, SciFiHeading } from "@/components/ui";
+import Avatar from "@/components/Avatar";
 import { ONBOARDING_COMPLETED_KEY } from "@/constants";
 
 const navLinks = [
@@ -96,15 +97,7 @@ export default function Header() {
             </Link>
           </SignedOut>
           <SignedIn>
-            <div suppressHydrationWarning>
-              <UserButton
-                appearance={{
-                  elements: {
-                    avatarBox: "w-10 h-10 border-2 border-[#00ff41]"
-                  }
-                }}
-              />
-            </div>
+            <Avatar />
           </SignedIn>
         </div>
 
@@ -116,15 +109,7 @@ export default function Header() {
             </Link>
           </SignedOut>
           <SignedIn>
-            <div suppressHydrationWarning>
-              <UserButton
-                appearance={{
-                  elements: {
-                    avatarBox: "w-10 h-10 border-2 border-[#00ff41]"
-                  }
-                }}
-              />
-            </div>
+            <Avatar />
           </SignedIn>
         </div>
       </div>

--- a/frontend/src/components/icons/TablerIcons.tsx
+++ b/frontend/src/components/icons/TablerIcons.tsx
@@ -1,0 +1,97 @@
+/* frontend/src/components/icons/TablerIcons.tsx */
+
+/*
+ * Tabler Icons (outline, https://tabler.io/icons, MIT License) のパスをローカルに複製したもの。
+ * frontend/CLAUDE.md の方針(アイコンライブラリ非導入)に従い、依存追加ではなくSVGパスの
+ * インライン実装で統一する。アバター・ボトムナビ等、UI全体で同一セットのみを使用すること。
+ */
+
+export type TablerIconProps = {
+  className?: string;
+};
+
+const baseProps = {
+  xmlns: "http://www.w3.org/2000/svg",
+  viewBox: "0 0 24 24",
+  fill: "none",
+  stroke: "currentColor",
+  strokeWidth: 2,
+  strokeLinecap: "round" as const,
+  strokeLinejoin: "round" as const,
+  "aria-hidden": true,
+};
+
+export function IconHome({ className }: TablerIconProps) {
+  return (
+    <svg {...baseProps} className={className}>
+      <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+      <path d="M5 12l-2 0l9 -9l9 9l-2 0" />
+      <path d="M5 12v7a2 2 0 0 0 2 2h10a2 2 0 0 0 2 -2v-7" />
+      <path d="M9 21v-6a2 2 0 0 1 2 -2h2a2 2 0 0 1 2 2v6" />
+    </svg>
+  );
+}
+
+export function IconTool({ className }: TablerIconProps) {
+  return (
+    <svg {...baseProps} className={className}>
+      <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+      <path d="M7 10h3v-3l-3.5 -3.5a6 6 0 0 1 8 8l6 6a2 2 0 0 1 -3 3l-6 -6a6 6 0 0 1 -8 -8l3.5 3.5" />
+    </svg>
+  );
+}
+
+export function IconShoppingCart({ className }: TablerIconProps) {
+  return (
+    <svg {...baseProps} className={className}>
+      <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+      <path d="M6 19a1 1 0 1 0 2 0a1 1 0 1 0 -2 0" />
+      <path d="M17 19a1 1 0 1 0 2 0a1 1 0 1 0 -2 0" />
+      <path d="M17 17h-11v-14h-2" />
+      <path d="M6 5l14 1l-1 7h-13" />
+    </svg>
+  );
+}
+
+export function IconHistory({ className }: TablerIconProps) {
+  return (
+    <svg {...baseProps} className={className}>
+      <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+      <path d="M12 8l0 4l2 2" />
+      <path d="M3.05 11a9 9 0 1 1 .5 4m-.5 5v-5h5" />
+    </svg>
+  );
+}
+
+export function IconUsers({ className }: TablerIconProps) {
+  return (
+    <svg {...baseProps} className={className}>
+      <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+      <path d="M9 7m-4 0a4 4 0 1 0 8 0a4 4 0 1 0 -8 0" />
+      <path d="M3 21v-2a4 4 0 0 1 4 -4h4a4 4 0 0 1 4 4v2" />
+      <path d="M16 3.13a4 4 0 0 1 0 7.75" />
+      <path d="M21 21v-2a4 4 0 0 0 -3 -3.85" />
+    </svg>
+  );
+}
+
+export function IconUser({ className }: TablerIconProps) {
+  return (
+    <svg {...baseProps} className={className}>
+      <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+      <path d="M8 7a4 4 0 1 0 8 0a4 4 0 0 0 -8 0" />
+      <path d="M6 21v-2a4 4 0 0 1 4 -4h4a4 4 0 0 1 4 4v2" />
+    </svg>
+  );
+}
+
+export function IconMenu2({ className }: TablerIconProps) {
+  return (
+    <svg {...baseProps} className={className}>
+      <path stroke="none" d="M0 0h24v24H0z" fill="none" />
+      <path d="M4 6l16 0" />
+      <path d="M4 12l16 0" />
+      <path d="M4 18l16 0" />
+    </svg>
+  );
+}


### PR DESCRIPTION
## Summary
- Clerkの`UserButton`が表示するデフォルト生成アバター(グラデーション背景)を廃止し、緑1pxアウトライン円+緑モノクロの`IconUser`(独自ユーザー画像がある場合はそのまま表示)に統一する新規`Avatar`コンポーネントを追加
- ボトムナビの絵文字アイコンをTabler Icons(outline, MIT License)のSVGパスをローカル複製した共通アイコンセット(`frontend/src/components/icons/TablerIcons.tsx`)に置き換え
- ボトムナビの「アクティブ=塗り、非アクティブ=線画」ルールを廃止し、全項目を線画に統一。アクティブ項目は「文字色を明るい緑にする+下線インジケータ(`border-b-2`)」のみで表現
- `frontend/CLAUDE.md`のアイコン方針に「複数コンポーネントで共有するアイコンは`TablerIcons.tsx`に集約する」旨を追記
- `docs/features/nav-avatar-ui-unification.md`を新規追加

Closes #406

## Test plan
- [x] `cd frontend && ./node_modules/.bin/tsc --noEmit` が通る
- [x] `cd frontend && npx vitest run tests/unit/` が通る(209 tests pass)
- [x] `npx eslint` で変更ファイルにエラーなし
- [x] `next dev` を起動し、未ログイン状態でHome/Shop/Menuページのボトムナビの見た目を確認(アクティブ項目が明るい緑+下線、非アクティブが暗い緑で線画アイコンのみ表示されることを確認)
- [ ] ログイン状態でのアバター表示(グラデーション廃止・アウトライン円+アイコン)は、リポジトリにClerkテストトークンを使ったE2E環境がないため未確認。手動でのログイン確認を推奨

🤖 Generated with [Claude Code](https://claude.com/claude-code)