### PR TITLE
[Refactor]: 武器改造機能に向けたデータモデル整理とマイグレーション

### DIFF
--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -1008,6 +1008,22 @@ class TeamMember(SQLModel, table=True):
     )
 
 
+class WeaponCustomStats(SQLModel):
+    """武器インスタンスの強化・改造差分スキーマ (Issue #404).
+
+    `PlayerWeapon.custom_stats` (自由形式JSON) に実際に書き込まれる想定のキーを
+    型として明示する。キー欠損時はデフォルト0/未変更として扱う（後方互換）。
+    `weapon_power`（機体側のパイロット/システム補正、`EngineeringService` 管理）とは
+    別軸の、武器インスタンス単位の改造差分。
+    """
+
+    power_bonus: int = Field(default=0, description="威力への加算値")
+    accuracy_bonus: float = Field(default=0.0, description="命中率への加算値(%)")
+    upgrade_level: int = Field(
+        default=0, description="改造レベル（将来の改造ツリー・表示用）"
+    )
+
+
 class PlayerWeapon(SQLModel, table=True):
     """プレイヤー武器インスタンステーブル."""
 
@@ -1029,7 +1045,12 @@ class PlayerWeapon(SQLModel, table=True):
     custom_stats: dict = Field(
         default_factory=dict,
         sa_column=Column(JSON),
-        description="強化・改造による差分（初期値: {}）",
+        description=(
+            "強化・改造による差分（初期値: {}）。"
+            "スキーマは WeaponCustomStats を参照（power_bonus / accuracy_bonus / "
+            "upgrade_level）。実効スペックは WeaponService.apply_effective_spec で "
+            "base_snapshot とマージして計算する"
+        ),
     )
     equipped_ms_id: uuid.UUID | None = Field(
         default=None,

--- a/backend/app/services/engineering_service.py
+++ b/backend/app/services/engineering_service.py
@@ -19,7 +19,15 @@ class _FloatStatConfig(NamedTuple):
 
 
 class EngineeringService:
-    """Service for upgrading mobile suit stats using Credits."""
+    """Service for upgrading mobile suit stats using Credits.
+
+    NOTE (Issue #404): ``weapon_power`` はここでは「機体側のパイロット/システム補正」
+    として扱う。装備中の全武器の ``MobileSuit.weapons[*].power`` に一律加算する現行
+    実装のままとし、武器インスタンス単位の改造（``PlayerWeapon.custom_stats``、
+    ``WeaponService.apply_effective_spec``）とは意図的に別軸として維持する（方針(b)）。
+    武器を外す・付け替えると本強化の投資は失われる既知の制約があるため、UIでは
+    「機体強化」と「武器改造」を別物として提示すること。
+    """
 
     # Upgrade cost multipliers
     BASE_HP_COST = 50

--- a/backend/app/services/weapon_service.py
+++ b/backend/app/services/weapon_service.py
@@ -16,11 +16,32 @@ from app.models.models import (
     Pilot,
     PlayerWeapon,
     Weapon,
+    WeaponCustomStats,
 )
 
 
 class WeaponService:
     """武器インスタンスを操作するサービス."""
+
+    @staticmethod
+    def apply_effective_spec(base_snapshot: dict, custom_stats: dict) -> Weapon:
+        """base_snapshot に custom_stats の強化・改造差分をマージした実効スペックを計算する.
+
+        custom_stats にキーが欠損している場合は WeaponCustomStats のデフォルト
+        （0 / 未変更）として扱うため、既存の空 `{}` の行も安全にマージできる。
+
+        Args:
+            base_snapshot: 購入時の Weapon スペックスナップショット
+            custom_stats: 強化・改造による差分（PlayerWeapon.custom_stats）
+
+        Returns:
+            Weapon: base_snapshot + custom_stats をマージした実効スペック
+        """
+        diff = WeaponCustomStats(**custom_stats)
+        merged = dict(base_snapshot)
+        merged["power"] = merged.get("power", 0) + diff.power_bonus
+        merged["accuracy"] = merged.get("accuracy", 0.0) + diff.accuracy_bonus
+        return Weapon(**merged)
 
     @staticmethod
     def purchase_weapon(session: Session, user_id: str, weapon_id: str) -> PlayerWeapon:
@@ -221,7 +242,10 @@ class WeaponService:
         session.add(player_weapon)
 
         # 後方互換性のため MobileSuit.weapons も更新する
-        weapon_obj = Weapon(**player_weapon.base_snapshot)
+        # （base_snapshot + custom_stats をマージした実効スペックを書き込む）
+        weapon_obj = WeaponService.apply_effective_spec(
+            player_weapon.base_snapshot, player_weapon.custom_stats
+        )
         new_weapons = list(mobile_suit.weapons or [])
         if slot_index >= len(new_weapons):
             new_weapons.append(weapon_obj)

--- a/backend/app/services/weapon_service.py
+++ b/backend/app/services/weapon_service.py
@@ -24,20 +24,22 @@ class WeaponService:
     """武器インスタンスを操作するサービス."""
 
     @staticmethod
-    def apply_effective_spec(base_snapshot: dict, custom_stats: dict) -> Weapon:
+    def apply_effective_spec(base_snapshot: dict, custom_stats: dict | None) -> Weapon:
         """base_snapshot に custom_stats の強化・改造差分をマージした実効スペックを計算する.
 
         custom_stats にキーが欠損している場合は WeaponCustomStats のデフォルト
         （0 / 未変更）として扱うため、既存の空 `{}` の行も安全にマージできる。
+        `player_weapons.custom_stats` カラムは nullable のため、DB上で `None` の
+        行が存在しうる（`None` も空 `{}` と同等に扱う）。
 
         Args:
             base_snapshot: 購入時の Weapon スペックスナップショット
-            custom_stats: 強化・改造による差分（PlayerWeapon.custom_stats）
+            custom_stats: 強化・改造による差分（PlayerWeapon.custom_stats）。None可
 
         Returns:
             Weapon: base_snapshot + custom_stats をマージした実効スペック
         """
-        diff = WeaponCustomStats(**custom_stats)
+        diff = WeaponCustomStats(**(custom_stats or {}))
         merged = dict(base_snapshot)
         merged["power"] = merged.get("power", 0) + diff.power_bonus
         merged["accuracy"] = merged.get("accuracy", 0.0) + diff.accuracy_bonus

--- a/backend/tests/test_weapon_shop.py
+++ b/backend/tests/test_weapon_shop.py
@@ -1040,3 +1040,61 @@ def test_unequip_weapon_via_service(client, session):
 
     assert result.equipped_ms_id is None
     assert result.equipped_slot is None
+
+
+def test_equip_weapon_reflects_custom_stats_bonus_in_mobile_suit_weapons(
+    client, session
+):
+    """装備時、custom_stats の改造差分がマージされた実効値が MobileSuit.weapons に書き込まれることをテスト."""
+    test_user_id = "test_user_equip_custom_stats"
+    pilot = Pilot(
+        user_id=test_user_id,
+        name="Test Pilot",
+        level=1,
+        exp=0,
+        credits=1000,
+    )
+    session.add(pilot)
+
+    mobile_suit = MobileSuit(
+        user_id=test_user_id,
+        name="Test Zaku",
+        max_hp=800,
+        current_hp=800,
+        armor=50,
+        mobility=1.0,
+        weapons=[],
+        side="PLAYER",
+    )
+    session.add(mobile_suit)
+
+    from app.core.gamedata import get_weapon_listing_by_id
+
+    weapon_data = get_weapon_listing_by_id("zaku_mg")
+    base_power = weapon_data["weapon"].model_dump()["power"]
+
+    player_weapon = PlayerWeapon(
+        user_id=test_user_id,
+        master_weapon_id="zaku_mg",
+        base_snapshot=weapon_data["weapon"].model_dump(),
+        custom_stats={"power_bonus": 15, "accuracy_bonus": 3.0},
+    )
+    session.add(player_weapon)
+    session.commit()
+    session.refresh(mobile_suit)
+    session.refresh(player_weapon)
+
+    app.dependency_overrides[get_current_user] = lambda: test_user_id
+
+    try:
+        response = client.put(
+            f"/api/mobile_suits/{mobile_suit.id}/equip",
+            json={"player_weapon_id": str(player_weapon.id), "slot_index": 0},
+        )
+
+        assert response.status_code == status.HTTP_200_OK
+
+        data = response.json()
+        assert data["weapons"][0]["power"] == base_power + 15
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)

--- a/backend/tests/unit/test_weapon_custom_stats.py
+++ b/backend/tests/unit/test_weapon_custom_stats.py
@@ -1,0 +1,37 @@
+"""WeaponService.apply_effective_spec（custom_stats マージ）のユニットテスト."""
+
+from app.services.weapon_service import WeaponService
+
+BASE_SNAPSHOT = {
+    "id": "zaku_mg",
+    "name": "ザク・マシンガン",
+    "power": 50,
+    "range": 400.0,
+    "accuracy": 80.0,
+}
+
+
+def test_apply_effective_spec_with_empty_custom_stats_returns_base_values() -> None:
+    """custom_stats が空 {} の場合、base_snapshot の値がそのまま使われる（既存データの後方互換）."""
+    weapon = WeaponService.apply_effective_spec(BASE_SNAPSHOT, {})
+
+    assert weapon.power == 50
+    assert weapon.accuracy == 80.0
+
+
+def test_apply_effective_spec_applies_power_and_accuracy_bonus() -> None:
+    """power_bonus / accuracy_bonus が base_snapshot の値に加算される."""
+    custom_stats = {"power_bonus": 10, "accuracy_bonus": 5.0}
+
+    weapon = WeaponService.apply_effective_spec(BASE_SNAPSHOT, custom_stats)
+
+    assert weapon.power == 60
+    assert weapon.accuracy == 85.0
+
+
+def test_apply_effective_spec_ignores_missing_keys_as_zero() -> None:
+    """一部のキーのみ存在する場合、欠損キーは0/未変更として扱われる."""
+    weapon = WeaponService.apply_effective_spec(BASE_SNAPSHOT, {"power_bonus": 20})
+
+    assert weapon.power == 70
+    assert weapon.accuracy == 80.0

--- a/backend/tests/unit/test_weapon_custom_stats.py
+++ b/backend/tests/unit/test_weapon_custom_stats.py
@@ -35,3 +35,11 @@ def test_apply_effective_spec_ignores_missing_keys_as_zero() -> None:
 
     assert weapon.power == 70
     assert weapon.accuracy == 80.0
+
+
+def test_apply_effective_spec_with_none_custom_stats_returns_base_values() -> None:
+    """custom_stats が None（DB上のnullable列由来）の場合も空 {} と同様に扱われる."""
+    weapon = WeaponService.apply_effective_spec(BASE_SNAPSHOT, None)
+
+    assert weapon.power == 50
+    assert weapon.accuracy == 80.0

--- a/docs/features/weapon-data-model.md
+++ b/docs/features/weapon-data-model.md
@@ -1,0 +1,105 @@
+# 武器データモデル（`master_weapons` / `player_weapons` / 改造差分）
+
+## 概要
+
+武器改造（強化）機能の実装に向けて、武器データモデルの整理を行った（Issue #404）。
+`PlayerWeapon.custom_stats` は以前から `player_weapons` テーブルの予約フィールドとして存在していたが、書き込み・読み取りロジックが一切なく常に空 `{}` だった。本Issueで `custom_stats` のスキーマを定義し、`base_snapshot + custom_stats` をマージして実効スペックを計算するロジックを実装した。
+
+本Issueは**データモデル整理が主目的**であり、UI（改造画面）の実装は別Issueに切り出す。
+
+---
+
+## テーブル構成
+
+```
+master_weapons (マスター武器定義)
+├── id: str                   ← スネークケースID (例: zaku_mg)
+├── name / price / description
+└── weapon: JSON               ← Weapon スペック本体
+
+player_weapons (プレイヤー武器インスタンス)
+├── id: UUID
+├── user_id: str                ← 所有者
+├── master_weapon_id: str       ← master_weapons への論理FK
+├── base_snapshot: JSON         ← 購入時の Weapon スペックスナップショット
+├── custom_stats: JSON          ← 強化・改造による差分（本Issueでスキーマ定義）
+├── equipped_ms_id / equipped_slot ← 装備状態の正
+└── acquired_at: datetime
+```
+
+`MobileSuit.weapons`（JSON列）はバトルエンジンが直接参照するためのスナップショットであり、装備操作のたびに `PlayerWeapon` の内容（`base_snapshot + custom_stats` のマージ結果）が dual-write される。装備状態やスペックの問い合わせは常に `PlayerWeapon` 側を正として使うこと。
+
+---
+
+## `weapon_power`（機体強化）と武器改造の関係 — 方針(b)を採用
+
+既存の機体強化機能 `EngineeringService` には `weapon_power` という強化項目があり、装備中の**全武器**の `MobileSuit.weapons[*].power` に一律加算する実装になっている（`_apply_weapon_power_upgrade`）。これは武器インスタンス単位ではなく機体のJSONスナップショットに乗っているため、武器を外す・付け替えると強化投資が失われるという既知の制約がある。
+
+本Issueでは、以下の理由から **`weapon_power` を武器インスタンス単位の `custom_stats` へ統合しない（方針(b)）** ことを決定した:
+
+- 過去に武器を付け替えたプレイヤーは、その時点で強化投資が既に失われている。現在の `MobileSuit.weapons[*].power` と `PlayerWeapon.base_snapshot` の差分は「現在装備中の武器」についてしか計算できず、正確な移行スクリプトを書けない
+- 既存データを破壊せずに済む安全な選択肢を優先した
+
+そのため `weapon_power` は「機体側のパイロット/システム補正」として用途を再定義し、`EngineeringService` の実装はそのまま維持する。武器インスタンス単位の改造（`custom_stats`）とは別軸の強化として、コード上のコメント・将来のUIコピーで明確に区別する（`EngineeringService` docstring 参照）。
+
+この決定に伴い、**Alembic マイグレーションは本Issueでは不要**（`custom_stats` は既存カラムで、スキーマ変更を伴わない）。
+
+---
+
+## `custom_stats` スキーマ
+
+`app/models/models.py` の `WeaponCustomStats`（`SQLModel`、テーブル定義ではなくスキーマ定義用）:
+
+| キー | 型 | デフォルト | 説明 |
+|---|---|---|---|
+| `power_bonus` | `int` | `0` | 威力への加算値 |
+| `accuracy_bonus` | `float` | `0.0` | 命中率への加算値(%) |
+| `upgrade_level` | `int` | `0` | 改造レベル（将来の改造ツリー・表示用、現状は算出に使用しない） |
+
+`custom_stats` カラム自体は引き続き自由形式の `dict`（JSON）。キー欠損時は `WeaponCustomStats` のデフォルト値（0/未変更）として扱われるため、既存の空 `{}` の行も安全にマージできる。
+
+---
+
+## 実効スペックのマージ
+
+`app/services/weapon_service.py` の `WeaponService.apply_effective_spec(base_snapshot, custom_stats) -> Weapon`:
+
+```python
+diff = WeaponCustomStats(**custom_stats)
+merged = dict(base_snapshot)
+merged["power"] = merged.get("power", 0) + diff.power_bonus
+merged["accuracy"] = merged.get("accuracy", 0.0) + diff.accuracy_bonus
+return Weapon(**merged)
+```
+
+`WeaponService.equip_weapon` は装備時、`MobileSuit.weapons` に書き込む値としてこのマージ結果を使用する（`base_snapshot` をそのまま書き込んでいた従来の実装から変更）。これにより、将来 `custom_stats` に改造差分が書き込まれるようになれば、装備し直すだけでバトルエンジン側にも反映される。
+
+現時点では `custom_stats` を書き込むAPI・UIは未実装のため、常に空 `{}` として扱われ、実質的な挙動は変化しない。
+
+---
+
+## 関連ファイル
+
+- `backend/app/models/models.py` — `WeaponCustomStats`、`PlayerWeapon.custom_stats` の docstring 更新
+- `backend/app/services/weapon_service.py` — `apply_effective_spec` 追加、`equip_weapon` を更新
+- `backend/app/services/engineering_service.py` — `weapon_power` の位置づけをdocstringで明記
+- `backend/tests/unit/test_weapon_custom_stats.py` — マージロジックのユニットテスト
+- `backend/tests/test_weapon_shop.py` — 装備フローで改造差分が反映されることのテスト（`test_equip_weapon_reflects_custom_stats_bonus_in_mobile_suit_weapons`）
+- `frontend/src/types/shop.ts` — `WeaponCustomStats` 型、`PlayerWeapon.custom_stats` の型を具体化
+
+---
+
+## 今後の拡張（別Issue）
+
+- 武器改造UI（強化メニュー、コスト定義、`custom_stats` への書き込みAPI）
+- `docs/features/garage-weapon-inventory.md` の所持武器一覧に改造状態（`custom_stats` 由来の差分）を表示する拡張
+- 改造の種類・コスト体系をマスターデータ化するかどうかの検討（現状は本Issueの対象外）
+
+---
+
+## テスト
+
+```bash
+cd backend && python -m pytest tests/unit/test_weapon_custom_stats.py tests/test_weapon_shop.py --tb=short
+cd frontend && ./node_modules/.bin/tsc --noEmit
+```

--- a/frontend/src/types/shop.ts
+++ b/frontend/src/types/shop.ts
@@ -97,12 +97,23 @@ export interface EquipWeaponRequest {
     slot_index?: number;
 }
 
+/**
+ * 武器インスタンスの強化・改造差分（Issue #404）。
+ * キー欠損時はバックエンド側で0/未変更として扱われる（既存の空 `{}` も安全）。
+ * `weapon_power`（機体強化、`EngineeringService` 管理）とは別軸の武器個別改造。
+ */
+export interface WeaponCustomStats {
+    power_bonus?: number;
+    accuracy_bonus?: number;
+    upgrade_level?: number;
+}
+
 /** プレイヤーが所有する武器インスタンス（マスターとは別に個別強化データを持つ） */
 export interface PlayerWeapon {
     id: string;
     master_weapon_id: string;
     base_snapshot: Record<string, unknown>;
-    custom_stats: Record<string, unknown>;
+    custom_stats: WeaponCustomStats;
     equipped_ms_id: string | null;
     equipped_slot: number | null;
     acquired_at: string;


### PR DESCRIPTION
## 概要

Issue #404 の対応。武器改造（強化）機能に向けたデータモデル整理を行った。実装方針の決定を含む調査重視のIssueであり、本PRではUIの実装は含まない（別Issueで対応）。

## 方針決定（Issue内で意思決定）

`weapon_power`（機体強化、`EngineeringService`）と `PlayerWeapon.custom_stats`（武器インスタンス改造）の関係について **方針(b)** を採用した:

- `weapon_power` を `custom_stats` へ統合しない。「機体側のパイロット/システム補正」として維持し、武器インスタンス単位の改造とは別軸として区別する
- 理由: 過去に武器を付け替えたプレイヤーは既に強化投資を失っており、現在装備中の武器についてのみ正確な差分移行が可能なため、既存プレイヤーの資産を破壊するリスクを避けた
- 詳細な判断根拠は Issue #404 のコメントに記録済み

この決定に伴い、`custom_stats` は既存カラムのままスキーマ変更を伴わないため **Alembicマイグレーションは不要**。

## 変更内容

- `WeaponCustomStats`（`power_bonus: int` / `accuracy_bonus: float` / `upgrade_level: int`）を定義し、`PlayerWeapon.custom_stats` の想定スキーマを明示
- `WeaponService.apply_effective_spec(base_snapshot, custom_stats) -> Weapon` を実装。キー欠損時は0/未変更として扱われるため既存の空 `{}` データも安全
- `WeaponService.equip_weapon` が装備時、`MobileSuit.weapons` への書き込みに `apply_effective_spec` のマージ結果を使用するよう変更（従来は `base_snapshot` をそのまま書き込んでいた）
- `EngineeringService` に `weapon_power` の位置づけ（方針(b)）を明記
- フロントエンド `PlayerWeapon.custom_stats` 型を `Record<string, unknown>` から `WeaponCustomStats` 型に具体化
- `docs/features/weapon-data-model.md` を新規作成し、武器データモデル全体の設計を文書化

## テスト

- [x] `cd backend && python -m pytest tests/unit/test_weapon_custom_stats.py tests/test_weapon_shop.py --tb=short` — マージロジック・装備フローの新規/既存テスト
- [x] `cd backend && python -m pytest` — バックエンド全テスト
- [x] `cd backend && ruff check . && mypy .`（pre-commit hookで実行済み）
- [x] `cd frontend && ./node_modules/.bin/tsc --noEmit` — 型チェック
- [x] `cd frontend && npx vitest run tests/unit/` — フロントエンド既存テスト

## Test plan

- [x] `apply_effective_spec` が custom_stats 空/一部欠損/全指定の各ケースで正しくマージすること
- [x] 装備フロー（`PUT /api/mobile_suits/{ms_id}/equip`）が custom_stats の改造差分を反映した実効値を `MobileSuit.weapons` に書き込むこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)