### PR TITLE
feat: プレイヤー所持武器の改造(強化)機能を実装

### DIFF
--- a/backend/CLAUDE.md
+++ b/backend/CLAUDE.md
@@ -87,12 +87,12 @@ attacker_dex = 0  # DEX は廃止（Phase E-1: SHT/MEL に置換）
 
 - `id`（UUID）/ `user_id` / `master_weapon_id`（`master_weapons` への論理FK）
 - `base_snapshot`: 購入時点の `Weapon` スペックのスナップショット（JSON）
-- `custom_stats`: **強化・改造による差分を持たせるための予約フィールド。現状は常に空 `{}` で、読み書きするロジックは未実装**（将来の武器改造機能で `base_snapshot + custom_stats` をマージして実効スペックを計算する設計を想定）
+- `custom_stats`: 強化・改造による差分（`power_bonus` / `accuracy_bonus` / `upgrade_level`、スキーマは `WeaponCustomStats`）。`WeaponEngineeringService`（`app/services/weapon_engineering_service.py`、Issue #411）が改造ロジックを担い、`pilot.credits` を消費して段階強化する。上限は base値に対する倍率（`power_bonus` は200%、`accuracy_bonus` は130%）。実効スペックは `WeaponService.apply_effective_spec` で `base_snapshot + custom_stats` をマージして計算する
 - `equipped_ms_id` / `equipped_slot`: 装備状態の正。`UniqueConstraint(equipped_ms_id, equipped_slot)` で1スロット1武器を担保
 
-一方で `MobileSuit.weapons`（JSON列）は**バトルエンジンが直接参照するためのスナップショットのリスト**であり、装備操作のたびに `PlayerWeapon` の内容から書き込まれる（dual-write）。装備状態を問い合わせる/表示する処理は必ず `PlayerWeapon.equipped_ms_id`/`equipped_slot` を正として使うこと。
+一方で `MobileSuit.weapons`（JSON列）は**バトルエンジンが直接参照するためのスナップショットのリスト**であり、装備操作のたびに `PlayerWeapon` の内容から書き込まれる（dual-write）。装備状態を問い合わせる/表示する処理は必ず `PlayerWeapon.equipped_ms_id`/`equipped_slot` を正として使うこと。装備中の武器を改造した場合は dual-write だけでは反映されないため、`WeaponService.resync_mobile_suit_weapons` がバトルエントリー登録時（`app/routers/entries.py`）に再同期している。
 
-**既知の設計上の矛盾**: `EngineeringService`（`app/services/engineering_service.py`）の `weapon_power` 強化項目は、`PlayerWeapon` インスタンス単位ではなく `MobileSuit.weapons` の**全スロットに一律加算**する実装になっている（`_apply_weapon_power_upgrade`）。そのため武器を外す・付け替えると強化投資が失われ、`PlayerWeapon.custom_stats` を正とする将来の武器インスタンス単位の改造機能とは非互換。武器改造機能を実装する際は、この既存の `weapon_power` 強化との関係（統合するか、別軸の強化として維持するか）を先に決める必要がある。
+**`weapon_power`（機体強化）との関係**: `EngineeringService`（`app/services/engineering_service.py`）の `weapon_power` 強化項目は、`PlayerWeapon` インスタンス単位ではなく `MobileSuit.weapons` の**全スロットに一律加算**する実装（`_apply_weapon_power_upgrade`）のまま維持されている。武器を外す・付け替えると強化投資が失われるが、これは「機体側のパイロット/システム補正」として意図的に武器インスタンス単位の改造（`custom_stats`）とは別軸として維持する方針（Issue #404 で決定、方針(b)）。詳細は `docs/features/weapon-data-model.md` を参照。
 
 ## コーディング規約
 `Agent.md` の `4. コーディング規約`を参照してください。

--- a/backend/app/routers/entries.py
+++ b/backend/app/routers/entries.py
@@ -112,10 +112,11 @@ async def create_entry(
 
     # 装備中の武器改造差分（PlayerWeapon.custom_stats）をバトル開始前に反映する
     # （再装備なしでも改造結果がバトルエンジンに渡るようにするため。Issue #411）
+    # ここでは commit しない。以降の mobile_suit_snapshot（model_dump）に
+    # in-memory の状態を反映させれば十分で、永続化は既存エントリー作成/更新の
+    # commit にまとめて含める（余計なトランザクションを増やさないため）。
     WeaponService.resync_mobile_suit_weapons(session, mobile_suit)
     session.add(mobile_suit)
-    session.commit()
-    session.refresh(mobile_suit)
 
     # 現在募集中のルームを取得または作成
     room = get_or_create_open_room(session)

--- a/backend/app/routers/entries.py
+++ b/backend/app/routers/entries.py
@@ -11,6 +11,7 @@ from sqlmodel import Session, select
 from app.core.auth import get_current_user
 from app.db import get_session
 from app.models.models import BattleEntry, BattleRoom, MobileSuit
+from app.services.weapon_service import WeaponService
 
 router = APIRouter(prefix="/api/entries", tags=["entries"])
 
@@ -108,6 +109,13 @@ async def create_entry(
     mobile_suit = session.get(MobileSuit, mobile_suit_uuid)
     if not mobile_suit:
         raise HTTPException(status_code=404, detail="Mobile Suit not found")
+
+    # 装備中の武器改造差分（PlayerWeapon.custom_stats）をバトル開始前に反映する
+    # （再装備なしでも改造結果がバトルエンジンに渡るようにするため。Issue #411）
+    WeaponService.resync_mobile_suit_weapons(session, mobile_suit)
+    session.add(mobile_suit)
+    session.commit()
+    session.refresh(mobile_suit)
 
     # 現在募集中のルームを取得または作成
     room = get_or_create_open_room(session)

--- a/backend/app/routers/player_weapons.py
+++ b/backend/app/routers/player_weapons.py
@@ -124,8 +124,17 @@ def upgrade_player_weapon(
         WeaponUpgradeResponse: 更新後の武器インスタンス、残クレジット、消費コスト
 
     Raises:
-        HTTPException: パイロットが見つからない、上限到達、所持金不足などのエラー
+        HTTPException: パイロットが見つからない、武器が見つからない、権限なし、
+            上限到達、所持金不足などのエラー
     """
+    player_weapon = session.get(PlayerWeapon, pw_id)
+    if not player_weapon:
+        raise HTTPException(status_code=404, detail="武器インスタンスが見つかりません")
+    if player_weapon.user_id != user_id:
+        raise HTTPException(
+            status_code=403, detail="この武器インスタンスへのアクセス権がありません"
+        )
+
     statement = select(Pilot).where(Pilot.user_id == user_id)
     pilot = session.exec(statement).first()
     if not pilot:

--- a/backend/app/routers/player_weapons.py
+++ b/backend/app/routers/player_weapons.py
@@ -3,14 +3,43 @@
 import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, Query
-from sqlmodel import Session
+from pydantic import BaseModel
+from sqlmodel import Session, select
 
 from app.core.auth import get_current_user
 from app.db import get_session
-from app.models.models import PlayerWeapon, PlayerWeaponResponse
+from app.models.models import Pilot, PlayerWeapon, PlayerWeaponResponse
+from app.services.weapon_engineering_service import WeaponEngineeringService
 from app.services.weapon_service import WeaponService
 
 router = APIRouter(prefix="/api/player-weapons", tags=["player_weapons"])
+
+
+class WeaponUpgradeRequest(BaseModel):
+    """武器改造リクエスト."""
+
+    target_stat: str  # "power_bonus" or "accuracy_bonus"
+    steps: int = 1
+
+
+class WeaponUpgradeResponse(BaseModel):
+    """武器改造レスポンス."""
+
+    message: str
+    player_weapon: PlayerWeaponResponse
+    remaining_credits: int
+    cost_paid: int
+
+
+class WeaponUpgradePreviewResponse(BaseModel):
+    """武器改造プレビューレスポンス."""
+
+    player_weapon_id: str
+    stat_type: str
+    current_value: int | float
+    new_value: int | float
+    cost: int
+    at_max_cap: bool
 
 
 @router.get("", response_model=list[PlayerWeaponResponse])
@@ -71,3 +100,100 @@ def delete_player_weapon(
 
     session.delete(player_weapon)
     session.commit()
+
+
+@router.post("/{pw_id}/upgrade", response_model=WeaponUpgradeResponse)
+def upgrade_player_weapon(
+    pw_id: uuid.UUID,
+    request: WeaponUpgradeRequest,
+    session: Session = Depends(get_session),
+    user_id: str = Depends(get_current_user),
+) -> WeaponUpgradeResponse:
+    """武器インスタンスの custom_stats（power_bonus / accuracy_bonus）を改造する.
+
+    未装備の武器も改造可能。装備中の武器を改造した場合、バトル開始時に
+    再同期される（再装備は不要）。
+
+    Args:
+        pw_id: 改造対象の PlayerWeapon の UUID
+        request: 改造対象パラメータとステップ数
+        session: データベースセッション
+        user_id: 現在のユーザーID
+
+    Returns:
+        WeaponUpgradeResponse: 更新後の武器インスタンス、残クレジット、消費コスト
+
+    Raises:
+        HTTPException: パイロットが見つからない、上限到達、所持金不足などのエラー
+    """
+    statement = select(Pilot).where(Pilot.user_id == user_id)
+    pilot = session.exec(statement).first()
+    if not pilot:
+        raise HTTPException(status_code=404, detail="パイロット情報が見つかりません")
+
+    service = WeaponEngineeringService(session)
+
+    try:
+        updated_pw, updated_pilot, cost = service.upgrade_stat(
+            str(pw_id), request.target_stat, pilot, request.steps
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+    except RuntimeError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+    return WeaponUpgradeResponse(
+        message="武器を改造しました！",
+        player_weapon=PlayerWeaponResponse.model_validate(updated_pw.model_dump()),
+        remaining_credits=updated_pilot.credits,
+        cost_paid=cost,
+    )
+
+
+@router.get(
+    "/{pw_id}/upgrade-preview/{stat_type}",
+    response_model=WeaponUpgradePreviewResponse,
+)
+def get_weapon_upgrade_preview(
+    pw_id: uuid.UUID,
+    stat_type: str,
+    session: Session = Depends(get_session),
+    user_id: str = Depends(get_current_user),
+) -> WeaponUpgradePreviewResponse:
+    """次の1ステップ改造した場合のコスト・変化後スペックのプレビューを返す.
+
+    Args:
+        pw_id: 対象の PlayerWeapon の UUID
+        stat_type: "power_bonus" または "accuracy_bonus"
+        session: データベースセッション
+        user_id: 現在のユーザーID
+
+    Returns:
+        WeaponUpgradePreviewResponse: 現在値・改造後の値・コスト・上限到達フラグ
+
+    Raises:
+        HTTPException: 武器が見つからない、権限なし、stat_type不正などのエラー
+    """
+    player_weapon = session.get(PlayerWeapon, pw_id)
+    if not player_weapon:
+        raise HTTPException(status_code=404, detail="武器インスタンスが見つかりません")
+    if player_weapon.user_id != user_id:
+        raise HTTPException(
+            status_code=403, detail="この武器インスタンスへのアクセス権がありません"
+        )
+
+    service = WeaponEngineeringService(session)
+
+    try:
+        preview = service.get_upgrade_preview(str(pw_id), stat_type)
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+    return WeaponUpgradePreviewResponse(
+        player_weapon_id=str(pw_id),
+        stat_type=stat_type,
+        current_value=preview["current_value"],
+        new_value=preview["new_value"],
+        cost=preview["cost"],
+        at_max_cap=preview["at_max_cap"],
+    )

--- a/backend/app/services/weapon_engineering_service.py
+++ b/backend/app/services/weapon_engineering_service.py
@@ -1,0 +1,248 @@
+"""Engineering service for player weapon instance upgrades (custom_stats)."""
+
+import uuid
+from typing import NamedTuple
+
+from sqlalchemy.orm import attributes
+from sqlmodel import Session
+
+from app.models.models import Pilot, PlayerWeapon, WeaponCustomStats
+
+
+class _WeaponStatConfig(NamedTuple):
+    """Configuration for a custom_stats upgrade target."""
+
+    key: str
+    base_field: str
+    increment: int | float
+    cap_multiplier: float
+    base_cost: int
+    divisor: float
+    label: str
+
+
+class WeaponEngineeringService:
+    """Service for upgrading PlayerWeapon.custom_stats using Credits.
+
+    NOTE (Issue #411): ``weapon_power``（機体側のパイロット/システム補正、
+    ``EngineeringService`` 管理）とは別軸の、武器インスタンス単位の改造
+    （``PlayerWeapon.custom_stats``）を扱う。武器を外す・付け替えても改造投資は
+    失われない（PlayerWeapon に紐づくため）。未装備の武器も改造可能。
+    """
+
+    POWER_INCREASE = 5
+    ACCURACY_INCREASE = 1.0
+
+    # 上限キャップは base値（base_snapshot）に対する倍率
+    # 例: power_bonus は実効値(base + bonus)が base の 200% に達するまで、
+    #     accuracy_bonus は 130% に達するまで改造可能
+    POWER_CAP_MULTIPLIER = 2.0
+    ACCURACY_CAP_MULTIPLIER = 1.3
+
+    BASE_POWER_COST = 60
+    BASE_ACCURACY_COST = 100
+
+    _STAT_CONFIGS: dict[str, _WeaponStatConfig] = {
+        "power_bonus": _WeaponStatConfig(
+            key="power_bonus",
+            base_field="power",
+            increment=POWER_INCREASE,
+            cap_multiplier=POWER_CAP_MULTIPLIER,
+            base_cost=BASE_POWER_COST,
+            divisor=30.0,
+            label="威力",
+        ),
+        "accuracy_bonus": _WeaponStatConfig(
+            key="accuracy_bonus",
+            base_field="accuracy",
+            increment=ACCURACY_INCREASE,
+            cap_multiplier=ACCURACY_CAP_MULTIPLIER,
+            base_cost=BASE_ACCURACY_COST,
+            divisor=5.0,
+            label="命中率",
+        ),
+    }
+
+    def __init__(self, session: Session):
+        """Initialize the weapon engineering service.
+
+        Args:
+            session: Database session
+        """
+        self.session = session
+
+    @classmethod
+    def calculate_upgrade_cost(cls, stat_type: str, current_bonus: int | float) -> int:
+        """Calculate upgrade cost based on the current bonus value.
+
+        Args:
+            stat_type: "power_bonus" or "accuracy_bonus"
+            current_bonus: Current bonus value for the stat
+
+        Returns:
+            Cost in Credits for the next upgrade step
+
+        Raises:
+            ValueError: If stat_type is invalid
+        """
+        cfg = cls._STAT_CONFIGS.get(stat_type)
+        if cfg is None:
+            raise ValueError(
+                f"Invalid stat type: {stat_type}. "
+                "Must be one of: power_bonus, accuracy_bonus"
+            )
+        multiplier = 1 + (current_bonus / cfg.divisor)
+        return int(cfg.base_cost * multiplier)
+
+    @staticmethod
+    def _get_player_weapon(session: Session, player_weapon_id: str) -> PlayerWeapon:
+        pw_id = (
+            uuid.UUID(player_weapon_id)
+            if isinstance(player_weapon_id, str)
+            else player_weapon_id
+        )
+        player_weapon = session.get(PlayerWeapon, pw_id)
+        if not player_weapon:
+            raise ValueError("武器インスタンスが見つかりません")
+        return player_weapon
+
+    def _validate_and_get_cost(
+        self, player_weapon: PlayerWeapon, stat_type: str
+    ) -> tuple[int | float, int]:
+        """Validate cap and compute the cost for the next upgrade step.
+
+        Args:
+            player_weapon: Target weapon instance
+            stat_type: "power_bonus" or "accuracy_bonus"
+
+        Returns:
+            tuple[int | float, int]: Current bonus value and cost
+
+        Raises:
+            ValueError: If stat is at max cap or invalid
+        """
+        cfg = self._STAT_CONFIGS.get(stat_type)
+        if cfg is None:
+            raise ValueError(
+                f"Invalid stat type: {stat_type}. "
+                "Must be one of: power_bonus, accuracy_bonus"
+            )
+
+        base_value = player_weapon.base_snapshot.get(cfg.base_field, 0)
+        current_stats = WeaponCustomStats(**(player_weapon.custom_stats or {}))
+        current_bonus = getattr(current_stats, stat_type)
+
+        cap = base_value * cfg.cap_multiplier
+        if base_value + current_bonus >= cap:
+            raise ValueError(f"{cfg.label}は既に上限に達しています（上限: {cap}）")
+
+        cost = self.calculate_upgrade_cost(stat_type, current_bonus)
+        return current_bonus, cost
+
+    def _apply_upgrade(self, player_weapon: PlayerWeapon, stat_type: str) -> None:
+        """Apply one upgrade step to the weapon's custom_stats.
+
+        Args:
+            player_weapon: Target weapon instance
+            stat_type: "power_bonus" or "accuracy_bonus"
+        """
+        cfg = self._STAT_CONFIGS[stat_type]
+        base_value = player_weapon.base_snapshot.get(cfg.base_field, 0)
+        cap = base_value * cfg.cap_multiplier
+
+        current_stats = dict(player_weapon.custom_stats or {})
+        current_bonus = getattr(WeaponCustomStats(**current_stats), stat_type)
+        # 実効値(base + bonus)がキャップを超えないよう bonus 側で丸める
+        new_bonus = min(current_bonus + cfg.increment, cap - base_value)
+
+        current_stats[stat_type] = new_bonus
+        player_weapon.custom_stats = current_stats
+        attributes.flag_modified(player_weapon, "custom_stats")
+
+    def upgrade_stat(
+        self,
+        player_weapon_id: str,
+        stat_type: str,
+        pilot: Pilot,
+        steps: int = 1,
+    ) -> tuple[PlayerWeapon, Pilot, int]:
+        """Upgrade a specific custom_stats field of a player weapon.
+
+        All cost calculation and cap validation is performed server-side for each
+        step so that client-supplied values are never trusted. Unequipped weapons
+        can be upgraded as well.
+
+        Args:
+            player_weapon_id: ID of the PlayerWeapon to upgrade
+            stat_type: "power_bonus" or "accuracy_bonus"
+            pilot: Pilot who owns the weapon
+            steps: Number of upgrade steps to apply (default 1)
+
+        Returns:
+            tuple[PlayerWeapon, Pilot, int]: Updated weapon, pilot, and total cost
+
+        Raises:
+            ValueError: If stat is at max cap, invalid parameters, or steps < 1
+            RuntimeError: If insufficient credits
+        """
+        if steps < 1:
+            raise ValueError("steps must be at least 1")
+
+        player_weapon = self._get_player_weapon(self.session, player_weapon_id)
+
+        if player_weapon.user_id != pilot.user_id:
+            raise ValueError("この武器インスタンスへのアクセス権がありません")
+
+        total_cost = 0
+        for _ in range(steps):
+            _, cost = self._validate_and_get_cost(player_weapon, stat_type)
+
+            if pilot.credits < cost:
+                raise RuntimeError(
+                    f"Insufficient credits. Required: {cost}, Available: {pilot.credits}"
+                )
+
+            pilot.credits -= cost
+            total_cost += cost
+            self._apply_upgrade(player_weapon, stat_type)
+
+        self.session.add(player_weapon)
+        self.session.add(pilot)
+        self.session.commit()
+        self.session.refresh(player_weapon)
+        self.session.refresh(pilot)
+
+        return player_weapon, pilot, total_cost
+
+    def get_upgrade_preview(self, player_weapon_id: str, stat_type: str) -> dict:
+        """Get a preview of what the next upgrade step would do.
+
+        Args:
+            player_weapon_id: ID of the PlayerWeapon
+            stat_type: "power_bonus" or "accuracy_bonus"
+
+        Returns:
+            dict with current_value, new_value, cost, and at_max_cap
+
+        Raises:
+            ValueError: If the weapon is not found or stat_type is invalid
+        """
+        player_weapon = self._get_player_weapon(self.session, player_weapon_id)
+
+        cfg = self._STAT_CONFIGS.get(stat_type)
+        if cfg is None:
+            raise ValueError(f"Invalid stat type: {stat_type}")
+
+        base_value = player_weapon.base_snapshot.get(cfg.base_field, 0)
+        current_stats = WeaponCustomStats(**(player_weapon.custom_stats or {}))
+        current_bonus = getattr(current_stats, stat_type)
+        cap = base_value * cfg.cap_multiplier
+
+        new_bonus = min(current_bonus + cfg.increment, cap - base_value)
+
+        return {
+            "current_value": current_bonus,
+            "new_value": new_bonus,
+            "cost": self.calculate_upgrade_cost(stat_type, current_bonus),
+            "at_max_cap": base_value + current_bonus >= cap,
+        }

--- a/backend/app/services/weapon_service.py
+++ b/backend/app/services/weapon_service.py
@@ -46,6 +46,35 @@ class WeaponService:
         return Weapon(**merged)
 
     @staticmethod
+    def resync_mobile_suit_weapons(session: Session, mobile_suit: MobileSuit) -> None:
+        """装備中の全 PlayerWeapon の実効スペックで MobileSuit.weapons を再同期する.
+
+        装備中の武器を改造（custom_stats 更新）しても、equip_weapon 実行時の
+        dual-write のみでは MobileSuit.weapons に改造差分が反映されない。
+        バトル開始前など、実効値の反映が必要なタイミングで呼び出すことで
+        再装備なしに改造差分をバトルエンジンへ反映できる（Issue #411）。
+
+        Args:
+            session: データベースセッション
+            mobile_suit: 再同期対象の機体（呼び出し元で add/commit すること）
+        """
+        equipped_stmt = select(PlayerWeapon).where(
+            PlayerWeapon.equipped_ms_id == mobile_suit.id
+        )
+        equipped_weapons = session.exec(equipped_stmt).all()
+        if not equipped_weapons:
+            return
+
+        new_weapons = list(mobile_suit.weapons or [])
+        for pw in equipped_weapons:
+            if pw.equipped_slot is None or pw.equipped_slot >= len(new_weapons):
+                continue
+            new_weapons[pw.equipped_slot] = WeaponService.apply_effective_spec(
+                pw.base_snapshot, pw.custom_stats
+            )
+        mobile_suit.weapons = new_weapons
+
+    @staticmethod
     def purchase_weapon(session: Session, user_id: str, weapon_id: str) -> PlayerWeapon:
         """武器を購入して PlayerWeapon 行を INSERT する.
 

--- a/backend/tests/test_weapon_engineering.py
+++ b/backend/tests/test_weapon_engineering.py
@@ -210,6 +210,46 @@ def test_upgrade_api_endpoint_at_max_cap_returns_400(
         app.dependency_overrides.pop(get_current_user, None)
 
 
+def test_upgrade_api_endpoint_weapon_not_found_returns_404(
+    client, session, pilot: Pilot
+):
+    """存在しない武器IDを指定した場合、改造APIは404を返す(所有権エラーの400と区別)."""
+    app.dependency_overrides[get_current_user] = lambda: pilot.user_id
+    try:
+        response = client.post(
+            "/api/player-weapons/00000000-0000-0000-0000-000000000000/upgrade",
+            json={"target_stat": "power_bonus", "steps": 1},
+        )
+        assert response.status_code == status.HTTP_404_NOT_FOUND
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
+def test_upgrade_api_endpoint_other_users_weapon_returns_403(
+    client, session, player_weapon: PlayerWeapon
+):
+    """他人の武器を改造しようとした場合、改造APIは403を返す."""
+    other_pilot = Pilot(
+        user_id="weapon_eng_other_user",
+        name="Other Pilot",
+        level=1,
+        exp=0,
+        credits=100000,
+    )
+    session.add(other_pilot)
+    session.commit()
+
+    app.dependency_overrides[get_current_user] = lambda: other_pilot.user_id
+    try:
+        response = client.post(
+            f"/api/player-weapons/{player_weapon.id}/upgrade",
+            json={"target_stat": "power_bonus", "steps": 1},
+        )
+        assert response.status_code == status.HTTP_403_FORBIDDEN
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
 def test_upgrade_preview_api_endpoint(
     client, session, pilot: Pilot, player_weapon: PlayerWeapon
 ):

--- a/backend/tests/test_weapon_engineering.py
+++ b/backend/tests/test_weapon_engineering.py
@@ -1,0 +1,292 @@
+"""武器改造(WeaponEngineeringService)のテスト."""
+
+import pytest
+from fastapi import status
+from sqlmodel import Session
+
+from app.core.auth import get_current_user
+from app.models.models import MobileSuit, Pilot, PlayerWeapon
+from app.services.weapon_engineering_service import WeaponEngineeringService
+from main import app
+
+
+@pytest.fixture
+def pilot(session: Session) -> Pilot:
+    """テスト用パイロット."""
+    pilot = Pilot(
+        user_id="weapon_eng_test_user",
+        name="Test Pilot",
+        level=1,
+        exp=0,
+        credits=100000,
+    )
+    session.add(pilot)
+    session.commit()
+    session.refresh(pilot)
+    return pilot
+
+
+@pytest.fixture
+def player_weapon(session: Session, pilot: Pilot) -> PlayerWeapon:
+    """未装備のテスト用武器インスタンス（power=100, accuracy=60）."""
+    pw = PlayerWeapon(
+        user_id=pilot.user_id,
+        master_weapon_id="zaku_mg",
+        base_snapshot={
+            "power": 100,
+            "range": 400,
+            "accuracy": 60,
+            "type": "PHYSICAL",
+        },
+        custom_stats={},
+    )
+    session.add(pw)
+    session.commit()
+    session.refresh(pw)
+    return pw
+
+
+def test_calculate_upgrade_cost_power_bonus() -> None:
+    """power_bonus のコスト計算式を検証."""
+    cost = WeaponEngineeringService.calculate_upgrade_cost("power_bonus", 0)
+    assert cost == 60  # int(60 * (1 + 0/30))
+
+    cost_after = WeaponEngineeringService.calculate_upgrade_cost("power_bonus", 30)
+    assert cost_after == 120  # int(60 * (1 + 30/30))
+
+
+def test_calculate_upgrade_cost_invalid_stat() -> None:
+    """未知の stat_type は ValueError."""
+    with pytest.raises(ValueError, match="Invalid stat type"):
+        WeaponEngineeringService.calculate_upgrade_cost("upgrade_level", 0)
+
+
+def test_upgrade_power_bonus_unequipped_weapon(
+    session: Session, pilot: Pilot, player_weapon: PlayerWeapon
+) -> None:
+    """未装備の武器でも改造でき、custom_stats.power_bonus が加算されることを確認."""
+    service = WeaponEngineeringService(session)
+    initial_credits = pilot.credits
+
+    updated_pw, updated_pilot, cost = service.upgrade_stat(
+        str(player_weapon.id), "power_bonus", pilot
+    )
+
+    assert updated_pw.custom_stats["power_bonus"] == 5
+    assert updated_pilot.credits == initial_credits - cost
+    assert cost == 60
+
+
+def test_upgrade_accuracy_bonus(
+    session: Session, pilot: Pilot, player_weapon: PlayerWeapon
+) -> None:
+    """accuracy_bonus の改造で custom_stats が更新されることを確認."""
+    service = WeaponEngineeringService(session)
+
+    updated_pw, _, _ = service.upgrade_stat(
+        str(player_weapon.id), "accuracy_bonus", pilot, steps=2
+    )
+
+    assert updated_pw.custom_stats["accuracy_bonus"] == pytest.approx(2.0)
+
+
+def test_upgrade_power_bonus_respects_cap(
+    session: Session, pilot: Pilot, player_weapon: PlayerWeapon
+) -> None:
+    """power_bonus は base値(100)の200%、つまり bonus上限100で頭打ちになることを確認."""
+    player_weapon.custom_stats = {"power_bonus": 99}
+    session.add(player_weapon)
+    session.commit()
+    session.refresh(player_weapon)
+
+    service = WeaponEngineeringService(session)
+    updated_pw, _, _ = service.upgrade_stat(str(player_weapon.id), "power_bonus", pilot)
+    assert updated_pw.custom_stats["power_bonus"] == 100
+
+    with pytest.raises(ValueError, match="上限"):
+        service.upgrade_stat(str(player_weapon.id), "power_bonus", pilot)
+
+
+def test_upgrade_accuracy_bonus_respects_cap(
+    session: Session, pilot: Pilot, player_weapon: PlayerWeapon
+) -> None:
+    """accuracy_bonus は base値(60)の130%、つまり bonus上限18で頭打ちになることを確認."""
+    player_weapon.custom_stats = {"accuracy_bonus": 17.5}
+    session.add(player_weapon)
+    session.commit()
+    session.refresh(player_weapon)
+
+    service = WeaponEngineeringService(session)
+    updated_pw, _, _ = service.upgrade_stat(
+        str(player_weapon.id), "accuracy_bonus", pilot
+    )
+    assert updated_pw.custom_stats["accuracy_bonus"] == pytest.approx(18.0)
+
+    with pytest.raises(ValueError, match="上限"):
+        service.upgrade_stat(str(player_weapon.id), "accuracy_bonus", pilot)
+
+
+def test_upgrade_insufficient_credits(
+    session: Session, pilot: Pilot, player_weapon: PlayerWeapon
+) -> None:
+    """所持金不足時は RuntimeError."""
+    pilot.credits = 10
+    session.add(pilot)
+    session.commit()
+
+    service = WeaponEngineeringService(session)
+    with pytest.raises(RuntimeError, match="Insufficient credits"):
+        service.upgrade_stat(str(player_weapon.id), "power_bonus", pilot)
+
+
+def test_upgrade_rejects_other_users_weapon(
+    session: Session, player_weapon: PlayerWeapon
+) -> None:
+    """所有者以外は改造できない."""
+    other_pilot = Pilot(
+        user_id="other_user",
+        name="Other Pilot",
+        level=1,
+        exp=0,
+        credits=100000,
+    )
+    session.add(other_pilot)
+    session.commit()
+    session.refresh(other_pilot)
+
+    service = WeaponEngineeringService(session)
+    with pytest.raises(ValueError, match="アクセス権"):
+        service.upgrade_stat(str(player_weapon.id), "power_bonus", other_pilot)
+
+
+def test_get_upgrade_preview(session: Session, player_weapon: PlayerWeapon) -> None:
+    """プレビューが現在値・改造後の値・コストを返すことを確認."""
+    service = WeaponEngineeringService(session)
+    preview = service.get_upgrade_preview(str(player_weapon.id), "power_bonus")
+
+    assert preview["current_value"] == 0
+    assert preview["new_value"] == 5
+    assert preview["cost"] == 60
+    assert preview["at_max_cap"] is False
+
+
+def test_upgrade_api_endpoint(
+    client, session, pilot: Pilot, player_weapon: PlayerWeapon
+):
+    """POST /api/player-weapons/{pw_id}/upgrade が custom_stats を更新することを確認."""
+    initial_credits = pilot.credits
+    app.dependency_overrides[get_current_user] = lambda: pilot.user_id
+    try:
+        response = client.post(
+            f"/api/player-weapons/{player_weapon.id}/upgrade",
+            json={"target_stat": "power_bonus", "steps": 1},
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        data = response.json()
+        assert data["player_weapon"]["custom_stats"]["power_bonus"] == 5
+        assert data["cost_paid"] == 60
+        assert data["remaining_credits"] == initial_credits - 60
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
+def test_upgrade_api_endpoint_at_max_cap_returns_400(
+    client, session, pilot: Pilot, player_weapon: PlayerWeapon
+):
+    """上限到達時、改造APIは400を返す."""
+    player_weapon.custom_stats = {"power_bonus": 100}
+    session.add(player_weapon)
+    session.commit()
+
+    app.dependency_overrides[get_current_user] = lambda: pilot.user_id
+    try:
+        response = client.post(
+            f"/api/player-weapons/{player_weapon.id}/upgrade",
+            json={"target_stat": "power_bonus", "steps": 1},
+        )
+        assert response.status_code == status.HTTP_400_BAD_REQUEST
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
+def test_upgrade_preview_api_endpoint(
+    client, session, pilot: Pilot, player_weapon: PlayerWeapon
+):
+    """GET /api/player-weapons/{pw_id}/upgrade-preview/{stat_type} を確認."""
+    app.dependency_overrides[get_current_user] = lambda: pilot.user_id
+    try:
+        response = client.get(
+            f"/api/player-weapons/{player_weapon.id}/upgrade-preview/accuracy_bonus"
+        )
+        assert response.status_code == status.HTTP_200_OK
+
+        data = response.json()
+        assert data["current_value"] == 0
+        assert data["new_value"] == pytest.approx(1.0)
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+
+def test_entry_creation_resyncs_equipped_weapon_upgrades(client, session, pilot: Pilot):
+    """装備中の武器を改造した後、エントリー登録時に MobileSuit.weapons に反映されることを確認.
+
+    再装備しなくても、バトル開始（エントリー）前に改造差分が反映される必要がある
+    （Issue #411 要件4）。
+    """
+    mobile_suit = MobileSuit(
+        user_id=pilot.user_id,
+        name="Test Zaku",
+        max_hp=800,
+        current_hp=800,
+        armor=50,
+        mobility=1.0,
+        weapons=[
+            {
+                "id": "zaku_mg",
+                "name": "Zaku Machine Gun",
+                "power": 100,
+                "range": 400,
+                "accuracy": 60,
+            }
+        ],
+        side="PLAYER",
+    )
+    session.add(mobile_suit)
+    session.commit()
+    session.refresh(mobile_suit)
+
+    player_weapon = PlayerWeapon(
+        user_id=pilot.user_id,
+        master_weapon_id="zaku_mg",
+        base_snapshot={
+            "id": "zaku_mg",
+            "name": "Zaku Machine Gun",
+            "power": 100,
+            "range": 400,
+            "accuracy": 60,
+            "type": "PHYSICAL",
+        },
+        custom_stats={},
+        equipped_ms_id=mobile_suit.id,
+        equipped_slot=0,
+    )
+    session.add(player_weapon)
+    session.commit()
+    session.refresh(player_weapon)
+
+    service = WeaponEngineeringService(session)
+    service.upgrade_stat(str(player_weapon.id), "power_bonus", pilot, steps=2)
+
+    app.dependency_overrides[get_current_user] = lambda: pilot.user_id
+    try:
+        response = client.post(
+            "/api/entries",
+            json={"mobile_suit_id": str(mobile_suit.id)},
+        )
+        assert response.status_code == status.HTTP_200_OK
+    finally:
+        app.dependency_overrides.pop(get_current_user, None)
+
+    session.refresh(mobile_suit)
+    assert mobile_suit.weapons[0]["power"] == 110  # 100 + 5*2

--- a/docs/features/weapon-data-model.md
+++ b/docs/features/weapon-data-model.md
@@ -89,17 +89,47 @@ return Weapon(**merged)
 
 ---
 
+## 武器改造機能（Issue #411）
+
+`custom_stats`（`power_bonus` / `accuracy_bonus`）を実際に読み書きする改造ロジック・APIを実装した。UI（改造画面）は本Issueの対象外で別Issueに切り出す。
+
+### `WeaponEngineeringService`（`app/services/weapon_engineering_service.py`）
+
+`EngineeringService`（機体強化）と同様に、サーバーサイドで段階コスト計算・上限キャップ検証を行い `pilot.credits` を消費する。対象は `PlayerWeapon` インスタンス単位で、**未装備の武器も改造可能**（`weapon_power` と異なり、改造投資は武器を外しても失われない）。
+
+- `power_bonus`: 1ステップ +5、コスト `int(60 * (1 + current_bonus / 30))`
+- `accuracy_bonus`: 1ステップ +1.0、コスト `int(100 * (1 + current_bonus / 5))`
+- 上限キャップは **base値（`base_snapshot`）に対する倍率**で表現する（絶対値キャップの `weapon_power` とは計算方法が異なる点に注意）:
+  - `power_bonus`: 実効値（`base.power + power_bonus`）が `base.power` の **200%** に達するまで
+  - `accuracy_bonus`: 実効値が `base.accuracy` の **130%** に達するまで
+- 改造回数の上限はなし（キャップまで何度でも改造可能）。失敗要素・改造のリセット機能はなし
+
+### APIエンドポイント（`app/routers/player_weapons.py`）
+
+- `POST /api/player-weapons/{pw_id}/upgrade` — `{ target_stat, steps }` を受け取り改造を実行
+- `GET /api/player-weapons/{pw_id}/upgrade-preview/{stat_type}` — 次の1ステップのコスト・変化後の値をプレビュー
+
+### バトルへの反映（装備中武器を改造した場合）
+
+装備時の dual-write（`equip_weapon`）だけでは、装備中の武器を後から改造しても `MobileSuit.weapons` に反映されない。これを解消するため `WeaponService.resync_mobile_suit_weapons(session, mobile_suit)` を新設し、バトルエントリー登録時（`app/routers/entries.py` の `create_entry`、機体スナップショットを保存する直前）に呼び出すことで、**再装備しなくてもバトル開始前に改造差分が反映される**。
+
+### フロントエンド
+
+- `frontend/src/types/shop.ts`: `WeaponUpgradeRequest` / `WeaponUpgradeResponse` / `WeaponUpgradePreview` 型を追加
+- `frontend/src/services/weaponEngineering.ts`: `upgradePlayerWeapon` / `getWeaponUpgradePreview`（`services/upgrades.ts` と同型のAPIクライアント）。UIからの呼び出しは別Issueで実装
+
 ## 今後の拡張（別Issue）
 
-- 武器改造UI（強化メニュー、コスト定義、`custom_stats` への書き込みAPI）
+- 武器改造UI（Garage/Engineering画面への統合、コスト・プレビュー表示）
 - `docs/features/garage-weapon-inventory.md` の所持武器一覧に改造状態（`custom_stats` 由来の差分）を表示する拡張
-- 改造の種類・コスト体系をマスターデータ化するかどうかの検討（現状は本Issueの対象外）
+- 改造の種類・コスト体系をマスターデータ化するかどうかの検討（現状は対象外）
 
 ---
 
 ## テスト
 
 ```bash
-cd backend && python -m pytest tests/unit/test_weapon_custom_stats.py tests/test_weapon_shop.py --tb=short
+cd backend && python -m pytest tests/unit/test_weapon_custom_stats.py tests/test_weapon_shop.py tests/test_weapon_engineering.py --tb=short
 cd frontend && ./node_modules/.bin/tsc --noEmit
+cd frontend && npx vitest run tests/unit/weaponEngineeringService.test.ts
 ```

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -8,6 +8,7 @@ export * from "./entry";
 export * from "./pilot";
 export * from "./shop";
 export * from "./upgrades";
+export * from "./weaponEngineering";
 export * from "./skills";
 export * from "./leaderboard";
 export * from "./friends";

--- a/frontend/src/services/weaponEngineering.ts
+++ b/frontend/src/services/weaponEngineering.ts
@@ -1,4 +1,4 @@
-import { WeaponUpgradeRequest, WeaponUpgradeResponse, WeaponUpgradePreview } from "@/types/shop";
+import { WeaponUpgradeRequest, WeaponUpgradeResponse, WeaponUpgradePreview, WeaponUpgradeStatType } from "@/types/shop";
 import { API_BASE_URL, getAuthToken } from "./auth";
 
 /** 所持武器の custom_stats（power_bonus / accuracy_bonus）を1段階改造する */
@@ -27,7 +27,7 @@ export async function upgradePlayerWeapon(playerWeaponId: string, request: Weapo
 }
 
 /** 武器改造前に費用と改造後の値をプレビュー取得する（確認ダイアログ表示に使用） */
-export async function getWeaponUpgradePreview(playerWeaponId: string, statType: string): Promise<WeaponUpgradePreview> {
+export async function getWeaponUpgradePreview(playerWeaponId: string, statType: WeaponUpgradeStatType): Promise<WeaponUpgradePreview> {
   const token = await getAuthToken();
   const headers: HeadersInit = {};
 

--- a/frontend/src/services/weaponEngineering.ts
+++ b/frontend/src/services/weaponEngineering.ts
@@ -1,0 +1,48 @@
+import { WeaponUpgradeRequest, WeaponUpgradeResponse, WeaponUpgradePreview } from "@/types/shop";
+import { API_BASE_URL, getAuthToken } from "./auth";
+
+/** 所持武器の custom_stats（power_bonus / accuracy_bonus）を1段階改造する */
+export async function upgradePlayerWeapon(playerWeaponId: string, request: WeaponUpgradeRequest): Promise<WeaponUpgradeResponse> {
+  const token = await getAuthToken();
+  const headers: HeadersInit = {
+    "Content-Type": "application/json",
+  };
+
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+
+  const res = await fetch(`${API_BASE_URL}/api/player-weapons/${playerWeaponId}/upgrade`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify(request),
+  });
+
+  if (!res.ok) {
+    const errorData = await res.json().catch(() => ({}));
+    throw new Error(errorData.detail || `Failed to upgrade weapon: ${res.status} ${res.statusText}`);
+  }
+
+  return res.json();
+}
+
+/** 武器改造前に費用と改造後の値をプレビュー取得する（確認ダイアログ表示に使用） */
+export async function getWeaponUpgradePreview(playerWeaponId: string, statType: string): Promise<WeaponUpgradePreview> {
+  const token = await getAuthToken();
+  const headers: HeadersInit = {};
+
+  if (token) {
+    headers['Authorization'] = `Bearer ${token}`;
+  }
+
+  const res = await fetch(`${API_BASE_URL}/api/player-weapons/${playerWeaponId}/upgrade-preview/${statType}`, {
+    headers,
+  });
+
+  if (!res.ok) {
+    const errorData = await res.json().catch(() => ({}));
+    throw new Error(errorData.detail || `Failed to get weapon upgrade preview: ${res.status} ${res.statusText}`);
+  }
+
+  return res.json();
+}

--- a/frontend/src/types/shop.ts
+++ b/frontend/src/types/shop.ts
@@ -118,3 +118,30 @@ export interface PlayerWeapon {
     equipped_slot: number | null;
     acquired_at: string;
 }
+
+/**
+ * 武器改造（custom_stats強化）リクエスト（Issue #411）。
+ * 未装備の武器も改造可能。装備中の武器はバトル開始時に再同期される。
+ */
+export interface WeaponUpgradeRequest {
+    target_stat: "power_bonus" | "accuracy_bonus";
+    steps?: number;
+}
+
+/** 武器改造後のレスポンス（更新後の武器インスタンスと消費クレジットを含む） */
+export interface WeaponUpgradeResponse {
+    message: string;
+    player_weapon: PlayerWeapon;
+    remaining_credits: number;
+    cost_paid: number;
+}
+
+/** 武器改造プレビューの情報（費用と改造後の値を事前確認するために使用） */
+export interface WeaponUpgradePreview {
+    player_weapon_id: string;
+    stat_type: string;
+    current_value: number;
+    new_value: number;
+    cost: number;
+    at_max_cap: boolean;
+}

--- a/frontend/src/types/shop.ts
+++ b/frontend/src/types/shop.ts
@@ -119,12 +119,15 @@ export interface PlayerWeapon {
     acquired_at: string;
 }
 
+/** 武器改造で強化可能な custom_stats のキー（バックエンドの stat_type と一致させる） */
+export type WeaponUpgradeStatType = "power_bonus" | "accuracy_bonus";
+
 /**
  * 武器改造（custom_stats強化）リクエスト（Issue #411）。
  * 未装備の武器も改造可能。装備中の武器はバトル開始時に再同期される。
  */
 export interface WeaponUpgradeRequest {
-    target_stat: "power_bonus" | "accuracy_bonus";
+    target_stat: WeaponUpgradeStatType;
     steps?: number;
 }
 
@@ -139,7 +142,7 @@ export interface WeaponUpgradeResponse {
 /** 武器改造プレビューの情報（費用と改造後の値を事前確認するために使用） */
 export interface WeaponUpgradePreview {
     player_weapon_id: string;
-    stat_type: string;
+    stat_type: WeaponUpgradeStatType;
     current_value: number;
     new_value: number;
     cost: number;

--- a/frontend/tests/unit/weaponEngineeringService.test.ts
+++ b/frontend/tests/unit/weaponEngineeringService.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { upgradePlayerWeapon, getWeaponUpgradePreview } from "@/services/weaponEngineering";
+
+// getAuthToken をモックしてテスト用トークンを注入する
+vi.mock("@/services/auth", async () => {
+  const actual = await vi.importActual<typeof import("@/services/auth")>("@/services/auth");
+  return { ...actual, getAuthToken: vi.fn().mockResolvedValue("test-token") };
+});
+
+/** 成功レスポンスを生成するヘルパー */
+const mockOk = (data: unknown) =>
+  ({ ok: true, json: () => Promise.resolve(data) } as unknown as Response);
+
+/** APIエラーレスポンスを生成するヘルパー */
+const mockErr = (detail: string, status = 400) =>
+  ({
+    ok: false,
+    status,
+    statusText: "Bad Request",
+    json: () => Promise.resolve({ detail }),
+  } as unknown as Response);
+
+beforeEach(() => {
+  vi.stubGlobal("fetch", vi.fn());
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+// ─────────────────────────────────────────────
+// upgradePlayerWeapon — 武器の custom_stats 改造
+// ─────────────────────────────────────────────
+describe("upgradePlayerWeapon", () => {
+  it("成功時にWeaponUpgradeResponseを返す", async () => {
+    const mockResponse = {
+      message: "武器を改造しました！",
+      player_weapon: { id: "pw-1", custom_stats: { power_bonus: 5 } },
+      remaining_credits: 940,
+      cost_paid: 60,
+    };
+    vi.mocked(fetch).mockResolvedValue(mockOk(mockResponse));
+
+    const result = await upgradePlayerWeapon("pw-1", { target_stat: "power_bonus" });
+
+    expect(result).toEqual(mockResponse);
+  });
+
+  it("POSTメソッドと正しいエンドポイントでfetchを呼び出す", async () => {
+    vi.mocked(fetch).mockResolvedValue(mockOk({}));
+
+    await upgradePlayerWeapon("pw-1", { target_stat: "accuracy_bonus" });
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/api/player-weapons/pw-1/upgrade"),
+      expect.objectContaining({ method: "POST" })
+    );
+  });
+
+  it("Authorizationヘッダーにトークンを付与する", async () => {
+    vi.mocked(fetch).mockResolvedValue(mockOk({}));
+
+    await upgradePlayerWeapon("pw-1", { target_stat: "power_bonus" });
+
+    const [, options] = vi.mocked(fetch).mock.calls[0];
+    expect((options as RequestInit).headers).toMatchObject({
+      Authorization: "Bearer test-token",
+    });
+  });
+
+  it("target_statとstepsをJSONボディとして送信する", async () => {
+    vi.mocked(fetch).mockResolvedValue(mockOk({}));
+
+    await upgradePlayerWeapon("pw-1", { target_stat: "power_bonus", steps: 3 });
+
+    const [, options] = vi.mocked(fetch).mock.calls[0];
+    const body = JSON.parse((options as RequestInit).body as string);
+    expect(body).toEqual({ target_stat: "power_bonus", steps: 3 });
+  });
+
+  it("APIがエラーを返したときdetailメッセージで例外を投げる", async () => {
+    vi.mocked(fetch).mockResolvedValue(mockErr("威力は既に上限に達しています"));
+
+    await expect(
+      upgradePlayerWeapon("pw-1", { target_stat: "power_bonus" })
+    ).rejects.toThrow("威力は既に上限に達しています");
+  });
+
+  it("APIがdetailなしでエラーを返したときフォールバックメッセージで例外を投げる", async () => {
+    vi.mocked(fetch).mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+      json: () => Promise.resolve({}),
+    } as unknown as Response);
+
+    await expect(
+      upgradePlayerWeapon("pw-1", { target_stat: "power_bonus" })
+    ).rejects.toThrow("500");
+  });
+});
+
+// ─────────────────────────────────────────────
+// getWeaponUpgradePreview — 改造前のコスト・効果プレビュー
+// ─────────────────────────────────────────────
+describe("getWeaponUpgradePreview", () => {
+  it("成功時にWeaponUpgradePreviewを返す", async () => {
+    const mockPreview = {
+      player_weapon_id: "pw-1",
+      stat_type: "power_bonus",
+      current_value: 0,
+      new_value: 5,
+      cost: 60,
+      at_max_cap: false,
+    };
+    vi.mocked(fetch).mockResolvedValue(mockOk(mockPreview));
+
+    const result = await getWeaponUpgradePreview("pw-1", "power_bonus");
+
+    expect(result).toEqual(mockPreview);
+  });
+
+  it("URLにplayerWeaponIdとstatTypeを含めてGETリクエストする", async () => {
+    vi.mocked(fetch).mockResolvedValue(mockOk({}));
+
+    await getWeaponUpgradePreview("pw-abc", "accuracy_bonus");
+
+    expect(fetch).toHaveBeenCalledWith(
+      expect.stringContaining("/api/player-weapons/pw-abc/upgrade-preview/accuracy_bonus"),
+      expect.any(Object)
+    );
+  });
+
+  it("at_max_cap=trueのとき上限到達状態を正しく返す", async () => {
+    vi.mocked(fetch).mockResolvedValue(
+      mockOk({ at_max_cap: true, cost: 0, current_value: 100, new_value: 100 })
+    );
+
+    const result = await getWeaponUpgradePreview("pw-1", "power_bonus");
+
+    expect(result.at_max_cap).toBe(true);
+  });
+
+  it("APIエラー時にdetailメッセージで例外を投げる", async () => {
+    vi.mocked(fetch).mockResolvedValue(mockErr("武器インスタンスが見つかりません"));
+
+    await expect(getWeaponUpgradePreview("pw-1", "power_bonus")).rejects.toThrow(
+      "武器インスタンスが見つかりません"
+    );
+  });
+});


### PR DESCRIPTION
## 概要

Issue #411 の対応。Issue #404 / PR #408 でデータモデル整理が完了した `PlayerWeapon.custom_stats`（`power_bonus` / `accuracy_bonus`）を実際に読み書きする、プレイヤー所持武器の改造（強化）機能を実装した。本PRは改造ロジック・APIまでを対象とし、UI実装は別Issueに切り出す。

## 変更内容

### Backend

- `WeaponEngineeringService`（`app/services/weapon_engineering_service.py`）を新設
  - `EngineeringService`（機体強化）と同様のパターンで、`PlayerWeapon.custom_stats` の `power_bonus` / `accuracy_bonus` を段階的に強化する
  - **未装備の武器も改造可能**（`weapon_power` と異なり、改造投資は武器を外しても失われない）
  - 段階コストは `pilot.credits` を消費（`power_bonus`: 1ステップ+5・`int(60*(1+bonus/30))`、`accuracy_bonus`: 1ステップ+1.0・`int(100*(1+bonus/5))`）
  - 上限キャップは **base値に対する倍率**（`power_bonus` は200%、`accuracy_bonus` は130%）。改造回数の上限・失敗要素・リセット機能はなし
- `POST /api/player-weapons/{pw_id}/upgrade`、`GET /api/player-weapons/{pw_id}/upgrade-preview/{stat_type}` を追加（`app/routers/player_weapons.py`）
- `WeaponService.resync_mobile_suit_weapons` を新設し、バトルエントリー登録時（`app/routers/entries.py`）に装備中武器の実効スペックを `MobileSuit.weapons` へ再同期。これにより、装備中の武器を改造しても再装備なしにバトル開始前に反映される
- `backend/CLAUDE.md` の武器データモデルの記述を更新（`custom_stats` が実装済みであることを反映）

### Frontend

- `types/shop.ts` に `WeaponUpgradeRequest` / `WeaponUpgradeResponse` / `WeaponUpgradePreview` 型を追加
- `services/weaponEngineering.ts` に `upgradePlayerWeapon` / `getWeaponUpgradePreview` を追加（`services/upgrades.ts` と同型のAPIクライアント。UIからの呼び出しは別Issue）

### ドキュメント

- `docs/features/weapon-data-model.md` に武器改造機能の設計を追記

## テスト

- [x] `cd backend && python -m pytest tests/test_weapon_engineering.py --tb=short` — 改造ロジック・APIエンドポイント・バトルエントリー時再同期のテスト（13件）
- [x] `cd backend && python -m pytest` — バックエンド全テスト
- [x] `cd backend && ruff check . && mypy app`（pre-commit hookで実行済み）
- [x] `cd frontend && ./node_modules/.bin/tsc --noEmit` — 型チェック
- [x] `cd frontend && npx vitest run tests/unit/` — フロントエンド全テスト（`weaponEngineeringService.test.ts` 追加分含む）
- [x] `cd frontend && npx eslint src/types/shop.ts src/services/weaponEngineering.ts src/services/api.ts`

## Test plan

- [x] 未装備の武器を `power_bonus` / `accuracy_bonus` それぞれ改造でき、`pilot.credits` が正しく消費されること
- [x] `power_bonus` は base値の200%、`accuracy_bonus` は130%で上限キャップされ、それ以上は400を返すこと
- [x] 装備中の武器を改造した後、バトルエントリー登録時に再装備なしで `MobileSuit.weapons` に改造差分が反映されること
- [x] 所有者以外は改造できないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)