### PR TITLE
fix: ログ読み込み完了前にBattleViewerがマウントされ自機を見失う不具合を修正

### DIFF
--- a/docs/features/battle-viewer-improvement.md
+++ b/docs/features/battle-viewer-improvement.md
@@ -294,3 +294,23 @@ Phase 3（ビジュアル強化）
 
 `MAX_VELOCITY_EXTRAPOLATION_SECONDS`（1.0秒）を超える `dt` では外挿を行わず、直近の実位置（`position_snapshot`）
 に留める。併せて `TargetLine` は自機（`playerState.hp > 0`）・ターゲット双方の生存を表示条件に加えている。
+
+---
+
+## BattleViewerのカメラ初期化タイミング（Issue #425）
+
+`BattleDetailModal` は `battle.player_info` / `enemies_info`（同期データ）のみで `hasReplayData` を判定していたため、
+`useBattleLogs` によるバトルログの非同期取得（`logsLoading`）が完了する前に `BattleViewer` が先にマウントされていた。
+
+`useBattleSnapshot.ts` の `getBattleSnapshot()` は `logs` が空の場合 `pos = initialMs.position` にフォールバックするが、
+この値は実際の戦闘開始位置ではない（ガレージ格納時などの座標）。一方 `BattleScene.tsx` の `CameraInitializer` は
+マウント時（`useEffect` の依存配列が空）に一度だけこのフォールバック座標を基準としてカメラ位置・`OrbitControls` の
+`target` を固定する。バトルログの読み込みが完了すると自機の描画位置は実ログの `position_snapshot` に基づく本来の
+位置に切り替わるが、カメラは追従しないため、自機がビューポート外に外れて見失われる不具合が発生していた。
+
+**修正:** `BattleDetailModal.tsx` にて `logsLoading` 中は `BattleViewer` をマウントせず、同サイズのプレースホルダー
+（「ビューアを準備中...」）を表示するようにした。ログ読み込み完了後に確定した実位置で `BattleViewer` が初めて
+マウントされるため、`CameraInitializer` は常に正しい初期位置を基準にカメラを配置する。
+
+**影響ファイル:**
+- `frontend/src/components/history/BattleDetailModal.tsx`

--- a/frontend/src/components/history/BattleDetailModal.tsx
+++ b/frontend/src/components/history/BattleDetailModal.tsx
@@ -66,21 +66,31 @@ export default function BattleDetailModal({
           {/* 上部固定: 3D Replay Viewer + ターンコントローラー */}
           <div className="flex-none p-4 border-b border-gray-700">
             {hasReplayData ? (
-              <>
-                <BattleViewer
-                  logs={logs}
-                  player={battle.player_info as MobileSuit}
-                  enemies={battle.enemies_info as MobileSuit[]}
-                  obstacles={battle.obstacles_info}
-                  currentTimestamp={currentTimestamp}
-                  environment={battle.environment || "SPACE"}
-                />
-                <TurnController
-                  currentTimestamp={currentTimestamp}
-                  maxTimestamp={maxTimestamp}
-                  onTimestampChange={setCurrentTimestamp}
-                />
-              </>
+              logsLoading ? (
+                // ログ読み込み完了前にBattleViewerをマウントすると、
+                // 実ログ未確定の仮位置でカメラが初期配置されてしまい、
+                // ログ読み込み完了後の再描画で自機が視界外に外れる不具合があった（Issue #425）。
+                // ログ確定後にマウントすることで、確定した初期位置を基準にカメラを配置させる。
+                <div className="w-full h-[300px] sm:h-[400px] md:h-[500px] rounded border border-green-800 mb-4 flex items-center justify-center bg-gray-900/50">
+                  <p className="text-gray-400 text-sm">ビューアを準備中...</p>
+                </div>
+              ) : (
+                <>
+                  <BattleViewer
+                    logs={logs}
+                    player={battle.player_info as MobileSuit}
+                    enemies={battle.enemies_info as MobileSuit[]}
+                    obstacles={battle.obstacles_info}
+                    currentTimestamp={currentTimestamp}
+                    environment={battle.environment || "SPACE"}
+                  />
+                  <TurnController
+                    currentTimestamp={currentTimestamp}
+                    maxTimestamp={maxTimestamp}
+                    onTimestampChange={setCurrentTimestamp}
+                  />
+                </>
+              )
             ) : (
               <div className="p-3 bg-yellow-900/20 border border-yellow-700 rounded" role="alert">
                 <p className="text-yellow-400 text-sm">


### PR DESCRIPTION
## Summary
- `BattleDetailModal` が `useBattleLogs` の非同期読み込み（`logsLoading`）を考慮せず `hasReplayData` のみで `BattleViewer` を即座にマウントしていたため、`CameraInitializer` がログ未確定時のフォールバック座標（`initialMs.position`）を基準にカメラを固定してしまい、ログ読み込み完了後の再描画で自機がビューポート外に外れて見失われる不具合を修正
- `logsLoading` 中は同サイズのプレースホルダー（「ビューアを準備中...」）を表示し、ログ確定後に `BattleViewer`（+ `TurnController`）をマウントするよう変更
- `docs/features/battle-viewer-improvement.md` に原因・修正内容を追記

Closes #425

## Test plan
- [x] `cd frontend && ./node_modules/.bin/tsc --noEmit` が通ることを確認
- [x] `cd frontend && npx vitest run tests/unit/` が全件パスすることを確認
- [x] ログ取得を3秒遅延させるモックfetchを仕込んだ一時プレビューページ（検証後に削除）をPlaywrightで操作し、
      - ログ読み込み中: Canvasがマウントされずプレースホルダーのみ表示されることを確認
      - ログ読み込み完了後: Canvasがマウントされ、自機・敵機がカメラ中心付近に正しく表示されることを確認（player.positionに実位置と大きくズレたダミー座標を設定した状態でも自機を見失わないことを確認）

🤖 Generated with [Claude Code](https://claude.com/claude-code)