### PR TITLE
feat: 密集戦闘時に自機を識別できる常時マーカーを追加

### DIFF
--- a/docs/features/battle-viewer-improvement.md
+++ b/docs/features/battle-viewer-improvement.md
@@ -297,6 +297,36 @@ Phase 3（ビジュアル強化）
 
 ---
 
+## 密集戦闘時の自機識別マーカー（Issue #426）
+
+格闘戦（近接戦闘）で複数ユニットの球体が密集すると、自機・敵機ともに同じ `MobileSuitMesh` の球体で
+描画され HP による色分けしかないため、ユーザーが自機を見失いやすい問題があった。
+
+**調査で判明した前提:** 自機が `isTargeted`（敵のターゲットハイライトリング、赤）の対象になる経路は
+コード上そもそも存在しない。`BattleScene.tsx` で自機は専用の `<MobileSuitMesh>` 呼び出しで描画され、この
+呼び出しには `isTargeted` prop が渡されない。敵側の `isTargeted={enemy.id === playerState.targetId}` は
+`enemyStates`（`enemies` prop 由来、自機とは別変数）に対してのみ評価される。バックエンド側も
+`main.py`/`run_batch.py` の両生成箇所で `player_info`/`enemies_info` を構造的に分離しており（後者は
+`enemies_info` 生成時に自ユニットIDを明示的に除外）、自機を敵側の配列に混入させる経路は無い。そのため
+自機用の常時マーカーを追加しても、既存の `isTargeted` リングと表示が衝突する懸念はない。
+
+**実装:**
+- `MobileSuitMesh.tsx` に `isSelf?: boolean` prop を追加し、true の場合のみ以下を描画する
+  - 常時表示の識別リング（マゼンタ `#ff00ff`、半径 2.0〜2.3。既存の `isTargeted` リング（赤、半径 1.4〜1.8）
+    ・センサーリング（緑、`AnimatedSensorRing`）と色・半径ともに重複しない）
+  - パルスアニメーション（`opacity` を sin波で 0.3〜0.9 の範囲で周期的に変化させ、密集時でも動きで目を引く）
+  - 常時表示の "YOU" ラベル（`Html` オーバーレイ、既存の警告アイコン表示位置 `[0, 3, 0]` と重ならないよう
+    `[0, 4, 0]` に配置）
+- 識別リング・ラベルは射撃反動アニメーション用の `innerGroupRef` の**外側**（`hoverGroupRef` 直下）に配置し、
+  反動でブレず自機の位置を安定して示せるようにしている
+- `BattleScene.tsx` の自機用 `<MobileSuitMesh>` 呼び出しに `isSelf={true}` を追加
+
+**影響ファイル:**
+- `frontend/src/components/BattleViewer/scene/MobileSuitMesh.tsx`
+- `frontend/src/components/BattleViewer/scene/BattleScene.tsx`
+
+---
+
 ## BattleViewerのカメラ初期化タイミング（Issue #425）
 
 `BattleDetailModal` は `battle.player_info` / `enemies_info`（同期データ）のみで `hasReplayData` を判定していたため、

--- a/docs/features/battle-viewer-improvement.md
+++ b/docs/features/battle-viewer-improvement.md
@@ -311,15 +311,18 @@ Phase 3（ビジュアル強化）
 自機用の常時マーカーを追加しても、既存の `isTargeted` リングと表示が衝突する懸念はない。
 
 **実装:**
-- `MobileSuitMesh.tsx` に `isSelf?: boolean` prop を追加し、true の場合のみ以下を描画する
-  - 常時表示の識別リング（マゼンタ `#ff00ff`、半径 2.0〜2.3。既存の `isTargeted` リング（赤、半径 1.4〜1.8）
-    ・センサーリング（緑、`AnimatedSensorRing`）と色・半径ともに重複しない）
-  - パルスアニメーション（`opacity` を sin波で 0.3〜0.9 の範囲で周期的に変化させ、密集時でも動きで目を引く）
-  - 常時表示の "YOU" ラベル（`Html` オーバーレイ、既存の警告アイコン表示位置 `[0, 3, 0]` と重ならないよう
-    `[0, 4, 0]` に配置）
-- 識別リング・ラベルは射撃反動アニメーション用の `innerGroupRef` の**外側**（`hoverGroupRef` 直下）に配置し、
+- `MobileSuitMesh.tsx` に `isSelf?: boolean` prop を追加し、true の場合のみ常時表示の識別リングを描画する
+  - 色は新規に導入せず、既存パレットの青系（向き矢印と同じ `#4488ff`）を使用。既存の `isTargeted` リング
+    （赤、半径 1.4〜1.8・細め）・センサーリング（緑、`AnimatedSensorRing`）とは、より太い幅（半径 1.9〜2.4）
+    とパルス点滅（`opacity` を sin波で周期的に変化）で区別する。ラベル文字（"YOU"等）は視認性を悪化させる
+    ため採用しない
+- 識別リングは射撃反動アニメーション用の `innerGroupRef` の**外側**（`hoverGroupRef` 直下）に配置し、
   反動でブレず自機の位置を安定して示せるようにしている
 - `BattleScene.tsx` の自機用 `<MobileSuitMesh>` 呼び出しに `isSelf={true}` を追加
+
+> [!IMPORTANT]
+> 3Dビューアの配色パレットからの逸脱は禁止（`frontend/CLAUDE.md`「BattleViewerの配色パレット」参照）。
+> 新しい視覚要素を追加する際は、既存色の太さ・点滅など表現方法の差異で区別すること。
 
 **影響ファイル:**
 - `frontend/src/components/BattleViewer/scene/MobileSuitMesh.tsx`

--- a/frontend/CLAUDE.md
+++ b/frontend/CLAUDE.md
@@ -299,6 +299,21 @@ luk: number;
 - 単一コンポーネント内でしか使わない一時的なアイコン: そのファイル内にローカル関数として定義する（例: `WeaponInventoryList.tsx` の `FilterIcon` / `TypeIcon` / `SortIcon` / `EmptyBoxIcon`）
 - 複数コンポーネントで共有するアイコン: `frontend/src/components/icons/TablerIcons.tsx` に集約する。Header/BottomNav等のグローバルUIは[Tabler Icons](https://tabler.io/icons)（outline, MIT License）のSVGパスをここに複製して使う。**新しいグローバルアイコンが必要になった場合も、このファイルに追記し、他のアイコンセットと混在させないこと**（`BottomNav.tsx`, `Avatar.tsx` が利用例）
 
+## BattleViewer（3Dビューア）の配色パレット
+
+`frontend/src/components/BattleViewer/scene/` 配下の各コンポーネントは、以下の固定配色を使用している。
+
+| 色 | 用途 | 定義箇所 |
+|---|---|---|
+| `#ff4444`（赤） | 敵ターゲットハイライトリング（`isTargeted`） | `MobileSuitMesh.tsx` |
+| `#00ff00`（緑） | センサー範囲リング（`showSensorRange`） | `AnimatedSensorRing.tsx` |
+| `#4488ff`（青） | 向き矢印（`heading`）、自機識別リング（`isSelf`、Issue #426） | `MobileSuitMesh.tsx` |
+| `#ff9800`/`#ffeb3b`/`#2196f3` | 警告アイコン（弾切れ/EN不足/クールダウン） | `MobileSuitMesh.tsx` |
+
+**新しい視覚要素（マーカー・リング・ラベル等）を追加する際、このパレットから外れる新規の色を独断で導入してはいけない。** 密集戦闘時の自機識別マーカー（Issue #426）で当初マゼンタ（`#ff00ff`）を新規に使ったが、既存パレットからの逸脱だとしてユーザーから差し戻された経緯がある。同種の要素と区別したい場合は、既存色を使い回した上で太さ・点滅（パルスアニメーション）・破線などの**表現方法の違い**で区別すること。既存パレットでは要件を満たせないと判断した場合は、実装前に新しい色の採用についてユーザーと協議すること。
+
+---
+
 ## SWRフックはコンポーネント側で直接呼んでよい（プロップドリリング不要）
 
 親コンポーネントが既に同じデータソースを別条件で fetch している場合でも、子コンポーネントが異なるクエリパラメータで取得したい時は、子側で直接 SWR フック（`usePlayerWeapons(unequippedOnly)` など）を呼び出してよい。SWR は同一URLをグローバルキャッシュキーとして重複排除するため、条件が親と同じ（例: フィルタOFF時）であれば追加のネットワークリクエストは発生せず、条件が異なる（例: `?unequipped=true` を付けたい時）場合だけ新しいキーとして取得される。`playerWeapons` を毎回 prop で渡す設計より、こちらの方が「必要な時だけ絞り込みクエリを叩く」実装をシンプルに保てる（`WeaponInventoryList.tsx` 参照）。

--- a/frontend/src/components/BattleViewer/scene/BattleScene.tsx
+++ b/frontend/src/components/BattleViewer/scene/BattleScene.tsx
@@ -410,6 +410,7 @@ export function BattleScene({
                 heading={playerState.heading}
                 isAttacking={attackingUnitIds?.has(String(player.id))}
                 isFlashing={flashingUnitIds.has(String(player.id))}
+                isSelf={true}
             />
 
             {/* Enemies */}

--- a/frontend/src/components/BattleViewer/scene/MobileSuitMesh.tsx
+++ b/frontend/src/components/BattleViewer/scene/MobileSuitMesh.tsx
@@ -216,26 +216,14 @@ export function MobileSuitMesh({
                 )}
             </group>
 
-            {/* 自機識別マーカー: 反動アニメーション(innerGroupRef)の影響を受けないよう外側に配置 (Issue #426) */}
+            {/* 自機識別リング: 反動アニメーション(innerGroupRef)の影響を受けないよう外側に配置 (Issue #426) */}
+            {/* 既存パレットの青系（向き矢印と同じ #4488ff）を使用し、isTargeted/センサーリングとは
+                太さ（幅広）とパルス点滅で区別する。新規の色を導入しない */}
             {isSelf && (
-                <>
-                    <mesh ref={selfRingRef} rotation={[-Math.PI / 2, 0, 0]}>
-                        <ringGeometry args={[2.0, 2.3, 32]} />
-                        <meshBasicMaterial color="#ff00ff" side={THREE.DoubleSide} transparent opacity={0.8} />
-                    </mesh>
-                    <Html position={[0, 4, 0]} center>
-                        <div
-                            className="pointer-events-none select-none text-xs font-bold px-2 py-0.5 rounded"
-                            style={{
-                                backgroundColor: "rgba(0, 0, 0, 0.8)",
-                                border: "2px solid #ff00ff",
-                                color: "#ff00ff",
-                            }}
-                        >
-                            YOU
-                        </div>
-                    </Html>
-                </>
+                <mesh ref={selfRingRef} rotation={[-Math.PI / 2, 0, 0]}>
+                    <ringGeometry args={[1.9, 2.4, 32]} />
+                    <meshBasicMaterial color="#4488ff" side={THREE.DoubleSide} transparent opacity={0.8} />
+                </mesh>
             )}
             </group>
         </group>

--- a/frontend/src/components/BattleViewer/scene/MobileSuitMesh.tsx
+++ b/frontend/src/components/BattleViewer/scene/MobileSuitMesh.tsx
@@ -24,6 +24,7 @@ export function MobileSuitMesh({
     isTargeted,
     isAttacking,
     isFlashing,
+    isSelf,
 }: {
     position: { x: number; y: number; z: number };
     maxHp: number;
@@ -41,6 +42,8 @@ export function MobileSuitMesh({
     isAttacking?: boolean;
     /** クリティカルヒット被弾時 true — emissiveIntensity フラッシュ用 (Issue #367) */
     isFlashing?: boolean;
+    /** 自機の場合 true — 密集戦闘時の視認性向上のための常時識別マーカー表示に使用 (Issue #426) */
+    isSelf?: boolean;
 }) {
     const scale = 0.05;
     const vec = new THREE.Vector3(position.x * scale, position.z * scale, position.y * scale);
@@ -63,6 +66,9 @@ export function MobileSuitMesh({
     const sphereMeshRef = useRef<THREE.Mesh>(null);
     const flashTimeRef = useRef(0);
     const FLASH_DURATION = 0.4;
+
+    // 自機識別リング用 ref（密集戦闘時の視認性向上、Issue #426）
+    const selfRingRef = useRef<THREE.Mesh>(null);
 
     useFrame((state, delta) => {
         // B-4: ホバリングアニメーション（宇宙浮遊感）
@@ -104,6 +110,12 @@ export function MobileSuitMesh({
                 (sphereMeshRef.current.material as THREE.MeshStandardMaterial).emissiveIntensity =
                     baseIntensity;
             }
+        }
+
+        // 自機識別リングのパルスアニメーション（密集時でも常に動きで目を引くように、Issue #426）
+        if (selfRingRef.current) {
+            const opacity = 0.6 + Math.sin(state.clock.elapsedTime * 3) * 0.3;
+            (selfRingRef.current.material as THREE.MeshBasicMaterial).opacity = opacity;
         }
     });
 
@@ -203,6 +215,28 @@ export function MobileSuitMesh({
                     </Html>
                 )}
             </group>
+
+            {/* 自機識別マーカー: 反動アニメーション(innerGroupRef)の影響を受けないよう外側に配置 (Issue #426) */}
+            {isSelf && (
+                <>
+                    <mesh ref={selfRingRef} rotation={[-Math.PI / 2, 0, 0]}>
+                        <ringGeometry args={[2.0, 2.3, 32]} />
+                        <meshBasicMaterial color="#ff00ff" side={THREE.DoubleSide} transparent opacity={0.8} />
+                    </mesh>
+                    <Html position={[0, 4, 0]} center>
+                        <div
+                            className="pointer-events-none select-none text-xs font-bold px-2 py-0.5 rounded"
+                            style={{
+                                backgroundColor: "rgba(0, 0, 0, 0.8)",
+                                border: "2px solid #ff00ff",
+                                color: "#ff00ff",
+                            }}
+                        >
+                            YOU
+                        </div>
+                    </Html>
+                </>
+            )}
             </group>
         </group>
     );


### PR DESCRIPTION
## Summary
- 格闘戦で複数ユニットが密集すると自機を見失いやすい問題（#426）を解消するため、`MobileSuitMesh.tsx` に自機専用の常時識別リング（`isSelf` prop）を追加
- 色は新規導入せず既存パレットの青系（`#4488ff`、向き矢印と同色）を使用し、既存の敵ターゲットリング（赤・isTargeted）・センサーリング（緑）とは太さ（幅広リング）とパルス点滅で区別
- レビュー指摘を受け、当初実装していた"YOU"ラベルは視認性を悪化させるだけのため削除し、リング表示のみに変更
- コード調査により「自機がisTargetedの対象になる経路は構造上存在しない」ことを確認済み（`BattleScene.tsx`で自機は`isTargeted` propを渡されない専用呼び出しで描画され、バックエンド側も`player_info`/`enemies_info`が構造的に分離されているため）。詳細は `docs/features/battle-viewer-improvement.md` に追記
- `frontend/CLAUDE.md` にBattleViewerの配色パレット規約を新設し、新規色の独断導入を禁止（必要な場合はユーザーと協議する旨を明記）

## Test plan
- [x] `cd frontend && ./node_modules/.bin/tsc --noEmit` — 型チェック成功
- [x] `cd frontend && npx vitest run tests/unit/` — 既存ユニットテスト全221件パス
- [x] 一時プレビューページ（Playwright + headless swiftshader）でBattleViewerに密集配置した敵5機と自機を描画し、青系のパルスリングが自機のみに表示され視覚的に識別できることを確認済み（ラベルは削除済み。確認用の一時ファイルはコミットせず削除済み）

Closes #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)