### PR TITLE
fix: ライブ観戦画面で障害物が描画されない不具合を修正

### DIFF
--- a/backend/app/engine/battle_utils.py
+++ b/backend/app/engine/battle_utils.py
@@ -8,7 +8,33 @@ from app.core.npc_data import BATTLE_CHATTER
 from app.models.models import BattleLog, MobileSuit
 
 if TYPE_CHECKING:
-    pass
+    from app.models.models import Obstacle
+
+
+def serialize_obstacles(obstacles: "list[Obstacle]") -> list[dict[str, Any]] | None:
+    """障害物リストを BattleResult.obstacles_info / BattleResponse 用に変換する.
+
+    `BattleResult` の生成箇所は main.py（即時実行）と run_batch.py（バッチ実行）の
+    2箇所あり、どちらも同じ変換ロジックを必要とするため共通化している。
+
+    Args:
+        obstacles: BattleSimulator.obstacles
+
+    Returns:
+        障害物が無い場合は None（DB上は NULL として保存される）
+    """
+    if not obstacles:
+        return None
+    return [
+        {
+            "obstacle_id": obs.obstacle_id,
+            "position": {"x": obs.position.x, "y": obs.position.y, "z": obs.position.z},
+            "radius": obs.radius,
+            "height": obs.height,
+        }
+        for obs in obstacles
+    ]
+
 
 # バトルログ保存時に除去するデバッグ専用フィールドのセット
 _BATTLE_LOG_DEBUG_FIELDS: frozenset[str] = frozenset({"fuzzy_scores"})

--- a/backend/main.py
+++ b/backend/main.py
@@ -14,7 +14,7 @@ from sqlmodel import Session, desc, select
 # DB関連
 from app.core.auth import get_current_user, get_current_user_optional
 from app.db import get_session
-from app.engine.battle_utils import strip_debug_fields
+from app.engine.battle_utils import serialize_obstacles, strip_debug_fields
 from app.engine.simulation import BattleSimulator
 from app.models.models import (
     BattleField,
@@ -341,15 +341,7 @@ async def simulate_battle(
     )
 
     # 10. バトル結果をDBに保存（リプレイ用スナップショット・詳細情報含む）
-    obstacles_data = [
-        {
-            "obstacle_id": obs.obstacle_id,
-            "position": {"x": obs.position.x, "y": obs.position.y, "z": obs.position.z},
-            "radius": obs.radius,
-            "height": obs.height,
-        }
-        for obs in sim.obstacles
-    ]
+    obstacles_data = serialize_obstacles(sim.obstacles)
     battle_result = BattleResult(
         user_id=user_id,
         mission_id=mission_id,
@@ -358,7 +350,7 @@ async def simulate_battle(
         environment=mission.environment,
         player_info=player.model_dump(),
         enemies_info=[e.model_dump() for e in enemies],
-        obstacles_info=obstacles_data if obstacles_data else None,
+        obstacles_info=obstacles_data,
         ms_snapshot=player.model_dump(),
         kills=kills,
         exp_gained=exp_gained,
@@ -378,7 +370,7 @@ async def simulate_battle(
         logs=sim.logs,
         player_info=player,
         enemies_info=enemies,
-        obstacles_info=obstacles_data if obstacles_data else None,
+        obstacles_info=obstacles_data,
         rewards=rewards,
     )
 

--- a/backend/main.py
+++ b/backend/main.py
@@ -107,6 +107,7 @@ class BattleResponse(BaseModel):
     logs: list[BattleLog]
     player_info: MobileSuit
     enemies_info: list[MobileSuit]
+    obstacles_info: list[dict] | None = None
     rewards: BattleRewards | None = None
 
 
@@ -377,6 +378,7 @@ async def simulate_battle(
         logs=sim.logs,
         player_info=player,
         enemies_info=enemies,
+        obstacles_info=obstacles_data if obstacles_data else None,
         rewards=rewards,
     )
 

--- a/backend/scripts/run_batch.py
+++ b/backend/scripts/run_batch.py
@@ -19,7 +19,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 from sqlmodel import Session, select
 
 from app.db import engine
-from app.engine.battle_utils import strip_debug_fields
+from app.engine.battle_utils import serialize_obstacles, strip_debug_fields
 from app.engine.simulation import BattleSimulator
 from app.models.models import (
     BattleEntry,
@@ -246,6 +246,7 @@ def _save_battle_results(
     # entry.mobile_suit_snapshot はエントリー時点（バトル前）のHPしか持たないため、
     # ダイジェスト集計にはシミュレーションで実際に更新された live なユニットを使う
     live_units_by_id = {str(u.id): u for u in [player_unit, *enemy_units]}
+    obstacles_data = serialize_obstacles(simulator.obstacles)
 
     # バトルログをルーム単位で1件保存（全参加者で共有）
     battle_log_record = BattleLogRecord(
@@ -332,6 +333,7 @@ def _save_battle_results(
             win_loss=individual_win_loss,
             player_info=entry_unit_for_info.model_dump(),
             enemies_info=enemies_info_for_entry,
+            obstacles_info=obstacles_data,
             ms_snapshot=entry.mobile_suit_snapshot,
             kills=individual_kills,
             exp_gained=exp_gained,

--- a/docs/features/battle-viewer-feature.md
+++ b/docs/features/battle-viewer-feature.md
@@ -318,6 +318,7 @@ POST /api/battle/simulate レスポンスの obstacles_info
 - `obstacles_info` が `null` / `undefined` の場合は何も描画しない（既存バトル履歴への後方互換性）
 - バックエンドで障害物が生成されない設定（`obstacle_density: "NONE"` など）では `obstacles_info` は `null` として保存される
 - `/api/battle/simulate` の `BattleResponse` にも `obstacles_info` フィールドが含まれる（バトル実行直後のライブ観戦画面で障害物を描画するために必要）
+- `BattleResult` の生成箇所は `backend/main.py`（即時実行）と `backend/scripts/run_batch.py`（デイリーバトルロイヤル等のバッチ実行）の2箇所あり、`obstacles_info` の設定も両方で必要（片方だけだと `NULL` のままになる）。障害物のシリアライズ処理は `backend/app/engine/battle_utils.py` の `serialize_obstacles()` に共通化されているため、両呼び出し元はこれを呼ぶだけでよい
 
 ---
 
@@ -651,6 +652,7 @@ POST /api/battle/simulate レスポンスの obstacles_info
 - `obstacles_info` が `null` / `undefined` の場合は何も描画しない（既存バトル履歴への後方互換性）
 - バックエンドで障害物が生成されない設定（`obstacle_density: "NONE"` など）では `obstacles_info` は `null` として保存される
 - `/api/battle/simulate` の `BattleResponse` にも `obstacles_info` フィールドが含まれる（バトル実行直後のライブ観戦画面で障害物を描画するために必要）
+- `BattleResult` の生成箇所は `backend/main.py`（即時実行）と `backend/scripts/run_batch.py`（デイリーバトルロイヤル等のバッチ実行）の2箇所あり、`obstacles_info` の設定も両方で必要（片方だけだと `NULL` のままになる）。障害物のシリアライズ処理は `backend/app/engine/battle_utils.py` の `serialize_obstacles()` に共通化されているため、両呼び出し元はこれを呼ぶだけでよい
 
 ---
 

--- a/docs/features/battle-viewer-feature.md
+++ b/docs/features/battle-viewer-feature.md
@@ -294,9 +294,20 @@ interface UnitSnapshot {
 
 ### データフロー
 
+バトル履歴のリプレイ（`BattleDetailModal`）:
 ```
 BattleResult.obstacles_info (DB)
   → BattleDetailModal (obstacles_info を BattleViewer に渡す)
+  → BattleViewer (obstacles prop)
+  → BattleScene (obstacles prop + blockingObstacleIds)
+  → ObstacleMesh (各障害物を個別描画、isBlocking で色変化)
+```
+
+ダッシュボードのライブ観戦（`page.tsx` / Tactical Monitor）:
+```
+POST /api/battle/simulate レスポンスの obstacles_info
+  → useBattleSimulation フック（obstaclesData state）
+  → page.tsx (obstaclesData を BattleViewer に渡す)
   → BattleViewer (obstacles prop)
   → BattleScene (obstacles prop + blockingObstacleIds)
   → ObstacleMesh (各障害物を個別描画、isBlocking で色変化)
@@ -306,6 +317,7 @@ BattleResult.obstacles_info (DB)
 
 - `obstacles_info` が `null` / `undefined` の場合は何も描画しない（既存バトル履歴への後方互換性）
 - バックエンドで障害物が生成されない設定（`obstacle_density: "NONE"` など）では `obstacles_info` は `null` として保存される
+- `/api/battle/simulate` の `BattleResponse` にも `obstacles_info` フィールドが含まれる（バトル実行直後のライブ観戦画面で障害物を描画するために必要）
 
 ---
 
@@ -615,9 +627,20 @@ function CameraInitializer({ px, py, pz, controlsRef }) {
 
 ### データフロー
 
+バトル履歴のリプレイ（`BattleDetailModal`）:
 ```
 BattleResult.obstacles_info (DB)
   → BattleDetailModal (obstacles_info を BattleViewer に渡す)
+  → BattleViewer (obstacles prop)
+  → BattleScene (obstacles prop + blockingObstacleIds)
+  → ObstacleMesh (各障害物を個別描画、isBlocking で色変化)
+```
+
+ダッシュボードのライブ観戦（`page.tsx` / Tactical Monitor）:
+```
+POST /api/battle/simulate レスポンスの obstacles_info
+  → useBattleSimulation フック（obstaclesData state）
+  → page.tsx (obstaclesData を BattleViewer に渡す)
   → BattleViewer (obstacles prop)
   → BattleScene (obstacles prop + blockingObstacleIds)
   → ObstacleMesh (各障害物を個別描画、isBlocking で色変化)
@@ -627,6 +650,7 @@ BattleResult.obstacles_info (DB)
 
 - `obstacles_info` が `null` / `undefined` の場合は何も描画しない（既存バトル履歴への後方互換性）
 - バックエンドで障害物が生成されない設定（`obstacle_density: "NONE"` など）では `obstacles_info` は `null` として保存される
+- `/api/battle/simulate` の `BattleResponse` にも `obstacles_info` フィールドが含まれる（バトル実行直後のライブ観戦画面で障害物を描画するために必要）
 
 ---
 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -85,6 +85,7 @@ export default function Home() {
     setSelectedMissionId,
     playerData,
     enemiesData,
+    obstaclesData,
     rewards,
     currentEnvironment,
     startBattle,
@@ -151,6 +152,7 @@ export default function Home() {
               logs={logs}
               player={playerData}
               enemies={enemiesData}
+              obstacles={obstaclesData}
               currentTimestamp={currentTimestamp}
               environment={currentEnvironment}
             />

--- a/frontend/src/hooks/useBattleSimulation.ts
+++ b/frontend/src/hooks/useBattleSimulation.ts
@@ -3,6 +3,7 @@
 
 import { useState, useEffect } from "react";
 import { BattleLog, BattleRewards, Mission, MobileSuit } from "@/types/battle";
+import { Obstacle } from "@/types/geometry";
 
 interface ModalResult {
   winLoss: "WIN" | "LOSE" | "DRAW";
@@ -31,6 +32,7 @@ interface UseBattleSimulationReturn {
   setSelectedMissionId: (id: number) => void;
   playerData: MobileSuit | null;
   enemiesData: MobileSuit[];
+  obstaclesData: Obstacle[];
   rewards: BattleRewards | null;
   currentEnvironment: string;
   startBattle: (missionId: number) => Promise<void>;
@@ -56,6 +58,7 @@ export function useBattleSimulation({
   const [selectedMissionId, setSelectedMissionId] = useState<number>(1);
   const [playerData, setPlayerData] = useState<MobileSuit | null>(null);
   const [enemiesData, setEnemiesData] = useState<MobileSuit[]>([]);
+  const [obstaclesData, setObstaclesData] = useState<Obstacle[]>([]);
   const [rewards, setRewards] = useState<BattleRewards | null>(null);
   const [currentEnvironment, setCurrentEnvironment] =
     useState<string>("SPACE");
@@ -80,6 +83,7 @@ export function useBattleSimulation({
     setWinLoss(null);
     setCurrentTimestamp(0);
     setRewards(null);
+    setObstaclesData([]);
 
     try {
       const token = await getToken();
@@ -128,6 +132,7 @@ export function useBattleSimulation({
 
       setPlayerData(data.player_info);
       setEnemiesData(data.enemies_info);
+      setObstaclesData(data.obstacles_info ?? []);
 
       if (data.rewards) {
         setRewards(data.rewards);
@@ -159,6 +164,7 @@ export function useBattleSimulation({
     setSelectedMissionId,
     playerData,
     enemiesData,
+    obstaclesData,
     rewards,
     currentEnvironment,
     startBattle,


### PR DESCRIPTION
## Summary
- ダッシュボードのライブ観戦画面（Tactical Monitor）で戦闘実行後、フィールドに障害物が生成されているにもかかわらず3Dシーンに一切表示されない不具合を修正
- あわせて、デイリーバトルロイヤル（バッチ実行）のバトル履歴でも障害物が表示されない不具合を修正（レビュー用に実機確認したところ発覚した派生バグ）

### 原因1: ライブ観戦画面（Tactical Monitor）
`/api/battle/simulate` のレスポンス（`BattleResponse`）に `obstacles_info` フィールドが存在せず、フロントエンドの `useBattleSimulation` フック・`page.tsx` の `BattleViewer` にも障害物データが渡っていなかった。

### 原因2: デイリーバトルロイヤル（バッチ）
`BattleResult` の生成箇所は `backend/main.py`（即時実行）と `backend/scripts/run_batch.py`（バッチ実行）の2箇所あるが、`obstacles_info` を設定していたのは `main.py` のみで、`run_batch.py` 側は常に `NULL` のまま保存されていた（バトル履歴の `BattleDetailModal` で障害物が表示されない）。

## Changes
- `backend/app/engine/battle_utils.py`: 障害物のシリアライズ処理を `serialize_obstacles()` として共通化
- `backend/main.py`: `BattleResponse` に `obstacles_info` フィールドを追加し、`serialize_obstacles()` を使ってレスポンス・DB保存の両方に設定
- `backend/scripts/run_batch.py`: `_save_battle_results` 内の `BattleResult` 生成にも `serialize_obstacles()` の結果を設定
- `frontend/src/hooks/useBattleSimulation.ts`: レスポンスの `obstacles_info` を `obstaclesData` stateとして保持
- `frontend/src/app/page.tsx`: `<BattleViewer>` に `obstacles={obstaclesData}` を追加
- `docs/features/battle-viewer-feature.md`: ライブ観戦画面側のデータフロー、および `BattleResult` 生成箇所が2つある点を追記

Closes #429

## Test plan
- [x] `npx tsc --noEmit`（フロントエンド型チェック）
- [x] `ruff check` / `ruff format` / `mypy`（バックエンド、pre-commitフックで実行）
- [x] `pytest tests/`（バックエンド全テスト、全件パス）
- [x] バックエンドを起動し `curl -X POST /api/battle/simulate?mission_id=1` を実行、レスポンスに `obstacles_info`（21件の障害物データ）が含まれることを確認
- [ ] ブラウザでのライブ観戦画面・バトル履歴の目視確認（Clerk認証が必要なためこの環境では未実施。レンダリング経路自体はリプレイ機能で動作実績のあるコンポーネントを再利用しており、propが渡るようになったことをAPIレベルで確認済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)