### PR TITLE
fix: BattleViewerの座標マッピングで軸が入れ替わっており配置が平面的に見える問題を修正

### DIFF
--- a/docs/features/battle-viewer-feature.md
+++ b/docs/features/battle-viewer-feature.md
@@ -144,7 +144,7 @@ BattleViewer
 - `CameraInitializer` コンポーネント（`Canvas` の子）が `useEffect` でマウント時に1回だけ実行
 - カメラ位置: `[px + 50, py + 50, pz + 50]`（自機初期 Three.js 座標からの固定オフセット）
 - `OrbitControls` の target（注視点）: `[px, py, pz]`（自機初期 Three.js 座標）
-- 座標変換: `scale = 0.05`、`game.z → three.y`、`game.y → three.z`（`MobileSuitMesh` と統一）
+- 座標変換: `scale = 0.05`、`game.x/y/z → three.x/y/z` の直接対応（`MobileSuitMesh` 等 BattleViewer 全体と統一。ゲームエンジン側は `x`/`z` が地面平面、`y` が高度（通常0）。以前は `game.z → three.y` / `game.y → three.z` と軸が入れ替わっており、障害物・機体とも本来の配置が「高さ」方向に潰れて平面的に見える不具合があった（Issue #433 で修正）
 
 ### 実装詳細
 
@@ -567,7 +567,7 @@ BattleViewer
 - `CameraInitializer` コンポーネント（`Canvas` の子）が `useEffect` でマウント時に1回だけ実行
 - カメラ位置: `[px + 50, py + 50, pz + 50]`（自機初期 Three.js 座標からの固定オフセット）
 - `OrbitControls` の target（注視点）: `[px, py, pz]`（自機初期 Three.js 座標）
-- 座標変換: `scale = 0.05`、`game.z → three.y`、`game.y → three.z`（`MobileSuitMesh` と統一）
+- 座標変換: `scale = 0.05`、`game.x/y/z → three.x/y/z` の直接対応（`MobileSuitMesh` 等 BattleViewer 全体と統一。ゲームエンジン側は `x`/`z` が地面平面、`y` が高度（通常0）。以前は `game.z → three.y` / `game.y → three.z` と軸が入れ替わっており、障害物・機体とも本来の配置が「高さ」方向に潰れて平面的に見える不具合があった（Issue #433 で修正）
 
 ### 実装詳細
 

--- a/frontend/src/components/BattleViewer/scene/BattleEventDisplay.tsx
+++ b/frontend/src/components/BattleViewer/scene/BattleEventDisplay.tsx
@@ -15,7 +15,7 @@ export function BattleEventDisplay({
     event: BattleEventEffect | null;
 }) {
     const scale = 0.05;
-    const vec = new THREE.Vector3(position.x * scale, position.z * scale, position.y * scale);
+    const vec = new THREE.Vector3(position.x * scale, position.y * scale, position.z * scale);
     
     if (!event) return null;
     // attack_line 型はテキスト表示なし（Three.js ラインのみ描画）

--- a/frontend/src/components/BattleViewer/scene/BattleScene.tsx
+++ b/frontend/src/components/BattleViewer/scene/BattleScene.tsx
@@ -118,13 +118,13 @@ function TargetLine({
     const lineObject = useMemo(() => {
         const p1 = new THREE.Vector3(
             playerPos.x * POSITION_SCALE,
-            playerPos.z * POSITION_SCALE,
             playerPos.y * POSITION_SCALE,
+            playerPos.z * POSITION_SCALE,
         );
         const p2 = new THREE.Vector3(
             targetPos.x * POSITION_SCALE,
-            targetPos.z * POSITION_SCALE,
             targetPos.y * POSITION_SCALE,
+            targetPos.z * POSITION_SCALE,
         );
         const geometry = new THREE.BufferGeometry().setFromPoints([p1, p2]);
         const material = new THREE.LineDashedMaterial({
@@ -157,13 +157,13 @@ function AttackLine({
     const lineObject = useMemo(() => {
         const p1 = new THREE.Vector3(
             fromPos.x * POSITION_SCALE,
-            fromPos.z * POSITION_SCALE,
             fromPos.y * POSITION_SCALE,
+            fromPos.z * POSITION_SCALE,
         );
         const p2 = new THREE.Vector3(
             toPos.x * POSITION_SCALE,
-            toPos.z * POSITION_SCALE,
             toPos.y * POSITION_SCALE,
+            toPos.z * POSITION_SCALE,
         );
         const geometry = new THREE.BufferGeometry().setFromPoints([p1, p2]);
         let material: THREE.LineBasicMaterial | THREE.LineDashedMaterial;
@@ -207,13 +207,13 @@ function LosLine({
     const lineObject = useMemo(() => {
         const p1 = new THREE.Vector3(
             playerPos.x * POSITION_SCALE,
-            playerPos.z * POSITION_SCALE,
             playerPos.y * POSITION_SCALE,
+            playerPos.z * POSITION_SCALE,
         );
         const p2 = new THREE.Vector3(
             enemyPos.x * POSITION_SCALE,
-            enemyPos.z * POSITION_SCALE,
             enemyPos.y * POSITION_SCALE,
+            enemyPos.z * POSITION_SCALE,
         );
         const geometry = new THREE.BufferGeometry().setFromPoints([p1, p2]);
         const material = new THREE.LineDashedMaterial({
@@ -252,8 +252,8 @@ export function BattleScene({
     // 自機MS初期Three.js座標をマウント時のみキャプチャ（MobileSuitMesh と同じ軸変換）
     const initialPos = useRef({
         x: playerState.pos.x * POSITION_SCALE,
-        y: playerState.pos.z * POSITION_SCALE, // game.z → Three.js の高さ方向 y
-        z: playerState.pos.y * POSITION_SCALE, // game.y → Three.js の奥行き方向 z
+        y: playerState.pos.y * POSITION_SCALE, // game.y（高度、通常0）→ Three.js の高さ方向 y
+        z: playerState.pos.z * POSITION_SCALE, // game.z（地面平面の第2軸）→ Three.js の奥行き方向 z
     });
     const { x: px, y: py, z: pz } = initialPos.current;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/frontend/src/components/BattleViewer/scene/HitEffectMesh.tsx
+++ b/frontend/src/components/BattleViewer/scene/HitEffectMesh.tsx
@@ -38,8 +38,8 @@ export function HitEffectMesh({
     // ゲーム座標 → Three.js 座標変換
     const center3D = new THREE.Vector3(
         position.x * POSITION_SCALE,
-        position.z * POSITION_SCALE,
         position.y * POSITION_SCALE,
+        position.z * POSITION_SCALE,
     );
 
     // 各パーティクルの初期方向ベクトルを事前計算（球面上にランダム分布）

--- a/frontend/src/components/BattleViewer/scene/MobileSuitMesh.tsx
+++ b/frontend/src/components/BattleViewer/scene/MobileSuitMesh.tsx
@@ -46,7 +46,8 @@ export function MobileSuitMesh({
     isSelf?: boolean;
 }) {
     const scale = 0.05;
-    const vec = new THREE.Vector3(position.x * scale, position.z * scale, position.y * scale);
+    // ゲーム座標(x,z=地面平面, y=高度)→Three.js座標(x,y=高さ,z=奥行き)は x→x, y→y, z→z でそのまま対応する
+    const vec = new THREE.Vector3(position.x * scale, position.y * scale, position.z * scale);
     const color = getHpColor(currentHp, maxHp);
 
     // ホバリングアニメーション用グループ ref (B-4)
@@ -123,13 +124,11 @@ export function MobileSuitMesh({
     const headingArrow = useMemo(() => {
         if (heading === undefined) return null;
         const headingRad = (heading * Math.PI) / 180;
-        // ゲーム座標→Three.js座標: game.x→X, game.z→Y, game.y(高さ=0)→Z
-        // バックエンド: direction=[cos,0,sin] (XZ平面) → Three.js: (cos, sin, 0) (XY平面)
+        // バックエンド: direction=[cos,0,sin] (game.x,z の地面平面) → Three.js座標もそのまま (cos, 0, sin)
         const dir = new THREE.Vector3(
-            Math.cos(headingRad), Math.sin(headingRad), 0
+            Math.cos(headingRad), 0, Math.sin(headingRad)
         ).normalize();
         return new THREE.ArrowHelper(dir, new THREE.Vector3(0, 0, 0), 4, 0x4488ff, 1.5, 1.0);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [heading]);
 
     // 撃破されたターンのみ💥を表示（前のターンでHPが残っていた場合のみ）

--- a/frontend/src/components/BattleViewer/scene/ObstacleMesh.tsx
+++ b/frontend/src/components/BattleViewer/scene/ObstacleMesh.tsx
@@ -23,8 +23,8 @@ export function ObstacleMesh({ obstacle, environment = "SPACE", isBlocking = fal
 
     const normalColor = environment === "GROUND" ? "#4a5a4a" : "#5a4a3a";
     const color = isBlocking ? "#8a3a3a" : normalColor;
-    // 輪郭線: 塗りと同じ色相を明るくした色を使用（isBlocking は既存パレットの赤 #ff4444 を流用）
-    const normalEdgeColor = environment === "GROUND" ? "#8fb88f" : "#b89b78";
+    // 輪郭線: SPACEはグレー(#808080)、GROUNDは塗りと同色相を明るくした色（isBlocking は既存パレットの赤 #ff4444 を流用）
+    const normalEdgeColor = environment === "GROUND" ? "#8fb88f" : "#808080";
     const edgeColor = isBlocking ? "#ff4444" : normalEdgeColor;
 
     return (

--- a/frontend/src/components/BattleViewer/scene/ObstacleMesh.tsx
+++ b/frontend/src/components/BattleViewer/scene/ObstacleMesh.tsx
@@ -16,15 +16,15 @@ interface ObstacleMeshProps {
 
 export function ObstacleMesh({ obstacle, environment = "SPACE", isBlocking = false }: ObstacleMeshProps) {
     const x = obstacle.position.x * OBSTACLE_SCALE;
-    const y = obstacle.position.z * OBSTACLE_SCALE;
-    const z = obstacle.position.y * OBSTACLE_SCALE;
+    const y = obstacle.position.y * OBSTACLE_SCALE;
+    const z = obstacle.position.z * OBSTACLE_SCALE;
     const r = obstacle.radius * OBSTACLE_SCALE;
     const h = Math.max(obstacle.height * OBSTACLE_SCALE, r * 2);
 
     const normalColor = environment === "GROUND" ? "#4a5a4a" : "#5a4a3a";
     const color = isBlocking ? "#8a3a3a" : normalColor;
-    // 輪郭線: 塗りと同じ色相を明るくした色を使用（isBlocking は既存パレットの赤 #ff4444 を流用）
-    const normalEdgeColor = environment === "GROUND" ? "#8fb88f" : "#b89b78";
+    // 輪郭線: SPACEはグレー(#808080)、GROUNDは塗りと同色相を明るくした色（isBlocking は既存パレットの赤 #ff4444 を流用）
+    const normalEdgeColor = environment === "GROUND" ? "#8fb88f" : "#808080";
     const edgeColor = isBlocking ? "#ff4444" : normalEdgeColor;
 
     return (

--- a/frontend/src/components/BattleViewer/scene/ProjectileMesh.tsx
+++ b/frontend/src/components/BattleViewer/scene/ProjectileMesh.tsx
@@ -38,16 +38,16 @@ export function ProjectileMesh({
     const meshRef = useRef<THREE.Mesh>(null);
     const completedRef = useRef(false);
 
-    // ゲーム座標 → Three.js 座標変換（BattleScene の軸変換と統一: x→X, z→Y, y→Z）
+    // ゲーム座標 → Three.js 座標変換（BattleScene の軸変換と統一: x→X, y→Y, z→Z）
     const from3D = new THREE.Vector3(
         fromPos.x * POSITION_SCALE,
-        fromPos.z * POSITION_SCALE,
         fromPos.y * POSITION_SCALE,
+        fromPos.z * POSITION_SCALE,
     );
     const to3D = new THREE.Vector3(
         toPos.x * POSITION_SCALE,
-        toPos.z * POSITION_SCALE,
         toPos.y * POSITION_SCALE,
+        toPos.z * POSITION_SCALE,
     );
 
     useFrame(() => {


### PR DESCRIPTION
## Summary
- Issue #431 の視認性改善作業中、ユーザーから「障害物が平面的な配置になっているように見える」との報告があり調査したところ、BattleViewer全体に影響する座標マッピングのバグが判明
- ゲームエンジン側の座標系は `x`/`z` が地面（戦闘平面）の2軸、`y` が高度（通常 `0.0` 固定）という設計で一貫している（`_sample_position_in_zone`、`combat.py`のhas_los docstring「Y軸（高度）も考慮する」、`movement.py`の`direction=[cos,0,sin]`などで確認。実データでも機体・障害物とも`position.y`は常に`0.0`だった）
- しかしフロントエンドの座標変換は `new THREE.Vector3(position.x*scale, position.z*scale, position.y*scale)` という共通パターンで、常に`0.0`固定の`game.y`をThree.jsの奥行き軸（Z）に、地面平面の一部である`game.z`を高さ軸（Y）に割り当てていた
- 結果として全オブジェクト（機体・障害物・LOSライン・攻撃ライン・飛翔体・ヒットエフェクト）がThree.js空間の同一Z断面（奥行き常に0）に押し込まれ、地面平面上の分布が高さ方向のばらつきとして表現され、配置が平面的に見えていた

## Changes
- `MobileSuitMesh.tsx` / `ObstacleMesh.tsx` / `BattleEventDisplay.tsx` / `HitEffectMesh.tsx` / `ProjectileMesh.tsx` / `BattleScene.tsx`（TargetLine/AttackLine/LosLine/カメラ初期化）: 座標変換を `x, y, z` の素直な対応に統一
- `MobileSuitMesh.tsx`: 向き矢印（ArrowHelper）の方向ベクトルもバックエンドの `[cos,0,sin]`（地面平面）にそのまま対応するよう修正（従来はXY平面向きになっており実質的に地面と平行ではなかった）
- `docs/features/battle-viewer-feature.md`: 座標変換の説明を修正

Closes #433

## Base branch について
このブランチは `fix/issue-431-obstacle-visibility`（PR #432, 未マージ）から派生しています。同じ `ObstacleMesh.tsx` を触っているため、#432マージ後にこのPRのベースは自動的に `main` に切り替わります。

## Test plan
- [x] `npx tsc --noEmit`（フロントエンド型チェック）
- [x] `eslint`（該当ファイル、警告0件）
- [x] ブラウザでの目視確認（Clerk認証が必要なためこの環境では未実施）

🤖 Generated with [Claude Code](https://claude.com/claude-code)