### PR TITLE
fix: 障害物の輪郭線色(SPACE)をグレー(#808080)に変更

### DIFF
--- a/frontend/src/components/BattleViewer/scene/ObstacleMesh.tsx
+++ b/frontend/src/components/BattleViewer/scene/ObstacleMesh.tsx
@@ -23,8 +23,8 @@ export function ObstacleMesh({ obstacle, environment = "SPACE", isBlocking = fal
 
     const normalColor = environment === "GROUND" ? "#4a5a4a" : "#5a4a3a";
     const color = isBlocking ? "#8a3a3a" : normalColor;
-    // 輪郭線: 塗りと同じ色相を明るくした色を使用（isBlocking は既存パレットの赤 #ff4444 を流用）
-    const normalEdgeColor = environment === "GROUND" ? "#8fb88f" : "#b89b78";
+    // 輪郭線: SPACEはグレー(#808080)、GROUNDは塗りと同色相を明るくした色（isBlocking は既存パレットの赤 #ff4444 を流用）
+    const normalEdgeColor = environment === "GROUND" ? "#8fb88f" : "#808080";
     const edgeColor = isBlocking ? "#ff4444" : normalEdgeColor;
 
     return (


### PR DESCRIPTION
## Summary
PR #432（マージ済み）レビュー後、ユーザーからのフィードバックでSPACE環境の障害物輪郭線色を `#b89b78` から `#808080`（グレー）に変更する追加修正です。#432マージ後に発生したため、別PRとして切り出しています。

## Changes
- `ObstacleMesh.tsx`: `normalEdgeColor`（SPACE）を `#808080` に変更

## Test plan
- [x] `npx tsc --noEmit`
- [x] `eslint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)