### PR TITLE
fix: BattleViewerの背景グリッドをバトルフィールドに整列させる

### DIFF
--- a/backend/alembic/versions/w6x7y8z9a0b1_add_map_bounds_to_battle_results.py
+++ b/backend/alembic/versions/w6x7y8z9a0b1_add_map_bounds_to_battle_results.py
@@ -1,0 +1,32 @@
+"""add_map_bounds_to_battle_results.
+
+Revision ID: w6x7y8z9a0b1
+Revises: v5w6x7y8z9a0
+Create Date: 2026-08-13 00:00:00.000000
+
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "w6x7y8z9a0b1"
+down_revision: str | Sequence[str] | None = "v5w6x7y8z9a0"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Upgrade schema."""
+    op.add_column(
+        "battle_results",
+        sa.Column("map_bounds", sa.JSON(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Downgrade schema."""
+    op.drop_column("battle_results", "map_bounds")

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -771,6 +771,11 @@ class BattleResult(SQLModel, table=True):
         sa_column=Column(JSON, nullable=True),
         description="参加時の機体データスナップショット（エントリー時点）",
     )
+    map_bounds: list[float] | None = Field(
+        default=None,
+        sa_column=Column(JSON, nullable=True),
+        description="フィールド範囲 [min, max] (m)。BattleViewerの背景グリッド整列用 (Issue #436)",
+    )
     kills: int = Field(default=0, description="撃墜数")
     exp_gained: int = Field(default=0, description="獲得経験値")
     credits_gained: int = Field(default=0, description="獲得クレジット")
@@ -818,6 +823,7 @@ class BattleResultSummary(SQLModel):
     enemies_info: list[dict] | None = None
     obstacles_info: list[dict] | None = None
     ms_snapshot: dict | None = None
+    map_bounds: list[float] | None = None
     kills: int = 0
     exp_gained: int = 0
     credits_gained: int = 0

--- a/backend/main.py
+++ b/backend/main.py
@@ -109,6 +109,7 @@ class BattleResponse(BaseModel):
     enemies_info: list[MobileSuit]
     obstacles_info: list[dict] | None = None
     rewards: BattleRewards | None = None
+    map_bounds: tuple[float, float] | None = None
 
 
 # --- API Endpoints ---
@@ -352,6 +353,7 @@ async def simulate_battle(
         enemies_info=[e.model_dump() for e in enemies],
         obstacles_info=obstacles_data,
         ms_snapshot=player.model_dump(),
+        map_bounds=list(sim.map_bounds),
         kills=kills,
         exp_gained=exp_gained,
         credits_gained=credits_gained,
@@ -372,6 +374,7 @@ async def simulate_battle(
         enemies_info=enemies,
         obstacles_info=obstacles_data,
         rewards=rewards,
+        map_bounds=sim.map_bounds,
     )
 
 

--- a/backend/scripts/run_batch.py
+++ b/backend/scripts/run_batch.py
@@ -335,6 +335,7 @@ def _save_battle_results(
             enemies_info=enemies_info_for_entry,
             obstacles_info=obstacles_data,
             ms_snapshot=entry.mobile_suit_snapshot,
+            map_bounds=list(simulator.map_bounds),
             kills=individual_kills,
             exp_gained=exp_gained,
             credits_gained=credits_gained,

--- a/docs/features/battle-viewer-feature.md
+++ b/docs/features/battle-viewer-feature.md
@@ -326,6 +326,30 @@ POST /api/battle/simulate レスポンスの obstacles_info
 
 ---
 
+## 背景グリッドとバトルフィールドの整列（`map_bounds`）（Issue #436）
+
+### 背景
+
+バトルフィールドは `backend/app/engine/simulation.py` の `BattleSimulator.map_bounds`（`(0.0, side_len)`、`side_len` はユニット数に応じて `MIN_FIELD_SIZE`〜`MAX_FIELD_SIZE`（2000〜8000）で動的算出）で表される、正の象限のみに存在する正方形。一方 `BattleScene.tsx` の `<Grid infiniteGrid>` は `position` 未指定だとThree.jsワールド原点 `(0,0,0)` を基準に描画されるうえ、`fadeDistance`（カメラからの距離でフェードする範囲）が固定値 `100` だったため、フィールドが大きい/カメラから離れているバトルではグリッドが早々にフェードアウトし、フィールドの一部にしかグリッドが重ならない見た目になっていた。
+
+### 対応内容
+
+1. **バックエンド**: `BattleSimulator.map_bounds` を `map_bounds: list[float] | None`（`[min, max]`）として `BattleResult`（DB, `battle_results.map_bounds` カラム）と `/api/battle/simulate` の `BattleResponse` の両方に含める。`BattleResult` の生成箇所は2箇所ある（`backend/main.py` / `backend/scripts/run_batch.py`）ため、障害物情報と同様に両方に設定が必要。マイグレーション前の既存レコードは `null`（バックフィルなし、既存カラムと同じ方針）
+2. **フロントエンド**: `BattleScene.tsx` が `mapBounds` prop（`[number, number] | null | undefined`）を受け取り、フィールド中心 `(min+max)/2 * POSITION_SCALE` を `<Grid position>` に設定。`fadeDistance` もフィールドの一辺長（`(max-min) * POSITION_SCALE`）に応じて動的に拡大する（最低値100は維持）。`mapBounds` が未取得（`null`/`undefined`、マイグレーション前の履歴データ等）の場合は `DEFAULT_MAP_BOUNDS = [0, 5000]`（`backend/app/engine/constants.py` の `MAP_BOUNDS` デフォルトと同値）にフォールバックする
+
+### データフロー
+
+```
+BattleSimulator.map_bounds (backend/app/engine/simulation.py)
+  → BattleResult.map_bounds (DB) / BattleResponse.map_bounds (即時実行レスポンス)
+  → useBattleSimulation フック（mapBounds state）/ BattleResult 型（履歴データ）
+  → page.tsx / BattleDetailModal.tsx (mapBounds を BattleViewer に渡す)
+  → BattleViewer (mapBounds prop)
+  → BattleScene (Grid の position・fadeDistance を算出)
+```
+
+---
+
 ## 攻撃エフェクト（武器・命中結果の可視化）
 
 ### 概要

--- a/docs/features/battle-viewer-feature.md
+++ b/docs/features/battle-viewer-feature.md
@@ -334,7 +334,7 @@ POST /api/battle/simulate レスポンスの obstacles_info
 
 ### 対応内容
 
-1. **バックエンド**: `BattleSimulator.map_bounds` を `map_bounds: list[float] | None`（`[min, max]`）として `BattleResult`（DB, `battle_results.map_bounds` カラム）と `/api/battle/simulate` の `BattleResponse` の両方に含める。`BattleResult` の生成箇所は2箇所ある（`backend/main.py` / `backend/scripts/run_batch.py`）ため、障害物情報と同様に両方に設定が必要。マイグレーション前の既存レコードは `null`（バックフィルなし、既存カラムと同じ方針）
+1. **バックエンド**: `BattleSimulator.map_bounds`（`tuple[float, float]`、`(0.0, side_len)`）を `BattleResult.map_bounds`（`list[float] | None`、DB, `battle_results.map_bounds` カラム）と `/api/battle/simulate` の `BattleResponse.map_bounds`（`tuple[float, float] | None`）の両方に含める。`BattleResult` の生成箇所は2箇所ある（`backend/main.py` / `backend/scripts/run_batch.py`）ため、障害物情報と同様に両方に設定が必要。マイグレーション前の既存レコードは `null`（バックフィルなし、既存カラムと同じ方針）
 2. **フロントエンド**: `BattleScene.tsx` が `mapBounds` prop（`[number, number] | null | undefined`）を受け取り、フィールド中心 `(min+max)/2 * POSITION_SCALE` を `<Grid position>` に設定。`fadeDistance` もフィールドの一辺長（`(max-min) * POSITION_SCALE`）に応じて動的に拡大する（最低値100は維持）。`mapBounds` が未取得（`null`/`undefined`、マイグレーション前の履歴データ等）の場合は `DEFAULT_MAP_BOUNDS = [0, 5000]`（`backend/app/engine/constants.py` の `MAP_BOUNDS` デフォルトと同値）にフォールバックする
 
 ### データフロー

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -86,6 +86,7 @@ export default function Home() {
     playerData,
     enemiesData,
     obstaclesData,
+    mapBounds,
     rewards,
     currentEnvironment,
     startBattle,
@@ -153,6 +154,7 @@ export default function Home() {
               player={playerData}
               enemies={enemiesData}
               obstacles={obstaclesData}
+              mapBounds={mapBounds}
               currentTimestamp={currentTimestamp}
               environment={currentEnvironment}
             />

--- a/frontend/src/components/BattleViewer/index.tsx
+++ b/frontend/src/components/BattleViewer/index.tsx
@@ -17,17 +17,20 @@ interface BattleViewerProps {
     player: MobileSuit;
     enemies: MobileSuit[];
     obstacles?: Obstacle[];
+    /** フィールド範囲 [min, max] (m)。BattleViewerの背景グリッド整列用 (Issue #436) */
+    mapBounds?: [number, number] | null;
     currentTimestamp: number;
     environment?: string;
 }
 
-export default function BattleViewer({ 
-    logs, 
-    player, 
-    enemies, 
+export default function BattleViewer({
+    logs,
+    player,
+    enemies,
     obstacles,
-    currentTimestamp, 
-    environment = "SPACE" 
+    mapBounds,
+    currentTimestamp,
+    environment = "SPACE"
 }: BattleViewerProps) {
     // LOS 表示のトグルステート（デフォルト: OFF）
     const [showLos, setShowLos] = useState(false);
@@ -88,6 +91,7 @@ export default function BattleViewer({
                 enemyStates={visibleEnemyStates}
                 enemyEvents={enemyEvents}
                 obstacles={obstacles}
+                mapBounds={mapBounds}
                 losResults={losResults}
                 attackingUnitIds={attackingUnitIds}
                 currentTimestamp={currentTimestamp}

--- a/frontend/src/components/BattleViewer/scene/BattleScene.tsx
+++ b/frontend/src/components/BattleViewer/scene/BattleScene.tsx
@@ -20,6 +20,10 @@ import { getEnvironmentColor } from "../utils";
 // MobileSuitMesh と同じスケール定数（座標変換の一貫性）
 const POSITION_SCALE = 0.05;
 
+// map_bounds が未取得（旧バトル履歴等）の場合のフォールバック値。
+// backend/app/engine/constants.py の MAP_BOUNDS デフォルトと合わせる
+const DEFAULT_MAP_BOUNDS: [number, number] = [0, 5000];
+
 // 飛翔体・ヒットエフェクトの上限数と飛翔時間
 const MAX_PROJECTILES = 20;
 const MAX_HIT_EFFECTS = 15;
@@ -99,6 +103,8 @@ interface BattleSceneProps {
     enemyStates: Array<{ enemy: MobileSuit; state: UnitState }>;
     enemyEvents: Array<{ id: string; event: BattleEventEffect | null }>;
     obstacles?: Obstacle[];
+    /** フィールド範囲 [min, max] (m)。背景グリッドをフィールドに整列させるために使用 (Issue #436) */
+    mapBounds?: [number, number] | null;
     /** LOS 表示が ON のときのみ渡される計算済み LOS 結果 */
     losResults?: LosResult[];
     /** 現在タイムスタンプで攻撃アクション中のユニット ID セット（射撃反動アニメーション用）*/
@@ -245,10 +251,16 @@ export function BattleScene({
     enemyStates,
     enemyEvents,
     obstacles,
+    mapBounds,
     losResults,
     attackingUnitIds,
     currentTimestamp,
 }: BattleSceneProps) {
+    // フィールド中心・全体をカバーするグリッドの位置とフェード距離を算出（Issue #436）
+    const [mapMin, mapMax] = mapBounds ?? DEFAULT_MAP_BOUNDS;
+    const fieldCenter = ((mapMin + mapMax) / 2) * POSITION_SCALE;
+    const fieldSpan = (mapMax - mapMin) * POSITION_SCALE;
+    const gridFadeDistance = Math.max(100, fieldSpan * 1.2);
     // 自機MS初期Three.js座標をマウント時のみキャプチャ（MobileSuitMesh と同じ軸変換）
     const initialPos = useRef({
         x: playerState.pos.x * POSITION_SCALE,
@@ -373,10 +385,11 @@ export function BattleScene({
                 <Stars radius={100} depth={50} count={2000} factor={4} fade speed={1} />
             )}
             <Grid
+                position={[fieldCenter, 0, fieldCenter]}
                 infiniteGrid
                 sectionSize={10}
                 cellSize={1}
-                fadeDistance={100}
+                fadeDistance={gridFadeDistance}
                 sectionColor={environment === "COLONY" ? "#8a8aaa" : "#00ff00"}
                 cellColor={environment === "COLONY" ? "#4a4a6a" : "#003300"}
             />

--- a/frontend/src/components/history/BattleDetailModal.tsx
+++ b/frontend/src/components/history/BattleDetailModal.tsx
@@ -81,6 +81,7 @@ export default function BattleDetailModal({
                     player={battle.player_info as MobileSuit}
                     enemies={battle.enemies_info as MobileSuit[]}
                     obstacles={battle.obstacles_info}
+                    mapBounds={battle.map_bounds}
                     currentTimestamp={currentTimestamp}
                     environment={battle.environment || "SPACE"}
                   />

--- a/frontend/src/hooks/useBattleSimulation.ts
+++ b/frontend/src/hooks/useBattleSimulation.ts
@@ -33,6 +33,7 @@ interface UseBattleSimulationReturn {
   playerData: MobileSuit | null;
   enemiesData: MobileSuit[];
   obstaclesData: Obstacle[];
+  mapBounds: [number, number] | null;
   rewards: BattleRewards | null;
   currentEnvironment: string;
   startBattle: (missionId: number) => Promise<void>;
@@ -59,6 +60,7 @@ export function useBattleSimulation({
   const [playerData, setPlayerData] = useState<MobileSuit | null>(null);
   const [enemiesData, setEnemiesData] = useState<MobileSuit[]>([]);
   const [obstaclesData, setObstaclesData] = useState<Obstacle[]>([]);
+  const [mapBounds, setMapBounds] = useState<[number, number] | null>(null);
   const [rewards, setRewards] = useState<BattleRewards | null>(null);
   const [currentEnvironment, setCurrentEnvironment] =
     useState<string>("SPACE");
@@ -84,6 +86,7 @@ export function useBattleSimulation({
     setCurrentTimestamp(0);
     setRewards(null);
     setObstaclesData([]);
+    setMapBounds(null);
 
     try {
       const token = await getToken();
@@ -133,6 +136,7 @@ export function useBattleSimulation({
       setPlayerData(data.player_info);
       setEnemiesData(data.enemies_info);
       setObstaclesData(data.obstacles_info ?? []);
+      setMapBounds(data.map_bounds ?? null);
 
       if (data.rewards) {
         setRewards(data.rewards);
@@ -165,6 +169,7 @@ export function useBattleSimulation({
     playerData,
     enemiesData,
     obstaclesData,
+    mapBounds,
     rewards,
     currentEnvironment,
     startBattle,

--- a/frontend/src/types/battleCore.ts
+++ b/frontend/src/types/battleCore.ts
@@ -51,6 +51,8 @@ export interface BattleResponse {
     player_info: MobileSuit;
     enemies_info: MobileSuit[];
     rewards?: BattleRewards;
+    /** フィールド範囲 [min, max] (m)。BattleViewerの背景グリッド整列用 (Issue #436) */
+    map_bounds?: [number, number];
 }
 
 /** バトル結果の履歴レコード（ログを含まない軽量版） */
@@ -66,6 +68,8 @@ export interface BattleResult {
     enemies_info?: MobileSuit[];
     obstacles_info?: Obstacle[];
     ms_snapshot?: MobileSuit;
+    /** フィールド範囲 [min, max] (m)。マイグレーション前の既存レコードは null (Issue #436) */
+    map_bounds?: [number, number] | null;
     kills?: number;
     exp_gained?: number;
     credits_gained?: number;

--- a/frontend/src/types/battleCore.ts
+++ b/frontend/src/types/battleCore.ts
@@ -52,7 +52,7 @@ export interface BattleResponse {
     enemies_info: MobileSuit[];
     rewards?: BattleRewards;
     /** フィールド範囲 [min, max] (m)。BattleViewerの背景グリッド整列用 (Issue #436) */
-    map_bounds?: [number, number];
+    map_bounds?: [number, number] | null;
 }
 
 /** バトル結果の履歴レコード（ログを含まない軽量版） */


### PR DESCRIPTION
## Summary
- `BattleSimulator.map_bounds`（フィールド範囲 `[0, side_len]`）をバックエンドAPI/DBに露出し、フロントエンドに伝搬させた
- `BattleScene.tsx` の `<Grid infiniteGrid>` にフィールド中心を `position` として設定し、`fadeDistance` もフィールドサイズに応じて拡大することで、大きいフィールド・原点から離れた位置でもグリッドがフィールド全体をカバーするようにした
- 旧バトル履歴（`map_bounds` が `null`）は `DEFAULT_MAP_BOUNDS = [0, 5000]`（バックエンドの `MAP_BOUNDS` デフォルトと同値）にフォールバック

## 変更内容
- **backend**: `BattleResult.map_bounds` カラム追加（Alembicマイグレーション、nullable・バックフィルなし）、`BattleResponse.map_bounds` 追加。生成箇所が2つある `BattleResult`（`main.py` / `scripts/run_batch.py`）両方に設定
- **frontend**: `BattleResponse`/`BattleResult` 型に `map_bounds` 追加 → `useBattleSimulation` フック → `page.tsx` / `BattleDetailModal.tsx` → `BattleViewer` → `BattleScene` の `Grid` position/fadeDistance算出まで一気通貫で配線
- `docs/features/battle-viewer-feature.md` に対応内容とデータフローを追記

Closes #436

## Test plan
- [x] `cd backend && python -m pytest tests/unit --tb=line`（全件パス）
- [x] `cd frontend && npx vitest run tests/unit/`（全件パス）
- [x] `cd frontend && ./node_modules/.bin/tsc --noEmit`（エラーなし）
- [x] Alembicマイグレーションを共有Neon DBに適用（`alembic upgrade head`）した上でローカルで両サーバーを起動し、Playwrightで実際にバトルを即時シミュレーション実行 → BattleViewerの3Dシーンをスクリーンショットで確認。グリッドが障害物・ユニットの配置と噛み合い、フィールド全体をカバーしていることを目視確認済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)