### PR TITLE
fix: 障害物→スポーンの順に生成を変更し、障害物がシミュレーションに影響するよう修正

### DIFF
--- a/backend/app/engine/constants.py
+++ b/backend/app/engine/constants.py
@@ -125,6 +125,10 @@ SPAWN_ZONE_MIN_DIST_RELAXATION_FACTOR: float = (
     0.5  # 最小間隔緩和係数（試行失敗時に min_dist に乗算）
 )
 
+# スポーン中心の障害物回避定数 (Issue #437: 障害物→スポーンの順に生成変更)
+SPAWN_CENTER_JITTER_RADIUS: float = 300.0  # 障害物回避のためのジッター探索半径 (m)
+SPAWN_CENTER_SEARCH_MAX_TRIES: int = 30  # 障害物回避位置の探索最大試行回数
+
 # フィールドスケーリング定数 (Phase 6-5)
 AREA_PER_UNIT: float = 250_000.0  # 1ユニットあたりの面積 (m²) = 500m × 500m
 MIN_FIELD_SIZE: float = 2000.0  # 最小フィールド辺長 (m)

--- a/backend/app/engine/simulation.py
+++ b/backend/app/engine/simulation.py
@@ -18,6 +18,8 @@ from app.engine.constants import (
     MIN_FIELD_SIZE,
     MOVE_LOG_MIN_DIST,
     OBSTACLE_GRID_PARAMS,
+    SPAWN_CENTER_JITTER_RADIUS,
+    SPAWN_CENTER_SEARCH_MAX_TRIES,
     SPAWN_ZONE_MIN_DIST_RELAXATION_FACTOR,
     SPAWN_ZONE_RADIUS_2TEAM,
     SPAWN_ZONE_RADIUS_3TEAM,
@@ -303,28 +305,10 @@ class BattleSimulator(
             for team_id in team_ids
         }
 
-        # スポーン領域の解決と適用 (Phase 6-3)
+        # 障害物・スポーン領域の解決と適用 (Phase 6-3)
         # battlefield が明示的に渡された場合のみ自動生成・適用する（後方互換性）
         if self._battlefield_explicit:
-            if not self.battlefield.spawn_zones:
-                spawn_zones = self._generate_default_spawn_zones()
-                self.battlefield = BattleField(
-                    obstacles=self.battlefield.obstacles,
-                    spawn_zones=spawn_zones,
-                    obstacle_density=self.battlefield.obstacle_density,
-                )
-            self._apply_spawn_zones()
-
-            # 障害物の自動生成 (Phase 6-3)
-            # obstacles が空かつ obstacle_density != "NONE" のとき自動生成
-            if not self.obstacles and self.battlefield.obstacle_density != "NONE":
-                generated = self._generate_obstacles()
-                self.battlefield = BattleField(
-                    obstacles=generated,
-                    spawn_zones=self.battlefield.spawn_zones,
-                    obstacle_density=self.battlefield.obstacle_density,
-                )
-                self.obstacles = self.battlefield.obstacles
+            self._resolve_obstacles_and_spawn_zones()
 
         # シグモイドダメージ計算キャッシュ: 全ユニット分を一括計算 (Phase E-1)
         self._build_combat_multiplier_cache()
@@ -333,8 +317,50 @@ class BattleSimulator(
     # Phase 6-3: スポーン領域・障害物自動生成メソッド
     # ---------------------------------------------------------------------------
 
+    def _resolve_obstacles_and_spawn_zones(self) -> None:
+        """障害物・スポーン領域を解決し、self.battlefield / self.obstacles に反映する.
+
+        Issue #437: 障害物を先に配置し、スポーン領域はその配置を踏まえて決定する
+        （障害物→スポーンの順）。これにより障害物が実際の交戦エリアに影響を持つ。
+        最終的に、ジッター探索で避けきれなかった障害物や明示的に渡されたスポーン
+        領域と重なる障害物を除去し、ユニットが障害物に埋まって出現しないことを保証する。
+        """
+        # 障害物の自動生成（obstacles が空かつ obstacle_density != "NONE" のとき）
+        if not self.obstacles and self.battlefield.obstacle_density != "NONE":
+            generated = self._generate_obstacles()
+            self.battlefield = BattleField(
+                obstacles=generated,
+                spawn_zones=self.battlefield.spawn_zones,
+                obstacle_density=self.battlefield.obstacle_density,
+            )
+            self.obstacles = self.battlefield.obstacles
+
+        # スポーン領域はこの時点の障害物配置を踏まえて決定する
+        # （デフォルト生成の場合は _generate_default_spawn_zones 内でジッター回避する）
+        spawn_zones = (
+            self.battlefield.spawn_zones or self._generate_default_spawn_zones()
+        )
+
+        cleared_obstacles = (
+            self._remove_obstacles_overlapping_spawn_zones(self.obstacles, spawn_zones)
+            if self.obstacles and spawn_zones
+            else self.obstacles
+        )
+
+        self.battlefield = BattleField(
+            obstacles=cleared_obstacles,
+            spawn_zones=spawn_zones,
+            obstacle_density=self.battlefield.obstacle_density,
+        )
+        self.obstacles = self.battlefield.obstacles
+
+        self._apply_spawn_zones()
+
     def _generate_default_spawn_zones(self) -> list[SpawnZone]:
         """チーム数とマップサイズに応じたデフォルトスポーン領域を生成する (Phase 6-3).
+
+        障害物は本メソッドの実行前に生成済みであるため (#437)、各チームの対称配置
+        候補点が障害物と重なる場合は `_find_clear_spawn_center` で近傍の空き位置を探索する。
 
         Returns:
             生成されたスポーン領域リスト
@@ -389,6 +415,11 @@ class BattleSimulator(
             ]
             radius = SPAWN_ZONE_RADIUS_4TEAM
 
+        rng = np.random.default_rng()
+        centers = [
+            self._find_clear_spawn_center(center, radius, rng) for center in centers
+        ]
+
         return [
             SpawnZone(
                 team_id=team_id,
@@ -397,6 +428,93 @@ class BattleSimulator(
             )
             for team_id, (cx, cz) in zip(team_ids, centers, strict=True)
         ]
+
+    @staticmethod
+    def _remove_obstacles_overlapping_spawn_zones(
+        obstacles: list[Obstacle], spawn_zones: list[SpawnZone]
+    ) -> list[Obstacle]:
+        """スポーン領域と重なる障害物を除去する (#437 の最終保証フォールバック).
+
+        `_find_clear_spawn_center` のジッター探索は障害物密度が高い狭いフィールド
+        では回避に失敗する場合がある（フィールド全体が障害物で埋まっているなど）。
+        本メソッドは最終的な spawn_zones と障害物リストを突き合わせ、重なりが残って
+        いる障害物を取り除くことで、ユニットが障害物に埋まって出現しないことを保証する。
+
+        Args:
+            obstacles: 障害物リスト
+            spawn_zones: 最終的なスポーン領域リスト（自動生成・明示指定いずれも可）
+
+        Returns:
+            スポーン領域と重ならない障害物のみのリスト
+        """
+        return [
+            obs
+            for obs in obstacles
+            if not any(
+                math.sqrt(
+                    (obs.position.x - sz.center.x) ** 2
+                    + (obs.position.z - sz.center.z) ** 2
+                )
+                < sz.radius + obs.radius
+                for sz in spawn_zones
+            )
+        ]
+
+    @staticmethod
+    def _spawn_center_overlaps_obstacles(
+        x: float, z: float, radius: float, obstacles: list[Obstacle]
+    ) -> bool:
+        """スポーン中心候補が、いずれかの障害物と重なるかを判定する (#437)."""
+        for obs in obstacles:
+            dist = math.sqrt((x - obs.position.x) ** 2 + (z - obs.position.z) ** 2)
+            if dist < radius + obs.radius:
+                return True
+        return False
+
+    def _find_clear_spawn_center(
+        self,
+        candidate: tuple[float, float],
+        radius: float,
+        rng: np.random.Generator,
+    ) -> tuple[float, float]:
+        """スポーン中心候補が障害物と重なる場合、近傍で重ならない位置を探索する (#437).
+
+        対称配置（対角・三角形・四隅・円周）の形状を大きく崩さないよう、候補点を
+        中心とした半径 SPAWN_CENTER_JITTER_RADIUS 以内でジッターさせながら再探索する。
+        試行上限に達した場合は候補点をそのまま返す（フィールド全体が障害物で
+        埋め尽くされるような極端なケースでのみ発生しうる）。
+
+        Args:
+            candidate: 対称配置から算出された候補中心座標 (x, z)
+            radius: スポーン領域の半径 (m)
+            rng: 乱数生成器
+
+        Returns:
+            障害物と重ならない中心座標 (x, z)。見つからない場合は candidate をそのまま返す。
+        """
+        cx, cz = candidate
+        if not self.obstacles or not self._spawn_center_overlaps_obstacles(
+            cx, cz, radius, self.obstacles
+        ):
+            return candidate
+
+        map_min, map_max = self.map_bounds
+        for _ in range(SPAWN_CENTER_SEARCH_MAX_TRIES):
+            angle = rng.uniform(0.0, 2.0 * math.pi)
+            dist = rng.uniform(0.0, SPAWN_CENTER_JITTER_RADIUS)
+            x = min(max(cx + dist * math.cos(angle), map_min), map_max)
+            z = min(max(cz + dist * math.sin(angle), map_min), map_max)
+            if not self._spawn_center_overlaps_obstacles(x, z, radius, self.obstacles):
+                return (x, z)
+
+        logger.warning(
+            "スポーン中心候補 (%.1f, %.1f) 付近で障害物を回避できる位置が"
+            "見つかりませんでした (%d 回試行)。候補点をそのまま使用します。",
+            cx,
+            cz,
+            SPAWN_CENTER_SEARCH_MAX_TRIES,
+        )
+        return candidate
 
     @staticmethod
     def _sample_position_in_zone(
@@ -492,7 +610,9 @@ class BattleSimulator(
         """障害物をグリッド分割＋ランダムオフセット方式で自動生成する (Phase 6-3).
 
         フィールドを N×N グリッドに分割し、各セルに確率 p で障害物を配置する。
-        スポーン領域と重複する位置には配置しない。
+        本メソッドはスポーン領域の生成前に実行される (#437)。スポーン領域は
+        `_generate_default_spawn_zones` 側でこの障害物配置を踏まえて決定される
+        ため、ここではスポーン領域との重複回避は行わない。
 
         Returns:
             生成された障害物リスト
@@ -510,7 +630,6 @@ class BattleSimulator(
         map_min, map_max = self.map_bounds
         cell_size = (map_max - map_min) / n
 
-        spawn_zones = self.battlefield.spawn_zones
         obstacles: list[Obstacle] = []
         rng = np.random.default_rng()
         obs_counter = 0
@@ -529,19 +648,6 @@ class BattleSimulator(
                 obs_x = cell_cx + ox
                 obs_z = cell_cz + oz
                 obs_radius = float(rng.uniform(radius_min, radius_max))
-
-                # スポーン領域との重複チェック
-                overlaps_spawn = False
-                for sz in spawn_zones:
-                    dist = math.sqrt(
-                        (obs_x - sz.center.x) ** 2 + (obs_z - sz.center.z) ** 2
-                    )
-                    if dist < sz.radius + obs_radius:
-                        overlaps_spawn = True
-                        break
-
-                if overlaps_spawn:
-                    continue
 
                 obstacles.append(
                     Obstacle(

--- a/backend/app/engine/simulation.py
+++ b/backend/app/engine/simulation.py
@@ -499,11 +499,16 @@ class BattleSimulator(
             return candidate
 
         map_min, map_max = self.map_bounds
+        # 中心のクランプ範囲は radius ぶんのマージンを確保する（スポーン領域自体が
+        # フィールド外へはみ出さないようにするため）。フィールドが radius の2倍より
+        # 狭い極端なケースではマージンを縮小してクランプ範囲の逆転を防ぐ。
+        margin = min(radius, (map_max - map_min) / 2.0)
+        clamp_min, clamp_max = map_min + margin, map_max - margin
         for _ in range(SPAWN_CENTER_SEARCH_MAX_TRIES):
             angle = rng.uniform(0.0, 2.0 * math.pi)
             dist = rng.uniform(0.0, SPAWN_CENTER_JITTER_RADIUS)
-            x = min(max(cx + dist * math.cos(angle), map_min), map_max)
-            z = min(max(cz + dist * math.sin(angle), map_min), map_max)
+            x = min(max(cx + dist * math.cos(angle), clamp_min), clamp_max)
+            z = min(max(cz + dist * math.sin(angle), clamp_min), clamp_max)
             if not self._spawn_center_overlaps_obstacles(x, z, radius, self.obstacles):
                 return (x, z)
 

--- a/backend/tests/unit/test_phase_6_3_field_init.py
+++ b/backend/tests/unit/test_phase_6_3_field_init.py
@@ -459,6 +459,39 @@ def test_obstacles_generated_before_spawn_zones_still_span_field() -> None:
     assert len(center_nearby) > 0, "フィールド中心付近に障害物が生成されていない"
 
 
+def test_find_clear_spawn_center_result_stays_within_field_margin() -> None:
+    """ジッター後のスポーン中心が radius マージンを保ってフィールド内に収まること.
+
+    GitHub Copilot レビュー指摘（PR #439）の回帰テスト:
+    クランプ範囲が `map_min..map_max` そのものだと、中心が端に寄った場合に
+    スポーン領域の半径ぶんフィールド外へはみ出しうる。
+    """
+    player = _make_unit("P", "PLAYER", "PT")
+    enemy = _make_unit("E", "ENEMY", "ET")
+    sim = BattleSimulator(
+        player, [enemy], battlefield=BattleField(obstacle_density="NONE")
+    )
+    map_min, map_max = sim.map_bounds
+    radius = SPAWN_ZONE_RADIUS_2TEAM
+
+    candidate = (map_min, map_min)  # フィールド最端の候補点
+    # 候補点そのものを覆う障害物を置き、ジッター探索を強制する
+    sim.obstacles = [
+        Obstacle(
+            obstacle_id="blocker",
+            position=Vector3(x=map_min, y=0.0, z=map_min),
+            radius=10.0,
+        )
+    ]
+    rng = np.random.default_rng(1)
+    x, z = sim._find_clear_spawn_center(candidate, radius, rng)
+
+    assert x - radius >= map_min - 1e-6, f"x={x} がフィールド外にはみ出している"
+    assert x + radius <= map_max + 1e-6, f"x={x} がフィールド外にはみ出している"
+    assert z - radius >= map_min - 1e-6, f"z={z} がフィールド外にはみ出している"
+    assert z + radius <= map_max + 1e-6, f"z={z} がフィールド外にはみ出している"
+
+
 def test_auto_generated_obstacles_have_valid_ids() -> None:
     """自動生成された障害物に一意の ID が付与されること."""
     player = _make_unit("P", "PLAYER", "PT")

--- a/backend/tests/unit/test_phase_6_3_field_init.py
+++ b/backend/tests/unit/test_phase_6_3_field_init.py
@@ -397,6 +397,68 @@ def test_auto_generated_obstacles_not_in_spawn_zones() -> None:
             )
 
 
+def test_default_spawn_zones_5_teams_ring_formation() -> None:
+    """5チーム以上のデフォルトスポーン領域が円周上に均等配置されること."""
+    p = _make_unit("P", "PLAYER", "T0")
+    enemies = [_make_unit(f"E{i}", "ENEMY", f"T{i}") for i in range(1, 5)]
+    sim = BattleSimulator(p, enemies, battlefield=BattleField(obstacle_density="NONE"))
+    zones = sim.battlefield.spawn_zones
+    assert len(zones) == 5
+    for sz in zones:
+        assert sz.radius == SPAWN_ZONE_RADIUS_4TEAM
+
+    # ユニット数に応じて動的に決まる実際のフィールド範囲 (Phase 6-5) を使う
+    map_min, map_max = sim.map_bounds
+    cx = (map_min + map_max) / 2.0
+    cz = (map_min + map_max) / 2.0
+    # 障害物なし (obstacle_density=NONE) のためジッターは発生せず、
+    # 厳密に円周上（フィールド中心からの距離が全チーム一定）に乗ること
+    distances = [
+        math.sqrt((sz.center.x - cx) ** 2 + (sz.center.z - cz) ** 2) for sz in zones
+    ]
+    assert max(distances) - min(distances) < 1e-6
+
+
+def test_5_teams_no_obstacles_in_spawn_zones() -> None:
+    """5チーム以上・障害物ありでも、最終的なスポーン領域は障害物と重ならないこと."""
+    p = _make_unit("P", "PLAYER", "T0")
+    enemies = [_make_unit(f"E{i}", "ENEMY", f"T{i}") for i in range(1, 6)]
+    sim = BattleSimulator(p, enemies, battlefield=BattleField(obstacle_density="DENSE"))
+    assert len(sim.battlefield.spawn_zones) == 6
+    for obs in sim.obstacles:
+        for sz in sim.battlefield.spawn_zones:
+            dx = obs.position.x - sz.center.x
+            dz = obs.position.z - sz.center.z
+            dist = math.sqrt(dx * dx + dz * dz)
+            assert dist >= sz.radius + obs.radius - 1e-6, (
+                f"障害物 {obs.obstacle_id} がスポーン領域 {sz.team_id} と重複: "
+                f"dist={dist:.1f} < radius_sum={sz.radius + obs.radius:.1f}"
+            )
+
+
+def test_obstacles_generated_before_spawn_zones_still_span_field() -> None:
+    """障害物→スポーンの順に生成しても、障害物はフィールド全体に分布すること (#437)."""
+    player = _make_unit("P", "PLAYER", "PT")
+    enemy = _make_unit("E", "ENEMY", "ET")
+    sim = BattleSimulator(
+        player, [enemy], battlefield=BattleField(obstacle_density="DENSE")
+    )
+    assert len(sim.obstacles) > 0
+    # フィールド中心付近にも障害物が存在しうること（スポーン専用の除外がないため）
+    map_min, map_max = sim.map_bounds
+    field_center = ((map_min + map_max) / 2.0, (map_min + map_max) / 2.0)
+    center_nearby = [
+        obs
+        for obs in sim.obstacles
+        if math.sqrt(
+            (obs.position.x - field_center[0]) ** 2
+            + (obs.position.z - field_center[1]) ** 2
+        )
+        < (map_max - map_min) / 4.0
+    ]
+    assert len(center_nearby) > 0, "フィールド中心付近に障害物が生成されていない"
+
+
 def test_auto_generated_obstacles_have_valid_ids() -> None:
     """自動生成された障害物に一意の ID が付与されること."""
     player = _make_unit("P", "PLAYER", "PT")

--- a/docs/features/battle-engine-feature.md
+++ b/docs/features/battle-engine-feature.md
@@ -861,10 +861,22 @@ def __init__(
 
 ```
 BattleField を battlefield=BattleField(...) で渡した場合:
-  1. spawn_zones が空 → _generate_default_spawn_zones() でデフォルト領域を生成
-  2. _apply_spawn_zones() で全ユニットをスポーン領域内にランダム配置
-  3. obstacles が空 かつ obstacle_density != "NONE" → _generate_obstacles() で自動生成
+  1. obstacles が空 かつ obstacle_density != "NONE" → _generate_obstacles() で自動生成
+  2. spawn_zones が空 → _generate_default_spawn_zones() でデフォルト領域を生成
+     （対称配置の候補点が障害物と重なる場合、_find_clear_spawn_center() が
+      近傍でジッター探索して回避する）
+  3. ジッターでも回避しきれなかった障害物・明示的な spawn_zones と重複する障害物は
+     _remove_obstacles_overlapping_spawn_zones() で最終的に除去する
+  4. _apply_spawn_zones() で全ユニットをスポーン領域内にランダム配置
 ```
+
+**Issue #437 での変更点（障害物→スポーンの順への変更）:** 旧実装ではスポーン領域を
+先に確定し、障害物生成側がスポーン領域と重なるグリッドセルをスキップしていた。この
+場合、常にスポーン中心の周囲だけが円形に障害物ゼロの「安全地帯」になり、障害物が
+実際の交戦（移動経路・LOS）にほとんど影響しない問題があった。障害物を先に配置する
+順に変更し、スポーン中心側が障害物配置に応じて（対称配置を保ったまま）ジッター移動
+するようにしたことで、障害物の抜け方が毎回異なる非対称な形状になり、障害物がカバー
+や進路の障壁として機能しやすくなった。
 
 ### 14.5 デフォルトスポーン領域
 
@@ -888,7 +900,9 @@ BattleField を battlefield=BattleField(...) で渡した場合:
 | `"DENSE"` | 10 | 0.8 | 60〜120m |
 | `"NONE"` | — | — | 障害物なし |
 
-生成方式: グリッド分割＋ランダムオフセット。スポーン領域と重複する位置には配置しない。
+生成方式: グリッド分割＋ランダムオフセット。障害物はスポーン領域より先に生成されるため、
+生成時点ではスポーン領域を考慮しない（フィールド全体に一様分布する）。スポーン領域との
+重複回避は、スポーン領域決定時のジッター探索・最終フィルタ側で行う（#437）。
 
 ### 14.7 新定数 (`constants.py`)
 
@@ -903,6 +917,10 @@ SPAWN_ZONE_RADIUS_2TEAM: float = 400.0
 SPAWN_ZONE_RADIUS_3TEAM: float = 400.0
 SPAWN_ZONE_RADIUS_4TEAM: float = 300.0
 SPAWN_ZONE_SAMPLE_MAX_TRIES: int = 50
+
+# スポーン中心の障害物回避 (#437)
+SPAWN_CENTER_JITTER_RADIUS: float = 300.0    # 障害物回避のためのジッター探索半径 (m)
+SPAWN_CENTER_SEARCH_MAX_TRIES: int = 30      # 障害物回避位置の探索最大試行回数
 ```
 
 ### 14.8 使用例


### PR DESCRIPTION
## Summary
- 障害物配置とスポーン位置決定の順序を反転し（障害物→スポーン）、障害物が実際の交戦エリア（移動経路・LOS）に影響を持つようにした
- 旧実装ではスポーン領域を先に確定し、障害物側がスポーン領域と重なるグリッドセルをスキップしていたため、各スポーン地点の周囲が常に円形の障害物ゼロ地帯になっていた（#437 の課題）
- `_generate_default_spawn_zones` は対称配置（2チーム対角/3チーム三角形/4チーム四隅/5チーム以上円周）の候補点をそのまま使いつつ、障害物と重なる場合のみ `_find_clear_spawn_center` で近傍にジッター探索して回避する。対称配置自体は維持したまま、障害物の抜け方が毎回非対称・非規則になる
- ジッター探索でも避けきれない極端なケース（狭小フィールド × 高密度障害物など）向けに、`_remove_obstacles_overlapping_spawn_zones` で最終的な重複除去のフォールバックを追加し、ユニットが障害物に埋まって出現しないことを保証
- `docs/features/battle-engine-feature.md`（Phase 6-3セクション）を新しい生成フロー・定数に合わせて更新

## Test plan
- [x] `cd backend && python -m pytest tests/unit --tb=short -q` — 全ユニットテスト（新規5+チームリング/障害物回避テスト含む）がパス
- [x] `ruff check` / `ruff format` / `mypy` — pre-commit フック経由でパス
- [ ] 実際のバトルを再生し、BattleViewer上で障害物がスポーン地点周辺にも配置され、以前より非対称な抜け方になっていることを目視確認

Closes #437

🤖 Generated with [Claude Code](https://claude.com/claude-code)
