### PR TITLE
feat: admin-toolへのNPCデータ管理画面の追加

### DIFF
--- a/admin-tool/src/app/npcs/page.tsx
+++ b/admin-tool/src/app/npcs/page.tsx
@@ -1,0 +1,155 @@
+/* admin-tool/src/app/npcs/page.tsx */
+"use client";
+
+import { useState } from "react";
+import { useAdminNpcs, useAdminNpcDetail } from "@/hooks/useAdminNpcs";
+import { NpcPilot } from "@/types/admin";
+import NpcTable from "@/components/admin/NpcTable";
+import NpcEditForm, { NpcPilotFormValues } from "@/components/admin/NpcEditForm";
+import { SciFiPanel, SciFiHeading } from "@/components/ui";
+
+interface Toast {
+  message: string;
+  type: "success" | "error";
+}
+
+export default function AdminNpcsPage() {
+  const { npcs, isLoading, isError, updateNpc, updateNpcMobileSuit, mutate } = useAdminNpcs();
+
+  const [selectedNpc, setSelectedNpc] = useState<NpcPilot | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [toast, setToast] = useState<Toast | null>(null);
+
+  const { npc: npcDetail, isLoading: isDetailLoading, mutate: mutateDetail } = useAdminNpcDetail(
+    selectedNpc?.id ?? null
+  );
+
+  function showToast(message: string, type: "success" | "error") {
+    setToast({ message, type });
+    setTimeout(() => setToast(null), 4000);
+  }
+
+  function handleSelectNpc(npc: NpcPilot) {
+    setSelectedNpc(npc);
+  }
+
+  async function handleSubmitPilot(values: NpcPilotFormValues) {
+    if (!selectedNpc) return;
+    setIsSubmitting(true);
+    try {
+      await updateNpc(selectedNpc.id, values);
+      await mutateDetail();
+      showToast(`${selectedNpc.name} を更新しました`, "success");
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : "エラーが発生しました", "error");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  async function handleSubmitMobileSuit(
+    msId: string,
+    payload: { name?: string; max_hp?: number; armor?: number; mobility?: number }
+  ) {
+    if (!selectedNpc) return;
+    try {
+      await updateNpcMobileSuit(selectedNpc.id, msId, payload);
+      await mutateDetail();
+      await mutate();
+      showToast("機体ステータスを更新しました", "success");
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : "エラーが発生しました", "error");
+    }
+  }
+
+  if (isError) {
+    return (
+      <div className="min-h-screen bg-[#050505] text-[#00ff41] p-8 font-mono">
+        <SciFiPanel variant="secondary">
+          <div className="p-6">
+            <p className="text-[#ffb000] font-bold text-xl mb-2">ERROR: データ取得失敗</p>
+            <p className="text-sm">
+              ADMIN_API_KEY が正しく設定されているか、バックエンドが起動しているか確認してください。
+            </p>
+          </div>
+        </SciFiPanel>
+      </div>
+    );
+  }
+
+  return (
+    <main className="min-h-screen bg-[#050505] text-[#00ff41] p-4 sm:p-6 font-mono">
+      <div className="max-w-screen-xl mx-auto">
+        {/* ヘッダー */}
+        <div className="mb-6 border-b-2 border-[#ffb000]/30 pb-4">
+          <SciFiHeading level={2} variant="secondary" className="text-xl sm:text-2xl">
+            ADMIN: NPC PILOTS
+          </SciFiHeading>
+          <p className="text-xs text-[#ffb000]/60 ml-0 sm:ml-5">
+            NPCパイロットデータ管理（is_npc=True）
+          </p>
+        </div>
+
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          {/* 左カラム: NPC一覧 */}
+          <div>
+            <SciFiPanel variant="primary">
+              <div className="p-4">
+                <SciFiHeading level={3} className="mb-3 text-base">
+                  NPC一覧
+                </SciFiHeading>
+                {isLoading ? (
+                  <p className="text-[#ffb000] animate-pulse py-8 text-center">LOADING...</p>
+                ) : (
+                  <NpcTable npcs={npcs ?? []} selectedId={selectedNpc?.id ?? null} onSelect={handleSelectNpc} />
+                )}
+              </div>
+            </SciFiPanel>
+          </div>
+
+          {/* 右カラム: 編集フォーム */}
+          <div>
+            {selectedNpc ? (
+              <SciFiPanel variant="secondary">
+                <div className="p-4">
+                  <SciFiHeading level={3} className="mb-3 text-base">
+                    編集: {selectedNpc.name}
+                  </SciFiHeading>
+                  {isDetailLoading || !npcDetail ? (
+                    <p className="text-[#ffb000] animate-pulse py-8 text-center">LOADING...</p>
+                  ) : (
+                    <NpcEditForm
+                      npc={npcDetail}
+                      onSubmitPilot={handleSubmitPilot}
+                      onSubmitMobileSuit={handleSubmitMobileSuit}
+                      isSubmitting={isSubmitting}
+                    />
+                  )}
+                </div>
+              </SciFiPanel>
+            ) : (
+              <SciFiPanel variant="primary">
+                <div className="p-4 flex items-center justify-center h-48">
+                  <p className="text-[#00ff41]/40 text-sm text-center">NPCを選択してください</p>
+                </div>
+              </SciFiPanel>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* トースト通知 */}
+      {toast && (
+        <div
+          className={`fixed top-4 right-4 z-50 max-w-sm border px-4 py-3 text-sm font-mono ${
+            toast.type === "success"
+              ? "bg-[#050505] border-[#00ff41]/60 text-[#00ff41]"
+              : "bg-[#050505] border-red-500/60 text-red-400"
+          }`}
+        >
+          {toast.message}
+        </div>
+      )}
+    </main>
+  );
+}

--- a/admin-tool/src/app/page.tsx
+++ b/admin-tool/src/app/page.tsx
@@ -20,6 +20,11 @@ export default function HomePage() {
               武器マスタ管理
             </SciFiButton>
           </Link>
+          <Link href="/npcs">
+            <SciFiButton className="w-full" variant="secondary">
+              NPCパイロット管理
+            </SciFiButton>
+          </Link>
         </div>
       </SciFiPanel>
     </main>

--- a/admin-tool/src/components/admin/NpcEditForm.tsx
+++ b/admin-tool/src/components/admin/NpcEditForm.tsx
@@ -1,0 +1,257 @@
+/* admin-tool/src/components/admin/NpcEditForm.tsx */
+"use client";
+
+import { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { NpcMobileSuit, NpcPilotDetail, NpcPersonality } from "@/types/admin";
+
+// ============================================================
+// Zod バリデーションスキーマ
+// ============================================================
+
+export const npcPilotSchema = z.object({
+  npc_personality: z.enum(["AGGRESSIVE", "CAUTIOUS", "SNIPER"]),
+  level: z.number({ message: "Must be a number" }).int().min(1, "Must be ≥ 1"),
+  exp: z.number({ message: "Must be a number" }).int().nonnegative(),
+  credits: z.number({ message: "Must be a number" }).int().nonnegative(),
+  skill_points: z.number({ message: "Must be a number" }).int().nonnegative(),
+  status_points: z.number({ message: "Must be a number" }).int().nonnegative(),
+  sht: z.number({ message: "Must be a number" }).int().nonnegative(),
+  mel: z.number({ message: "Must be a number" }).int().nonnegative(),
+  intel: z.number({ message: "Must be a number" }).int().nonnegative(),
+  ref: z.number({ message: "Must be a number" }).int().nonnegative(),
+  tou: z.number({ message: "Must be a number" }).int().nonnegative(),
+  luk: z.number({ message: "Must be a number" }).int().nonnegative(),
+  awq: z.number({ message: "Must be a number" }).int().nonnegative(),
+});
+
+export type NpcPilotFormValues = z.infer<typeof npcPilotSchema>;
+
+function toFormValues(npc: NpcPilotDetail): NpcPilotFormValues {
+  return {
+    npc_personality: (npc.npc_personality ?? "AGGRESSIVE") as NpcPersonality,
+    level: npc.level,
+    exp: npc.exp,
+    credits: npc.credits,
+    skill_points: npc.skill_points,
+    status_points: npc.status_points,
+    sht: npc.sht,
+    mel: npc.mel,
+    intel: npc.intel,
+    ref: npc.ref,
+    tou: npc.tou,
+    luk: npc.luk,
+    awq: npc.awq,
+  };
+}
+
+// ============================================================
+// UIヘルパー
+// ============================================================
+
+function Label({ children }: { children: React.ReactNode }) {
+  return <label className="block text-xs text-[#00ff41]/60 mb-1">{children}</label>;
+}
+
+function FieldError({ message }: { message?: string }) {
+  if (!message) return null;
+  return <p className="text-xs text-red-400 mt-1">{message}</p>;
+}
+
+const inputClass =
+  "w-full bg-[#0a0a0a] border border-[#00ff41]/30 text-[#00ff41] px-2 py-1.5 text-sm font-mono focus:outline-none focus:border-[#00ff41]";
+
+// ============================================================
+// コンポーネント
+// ============================================================
+
+interface NpcEditFormProps {
+  npc: NpcPilotDetail;
+  onSubmitPilot: (values: NpcPilotFormValues) => Promise<void>;
+  onSubmitMobileSuit: (msId: string, payload: { name?: string; max_hp?: number; armor?: number; mobility?: number }) => Promise<void>;
+  isSubmitting?: boolean;
+}
+
+export default function NpcEditForm({ npc, onSubmitPilot, onSubmitMobileSuit, isSubmitting }: NpcEditFormProps) {
+  "use no memo";
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors, isDirty },
+  } = useForm<NpcPilotFormValues>({
+    resolver: zodResolver(npcPilotSchema),
+    defaultValues: toFormValues(npc),
+  });
+
+  useEffect(() => {
+    reset(toFormValues(npc));
+  }, [npc, reset]);
+
+  const numberField = (key: keyof NpcPilotFormValues) => register(key, { valueAsNumber: true });
+
+  return (
+    <div className="space-y-6">
+      <form onSubmit={handleSubmit(onSubmitPilot)} className="space-y-4">
+        <div>
+          <Label>性格</Label>
+          <select {...register("npc_personality")} className={inputClass}>
+            <option value="AGGRESSIVE">AGGRESSIVE</option>
+            <option value="CAUTIOUS">CAUTIOUS</option>
+            <option value="SNIPER">SNIPER</option>
+          </select>
+        </div>
+
+        <div className="grid grid-cols-3 gap-3">
+          <div>
+            <Label>レベル</Label>
+            <input type="number" {...numberField("level")} className={inputClass} />
+            <FieldError message={errors.level?.message} />
+          </div>
+          <div>
+            <Label>EXP</Label>
+            <input type="number" {...numberField("exp")} className={inputClass} />
+            <FieldError message={errors.exp?.message} />
+          </div>
+          <div>
+            <Label>クレジット</Label>
+            <input type="number" {...numberField("credits")} className={inputClass} />
+            <FieldError message={errors.credits?.message} />
+          </div>
+          <div>
+            <Label>スキルポイント</Label>
+            <input type="number" {...numberField("skill_points")} className={inputClass} />
+            <FieldError message={errors.skill_points?.message} />
+          </div>
+          <div>
+            <Label>ステータスポイント</Label>
+            <input type="number" {...numberField("status_points")} className={inputClass} />
+            <FieldError message={errors.status_points?.message} />
+          </div>
+        </div>
+
+        <div>
+          <p className="text-xs text-[#ffb000]/80 mb-2 font-bold">ステータス</p>
+          <div className="grid grid-cols-3 sm:grid-cols-4 gap-3">
+            {(["sht", "mel", "intel", "ref", "tou", "luk", "awq"] as const).map((key) => (
+              <div key={key}>
+                <Label>{key.toUpperCase()}</Label>
+                <input type="number" {...numberField(key)} className={inputClass} />
+                <FieldError message={errors[key]?.message} />
+              </div>
+            ))}
+          </div>
+        </div>
+
+        <div className="flex gap-3 pt-2">
+          <button
+            type="submit"
+            disabled={isSubmitting || !isDirty}
+            className="flex-1 bg-[#00ff41]/10 border border-[#00ff41]/60 text-[#00ff41] py-2 text-sm font-bold hover:bg-[#00ff41]/20 disabled:opacity-40 disabled:cursor-not-allowed"
+          >
+            {isSubmitting ? "保存中..." : "保存"}
+          </button>
+        </div>
+      </form>
+
+      <div className="border-t border-[#00ff41]/20 pt-4">
+        <p className="text-xs text-[#ffb000]/80 mb-3 font-bold">所属機体（{npc.mobile_suits.length}）</p>
+        <div className="space-y-3">
+          {npc.mobile_suits.map((ms) => (
+            <MobileSuitInlineEditor key={ms.id} mobileSuit={ms} onSubmit={onSubmitMobileSuit} />
+          ))}
+          {npc.mobile_suits.length === 0 && (
+            <p className="text-xs text-[#00ff41]/40 text-center py-4">所属機体がありません</p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function MobileSuitInlineEditor({
+  mobileSuit,
+  onSubmit,
+}: {
+  mobileSuit: NpcMobileSuit;
+  onSubmit: (msId: string, payload: { name?: string; max_hp?: number; armor?: number; mobility?: number }) => Promise<void>;
+}) {
+  const [maxHp, setMaxHp] = useState(mobileSuit.max_hp);
+  const [armor, setArmor] = useState(mobileSuit.armor);
+  const [mobility, setMobility] = useState(mobileSuit.mobility);
+  const [saving, setSaving] = useState(false);
+
+  useEffect(() => {
+    setMaxHp(mobileSuit.max_hp);
+    setArmor(mobileSuit.armor);
+    setMobility(mobileSuit.mobility);
+  }, [mobileSuit]);
+
+  const dirty = maxHp !== mobileSuit.max_hp || armor !== mobileSuit.armor || mobility !== mobileSuit.mobility;
+
+  async function handleSave() {
+    setSaving(true);
+    try {
+      await onSubmit(mobileSuit.id, { max_hp: maxHp, armor, mobility });
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="border border-[#00ff41]/20 p-3 space-y-2">
+      <div className="flex items-center justify-between">
+        <p className="text-sm font-bold text-[#00ff41]">
+          {mobileSuit.name}
+          {mobileSuit.is_ace && (
+            <span className="ml-2 px-1.5 py-0.5 text-[10px] font-bold bg-[#ffb000]/20 text-[#ffb000] border border-[#ffb000]/50">
+              ACE
+            </span>
+          )}
+        </p>
+        <span className="text-xs text-[#00ff41]/50">
+          HP {mobileSuit.current_hp}/{mobileSuit.max_hp}
+        </span>
+      </div>
+      <div className="grid grid-cols-3 gap-2">
+        <div>
+          <Label>最大HP</Label>
+          <input
+            type="number"
+            value={maxHp}
+            onChange={(e) => setMaxHp(Number(e.target.value))}
+            className={inputClass}
+          />
+        </div>
+        <div>
+          <Label>装甲</Label>
+          <input
+            type="number"
+            value={armor}
+            onChange={(e) => setArmor(Number(e.target.value))}
+            className={inputClass}
+          />
+        </div>
+        <div>
+          <Label>機動性</Label>
+          <input
+            type="number"
+            step="0.1"
+            value={mobility}
+            onChange={(e) => setMobility(Number(e.target.value))}
+            className={inputClass}
+          />
+        </div>
+      </div>
+      <button
+        onClick={handleSave}
+        disabled={!dirty || saving}
+        className="w-full border border-[#00ff41]/40 text-[#00ff41]/80 py-1.5 text-xs font-bold hover:bg-[#00ff41]/10 disabled:opacity-40 disabled:cursor-not-allowed"
+      >
+        {saving ? "保存中..." : "この機体を保存"}
+      </button>
+    </div>
+  );
+}

--- a/admin-tool/src/components/admin/NpcTable.tsx
+++ b/admin-tool/src/components/admin/NpcTable.tsx
@@ -1,0 +1,177 @@
+/* admin-tool/src/components/admin/NpcTable.tsx */
+"use client";
+
+import { useState } from "react";
+import { NpcPersonality, NpcPilot } from "@/types/admin";
+
+interface NpcTableProps {
+  npcs: NpcPilot[];
+  selectedId: string | null;
+  onSelect: (npc: NpcPilot) => void;
+}
+
+type SortKey = "name" | "npc_personality" | "level" | "exp" | "credits" | "mobile_suit_count";
+type SortDir = "asc" | "desc";
+
+const PERSONALITY_OPTIONS: NpcPersonality[] = ["AGGRESSIVE", "CAUTIOUS", "SNIPER"];
+
+export default function NpcTable({ npcs, selectedId, onSelect }: NpcTableProps) {
+  const [sortKey, setSortKey] = useState<SortKey>("level");
+  const [sortDir, setSortDir] = useState<SortDir>("desc");
+  const [filter, setFilter] = useState("");
+  const [personalityFilter, setPersonalityFilter] = useState<NpcPersonality | "">("");
+  const [minLevel, setMinLevel] = useState("");
+  const [maxLevel, setMaxLevel] = useState("");
+  const [aceFilter, setAceFilter] = useState<"" | "ace" | "normal">("");
+
+  function handleSort(key: SortKey) {
+    if (sortKey === key) {
+      setSortDir((d) => (d === "asc" ? "desc" : "asc"));
+    } else {
+      setSortKey(key);
+      setSortDir("asc");
+    }
+  }
+
+  const filtered = npcs.filter((npc) => {
+    if (filter && !npc.name.toLowerCase().includes(filter.toLowerCase())) return false;
+    if (personalityFilter && npc.npc_personality !== personalityFilter) return false;
+    if (minLevel && npc.level < Number(minLevel)) return false;
+    if (maxLevel && npc.level > Number(maxLevel)) return false;
+    if (aceFilter === "ace" && !npc.is_ace) return false;
+    if (aceFilter === "normal" && npc.is_ace) return false;
+    return true;
+  });
+
+  const sorted = [...filtered].sort((a, b) => {
+    const av = a[sortKey] ?? "";
+    const bv = b[sortKey] ?? "";
+    if (av < bv) return sortDir === "asc" ? -1 : 1;
+    if (av > bv) return sortDir === "asc" ? 1 : -1;
+    return 0;
+  });
+
+  function SortIcon({ k }: { k: SortKey }) {
+    if (sortKey !== k) return <span className="text-[#00ff41]/30 ml-1">⇅</span>;
+    return <span className="text-[#ffb000] ml-1">{sortDir === "asc" ? "↑" : "↓"}</span>;
+  }
+
+  const thClass =
+    "px-3 py-2 text-left text-xs font-bold uppercase tracking-wider cursor-pointer select-none text-[#ffb000]/80 hover:text-[#ffb000] whitespace-nowrap";
+  const tdClass = "px-3 py-2 text-sm whitespace-nowrap";
+  const selectClass =
+    "bg-[#0a0a0a] border border-[#00ff41]/30 text-[#00ff41] px-2 py-2 text-sm font-mono focus:outline-none focus:border-[#00ff41]";
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-col sm:flex-row gap-2">
+        <input
+          type="text"
+          placeholder="Filter by name..."
+          value={filter}
+          onChange={(e) => setFilter(e.target.value)}
+          className="flex-1 bg-[#0a0a0a] border border-[#00ff41]/30 text-[#00ff41] placeholder-[#00ff41]/40 px-3 py-2 text-sm font-mono focus:outline-none focus:border-[#00ff41]"
+        />
+        <select
+          value={personalityFilter}
+          onChange={(e) => setPersonalityFilter(e.target.value as NpcPersonality | "")}
+          className={selectClass}
+        >
+          <option value="">性格: すべて</option>
+          {PERSONALITY_OPTIONS.map((p) => (
+            <option key={p} value={p}>
+              {p}
+            </option>
+          ))}
+        </select>
+        <select
+          value={aceFilter}
+          onChange={(e) => setAceFilter(e.target.value as "" | "ace" | "normal")}
+          className={selectClass}
+        >
+          <option value="">エース: すべて</option>
+          <option value="ace">エースのみ</option>
+          <option value="normal">通常NPCのみ</option>
+        </select>
+        <input
+          type="number"
+          placeholder="Lv 下限"
+          value={minLevel}
+          onChange={(e) => setMinLevel(e.target.value)}
+          className="w-24 bg-[#0a0a0a] border border-[#00ff41]/30 text-[#00ff41] placeholder-[#00ff41]/40 px-2 py-2 text-sm font-mono focus:outline-none focus:border-[#00ff41]"
+        />
+        <input
+          type="number"
+          placeholder="Lv 上限"
+          value={maxLevel}
+          onChange={(e) => setMaxLevel(e.target.value)}
+          className="w-24 bg-[#0a0a0a] border border-[#00ff41]/30 text-[#00ff41] placeholder-[#00ff41]/40 px-2 py-2 text-sm font-mono focus:outline-none focus:border-[#00ff41]"
+        />
+      </div>
+      <div className="overflow-x-auto border border-[#00ff41]/20">
+        <table className="min-w-full text-[#00ff41] font-mono">
+          <thead className="bg-[#0a0a0a] border-b border-[#00ff41]/20">
+            <tr>
+              <th className={thClass} onClick={() => handleSort("name")}>
+                名前 <SortIcon k="name" />
+              </th>
+              <th className={thClass} onClick={() => handleSort("npc_personality")}>
+                性格 <SortIcon k="npc_personality" />
+              </th>
+              <th className={thClass} onClick={() => handleSort("level")}>
+                Lv <SortIcon k="level" />
+              </th>
+              <th className={thClass} onClick={() => handleSort("exp")}>
+                EXP <SortIcon k="exp" />
+              </th>
+              <th className={thClass} onClick={() => handleSort("credits")}>
+                クレジット <SortIcon k="credits" />
+              </th>
+              <th className={thClass} onClick={() => handleSort("mobile_suit_count")}>
+                所属機体数 <SortIcon k="mobile_suit_count" />
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {sorted.map((npc) => {
+              const isSelected = npc.id === selectedId;
+              return (
+                <tr
+                  key={npc.id}
+                  onClick={() => onSelect(npc)}
+                  className={`cursor-pointer border-b border-[#00ff41]/10 transition-colors ${
+                    isSelected ? "bg-[#00ff41]/10 border-[#00ff41]/40" : "hover:bg-[#00ff41]/5"
+                  }`}
+                >
+                  <td className={`${tdClass} font-bold ${isSelected ? "text-[#ffb000]" : ""}`}>
+                    {npc.name}
+                    {npc.is_ace && (
+                      <span className="ml-2 px-1.5 py-0.5 text-[10px] font-bold bg-[#ffb000]/20 text-[#ffb000] border border-[#ffb000]/50">
+                        ACE
+                      </span>
+                    )}
+                  </td>
+                  <td className={tdClass}>{npc.npc_personality ?? "—"}</td>
+                  <td className={tdClass}>{npc.level}</td>
+                  <td className={tdClass}>{npc.exp.toLocaleString()}</td>
+                  <td className={tdClass}>{npc.credits.toLocaleString()} C</td>
+                  <td className={tdClass}>{npc.mobile_suit_count}</td>
+                </tr>
+              );
+            })}
+            {sorted.length === 0 && (
+              <tr>
+                <td colSpan={6} className="text-center text-[#00ff41]/40 py-8 text-sm">
+                  NPCデータが見つかりません
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+      <p className="text-xs text-[#00ff41]/40 text-right">
+        {sorted.length} / {npcs.length} NPC表示中
+      </p>
+    </div>
+  );
+}

--- a/admin-tool/src/hooks/useAdminNpcs.ts
+++ b/admin-tool/src/hooks/useAdminNpcs.ts
@@ -1,0 +1,108 @@
+/* admin-tool/src/hooks/useAdminNpcs.ts */
+"use client";
+
+import useSWR from "swr";
+import { NpcPilot, NpcPilotDetail, NpcPilotUpdate, NpcMobileSuitUpdate, NpcMobileSuit } from "@/types/admin";
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || "http://127.0.0.1:8000";
+const ADMIN_API_KEY = process.env.NEXT_PUBLIC_ADMIN_API_KEY || "";
+
+const ENDPOINT = `${API_BASE_URL}/api/admin/npcs`;
+
+function adminFetcher(url: string) {
+  return fetch(url, {
+    headers: { "X-API-Key": ADMIN_API_KEY },
+  }).then(async (res) => {
+    if (!res.ok) {
+      const err = new Error(`Failed to fetch ${url}: ${res.status} ${res.statusText}`) as Error & { status: number };
+      err.status = res.status;
+      throw err;
+    }
+    return res.json();
+  });
+}
+
+/**
+ * 管理者用NPC(Pilot)データを取得・変更する SWR フック
+ */
+export function useAdminNpcs() {
+  const { data, error, isLoading, mutate } = useSWR<NpcPilot[]>(ENDPOINT, adminFetcher);
+
+  /**
+   * NPCのステータスを更新する（楽観的更新）
+   */
+  async function updateNpc(pilotId: string, payload: NpcPilotUpdate): Promise<NpcPilotDetail> {
+    const optimisticData = data?.map((npc) => (npc.id === pilotId ? { ...npc, ...payload } : npc));
+
+    const res = await fetch(`${ENDPOINT}/${pilotId}`, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": ADMIN_API_KEY,
+      },
+      body: JSON.stringify(payload),
+    });
+    if (!res.ok) {
+      const detail = await res.json().catch(() => ({}));
+      throw new Error(detail.detail || `Update failed: ${res.status}`);
+    }
+    const updated: NpcPilotDetail = await res.json();
+
+    await mutate(data?.map((npc) => (npc.id === pilotId ? updated : npc)) ?? [updated], {
+      optimisticData,
+      rollbackOnError: true,
+      revalidate: false,
+    });
+
+    return updated;
+  }
+
+  /**
+   * NPC所有機体のステータスを更新する（一覧の mobile_suit_count には影響しないため単純呼び出し）
+   */
+  async function updateNpcMobileSuit(
+    pilotId: string,
+    msId: string,
+    payload: NpcMobileSuitUpdate
+  ): Promise<NpcMobileSuit> {
+    const res = await fetch(`${ENDPOINT}/${pilotId}/mobile-suits/${msId}`, {
+      method: "PUT",
+      headers: {
+        "Content-Type": "application/json",
+        "X-API-Key": ADMIN_API_KEY,
+      },
+      body: JSON.stringify(payload),
+    });
+    if (!res.ok) {
+      const detail = await res.json().catch(() => ({}));
+      throw new Error(detail.detail || `Update failed: ${res.status}`);
+    }
+    return res.json();
+  }
+
+  return {
+    npcs: data,
+    isLoading,
+    isError: error,
+    mutate,
+    updateNpc,
+    updateNpcMobileSuit,
+  };
+}
+
+/**
+ * NPC1体の詳細（所有機体一覧付き）を取得する SWR フック
+ */
+export function useAdminNpcDetail(pilotId: string | null) {
+  const { data, error, isLoading, mutate } = useSWR<NpcPilotDetail>(
+    pilotId ? `${ENDPOINT}/${pilotId}` : null,
+    adminFetcher
+  );
+
+  return {
+    npc: data,
+    isLoading,
+    isError: error,
+    mutate,
+  };
+}

--- a/admin-tool/src/types/admin.ts
+++ b/admin-tool/src/types/admin.ts
@@ -126,3 +126,77 @@ export interface CombatSimulationResponse {
     resistance_applied_damage: number;
     monte_carlo: MonteCarloCombatStats | null;
 }
+
+/** NPCの性格タイプ */
+export type NpcPersonality = "AGGRESSIVE" | "CAUTIOUS" | "SNIPER";
+
+/** NPC所有機体エントリー（Pilot詳細に含まれる） */
+export interface NpcMobileSuit {
+    id: string;
+    name: string;
+    max_hp: number;
+    current_hp: number;
+    armor: number;
+    mobility: number;
+    personality: NpcPersonality | null;
+    is_ace: boolean;
+    ace_id: string | null;
+    pilot_name: string | null;
+    bounty_exp: number;
+    bounty_credits: number;
+}
+
+/** NPCパイロット一覧エントリー（管理者用レスポンス） */
+export interface NpcPilot {
+    id: string;
+    user_id: string;
+    name: string;
+    npc_personality: NpcPersonality | null;
+    /** ACE_PILOTS由来のエースパイロットかどうか（名前一致によるbest-effort判定） */
+    is_ace: boolean;
+    level: number;
+    exp: number;
+    credits: number;
+    skill_points: number;
+    status_points: number;
+    sht: number;
+    mel: number;
+    intel: number;
+    ref: number;
+    tou: number;
+    luk: number;
+    awq: number;
+    mobile_suit_count: number;
+    created_at: string;
+    updated_at: string;
+}
+
+/** NPCパイロット詳細（所有機体一覧付き） */
+export interface NpcPilotDetail extends NpcPilot {
+    mobile_suits: NpcMobileSuit[];
+}
+
+/** NPCパイロットの部分更新リクエスト */
+export interface NpcPilotUpdate {
+    npc_personality?: NpcPersonality;
+    level?: number;
+    exp?: number;
+    credits?: number;
+    skill_points?: number;
+    status_points?: number;
+    sht?: number;
+    mel?: number;
+    intel?: number;
+    ref?: number;
+    tou?: number;
+    luk?: number;
+    awq?: number;
+}
+
+/** NPC所有機体の部分更新リクエスト */
+export interface NpcMobileSuitUpdate {
+    name?: string;
+    max_hp?: number;
+    armor?: number;
+    mobility?: number;
+}

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -950,6 +950,75 @@ class Pilot(SQLModel, table=True):
     )
 
 
+# --- NPC Admin Models ---
+
+
+class NpcMobileSuitEntry(SQLModel):
+    """NPC所有機体エントリー定義（管理者用レスポンス）."""
+
+    id: uuid.UUID
+    name: str
+    max_hp: int
+    current_hp: int
+    armor: int
+    mobility: float
+    personality: str | None = None
+    is_ace: bool = False
+    ace_id: str | None = None
+    pilot_name: str | None = None
+    bounty_exp: int = 0
+    bounty_credits: int = 0
+
+
+class NpcPilotEntry(SQLModel):
+    """NPCパイロットエントリー定義（管理者用レスポンス）."""
+
+    id: uuid.UUID
+    user_id: str
+    name: str
+    npc_personality: str | None = None
+    is_ace: bool = False
+    level: int
+    exp: int
+    credits: int
+    skill_points: int
+    status_points: int
+    sht: int
+    mel: int
+    intel: int
+    ref: int
+    tou: int
+    luk: int
+    awq: int
+    mobile_suit_count: int = 0
+    created_at: datetime
+    updated_at: datetime
+
+
+class NpcPilotDetail(NpcPilotEntry):
+    """NPCパイロット詳細定義（管理者用レスポンス、所有機体一覧付き）."""
+
+    mobile_suits: list[NpcMobileSuitEntry] = Field(default_factory=list)
+
+
+class NpcPilotUpdate(SQLModel):
+    """NPCパイロット更新リクエスト."""
+
+    npc_personality: str | None = None
+    level: int | None = Field(default=None, ge=1)
+    exp: int | None = Field(default=None, ge=0)
+    credits: int | None = Field(default=None, ge=0)
+    skill_points: int | None = Field(default=None, ge=0)
+    status_points: int | None = Field(default=None, ge=0)
+    sht: int | None = Field(default=None, ge=0)
+    mel: int | None = Field(default=None, ge=0)
+    intel: int | None = Field(default=None, ge=0)
+    ref: int | None = Field(default=None, ge=0)
+    tou: int | None = Field(default=None, ge=0)
+    luk: int | None = Field(default=None, ge=0)
+    awq: int | None = Field(default=None, ge=0)
+
+
 class Season(SQLModel, table=True):
     """シーズン管理テーブル."""
 

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -337,12 +337,13 @@ def list_npcs(
         max_level=max_level,
         ace_only=ace_only,
     )
+    counts = PilotService.count_owned_mobile_suits_by_user_id(
+        session, [pilot.user_id for pilot in pilots]
+    )
     entries = []
     for pilot in pilots:
         entry = _pilot_to_entry(pilot)
-        entry.mobile_suit_count = len(
-            PilotService.get_npc_owned_mobile_suits(session, pilot.user_id)
-        )
+        entry.mobile_suit_count = counts.get(pilot.user_id, 0)
         entries.append(entry)
     return entries
 

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -1,8 +1,10 @@
 """管理者専用 API ルーター.
 
-マスター機体データおよびマスター武器データの CRUD エンドポイントを提供する。
+マスター機体データ・マスター武器データ・NPC(Pilot)データの CRUD エンドポイントを提供する。
 全エンドポイントは ADMIN_API_KEY ヘッダー (X-API-Key) による認証が必要。
 """
+
+import uuid
 
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlmodel import Session
@@ -20,10 +22,17 @@ from app.models.models import (
     MasterWeaponEntry,
     MasterWeaponSpec,
     MasterWeaponUpdate,
+    MobileSuitUpdate,
+    NpcMobileSuitEntry,
+    NpcPilotDetail,
+    NpcPilotEntry,
+    NpcPilotUpdate,
+    Pilot,
     Weapon,
 )
 from app.services.combat_simulation_service import CombatSimulationService
 from app.services.mobile_suit_service import MobileSuitService
+from app.services.pilot_service import PilotService
 from app.services.weapon_service import WeaponService
 
 router = APIRouter(
@@ -41,6 +50,12 @@ weapon_router = APIRouter(
 simulation_router = APIRouter(
     prefix="/api/admin",
     tags=["admin-simulation"],
+    dependencies=[Depends(verify_admin_api_key)],
+)
+
+npc_router = APIRouter(
+    prefix="/api/admin/npcs",
+    tags=["admin-npcs"],
     dependencies=[Depends(verify_admin_api_key)],
 )
 
@@ -268,3 +283,166 @@ def simulate_combat(data: CombatSimulationRequest) -> CombatSimulationResponse:
         raise HTTPException(
             status_code=status.HTTP_422_UNPROCESSABLE_ENTITY, detail=str(e)
         ) from e
+
+
+# ===========================================================
+# NPC(Pilot) データ管理 エンドポイント (Issue #441)
+# ===========================================================
+
+
+def _pilot_to_entry(pilot: Pilot) -> NpcPilotEntry:
+    """Pilot モデルを NpcPilotEntry レスポンスに変換する."""
+    return NpcPilotEntry(
+        id=pilot.id,
+        user_id=pilot.user_id,
+        name=pilot.name,
+        npc_personality=pilot.npc_personality,
+        is_ace=PilotService.is_ace_pilot(pilot),
+        level=pilot.level,
+        exp=pilot.exp,
+        credits=pilot.credits,
+        skill_points=pilot.skill_points,
+        status_points=pilot.status_points,
+        sht=pilot.sht,
+        mel=pilot.mel,
+        intel=pilot.intel,
+        ref=pilot.ref,
+        tou=pilot.tou,
+        luk=pilot.luk,
+        awq=pilot.awq,
+        mobile_suit_count=0,
+        created_at=pilot.created_at,
+        updated_at=pilot.updated_at,
+    )
+
+
+@npc_router.get("", response_model=list[NpcPilotEntry])
+def list_npcs(
+    personality: str | None = None,
+    min_level: int | None = None,
+    max_level: int | None = None,
+    ace_only: bool | None = None,
+    session: Session = Depends(get_session),
+) -> list[NpcPilotEntry]:
+    """NPC(is_npc=True)パイロット一覧を返す.
+
+    - `personality`: 性格タイプで絞り込む (AGGRESSIVE/CAUTIOUS/SNIPER)
+    - `min_level` / `max_level`: レベル範囲で絞り込む
+    - `ace_only`: True でエース由来のNPCのみ、False で通常NPCのみに絞り込む
+    """
+    pilots = PilotService.list_npc_pilots(
+        session,
+        personality=personality,
+        min_level=min_level,
+        max_level=max_level,
+        ace_only=ace_only,
+    )
+    entries = []
+    for pilot in pilots:
+        entry = _pilot_to_entry(pilot)
+        entry.mobile_suit_count = len(
+            PilotService.get_npc_owned_mobile_suits(session, pilot.user_id)
+        )
+        entries.append(entry)
+    return entries
+
+
+@npc_router.get("/{pilot_id}", response_model=NpcPilotDetail)
+def get_npc(
+    pilot_id: uuid.UUID,
+    session: Session = Depends(get_session),
+) -> NpcPilotDetail:
+    """NPCパイロットの詳細（所有機体一覧付き）を返す."""
+    pilot = PilotService.get_npc_pilot_by_id(session, pilot_id)
+    if pilot is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"NPC pilot '{pilot_id}' not found.",
+        )
+    mobile_suits = PilotService.get_npc_owned_mobile_suits(session, pilot.user_id)
+    entry = _pilot_to_entry(pilot)
+    return NpcPilotDetail(
+        **entry.model_dump(exclude={"mobile_suit_count"}),
+        mobile_suit_count=len(mobile_suits),
+        mobile_suits=[
+            NpcMobileSuitEntry(
+                id=ms.id,
+                name=ms.name,
+                max_hp=ms.max_hp,
+                current_hp=ms.current_hp,
+                armor=ms.armor,
+                mobility=ms.mobility,
+                personality=ms.personality,
+                is_ace=ms.is_ace,
+                ace_id=ms.ace_id,
+                pilot_name=ms.pilot_name,
+                bounty_exp=ms.bounty_exp,
+                bounty_credits=ms.bounty_credits,
+            )
+            for ms in mobile_suits
+        ],
+    )
+
+
+@npc_router.put("/{pilot_id}", response_model=NpcPilotDetail)
+def update_npc(
+    pilot_id: uuid.UUID,
+    data: NpcPilotUpdate,
+    session: Session = Depends(get_session),
+) -> NpcPilotDetail:
+    """NPCパイロットのステータス（レベル/exp/credits/各種能力値等）を更新する."""
+    updated = PilotService.update_npc_pilot(session, pilot_id, data)
+    if updated is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"NPC pilot '{pilot_id}' not found.",
+        )
+    return get_npc(pilot_id, session)
+
+
+@npc_router.put("/{pilot_id}/mobile-suits/{ms_id}", response_model=NpcMobileSuitEntry)
+def update_npc_mobile_suit(
+    pilot_id: uuid.UUID,
+    ms_id: uuid.UUID,
+    data: MobileSuitUpdate,
+    session: Session = Depends(get_session),
+) -> NpcMobileSuitEntry:
+    """NPCパイロットが所有する機体のステータスを更新する.
+
+    - `ms_id` が `pilot_id` の所有機体でない場合は 404 を返す
+    """
+    pilot = PilotService.get_npc_pilot_by_id(session, pilot_id)
+    if pilot is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"NPC pilot '{pilot_id}' not found.",
+        )
+    owned_ids = {
+        ms.id for ms in PilotService.get_npc_owned_mobile_suits(session, pilot.user_id)
+    }
+    if ms_id not in owned_ids:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Mobile suit '{ms_id}' not owned by NPC pilot '{pilot_id}'.",
+        )
+
+    updated = MobileSuitService.update_mobile_suit(session, ms_id, data)
+    if updated is None:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Mobile suit '{ms_id}' not found.",
+        )
+    return NpcMobileSuitEntry(
+        id=updated.id,
+        name=updated.name,
+        max_hp=updated.max_hp,
+        current_hp=updated.current_hp,
+        armor=updated.armor,
+        mobility=updated.mobility,
+        personality=updated.personality,
+        is_ace=updated.is_ace,
+        ace_id=updated.ace_id,
+        pilot_name=updated.pilot_name,
+        bounty_exp=updated.bounty_exp,
+        bounty_credits=updated.bounty_credits,
+    )

--- a/backend/app/services/mobile_suit_service.py
+++ b/backend/app/services/mobile_suit_service.py
@@ -1,5 +1,6 @@
 # backend/app/services/mobile_suit_service.py
 import re
+import uuid
 
 from sqlmodel import Session, select
 
@@ -46,7 +47,7 @@ class MobileSuitService:
 
     @staticmethod
     def update_mobile_suit(
-        session: Session, ms_id: str, update_data: MobileSuitUpdate
+        session: Session, ms_id: str | uuid.UUID, update_data: MobileSuitUpdate
     ) -> MobileSuit | None:
         """機体データを更新する."""
         # IDで検索

--- a/backend/app/services/pilot_service.py
+++ b/backend/app/services/pilot_service.py
@@ -3,7 +3,7 @@
 import uuid
 from datetime import UTC, datetime
 
-from sqlmodel import Session, select
+from sqlmodel import Session, func, select
 
 from app.core.gamedata import get_shop_listing_by_id
 from app.core.npc_data import ACE_PILOTS
@@ -108,11 +108,12 @@ class PilotService:
             statement = statement.where(Pilot.level >= min_level)
         if max_level is not None:
             statement = statement.where(Pilot.level <= max_level)
+        if ace_only is True:
+            statement = statement.where(Pilot.name.in_(ACE_PILOT_NAMES))  # type: ignore[attr-defined]
+        elif ace_only is False:
+            statement = statement.where(Pilot.name.not_in(ACE_PILOT_NAMES))  # type: ignore[attr-defined]
 
-        pilots = list(session.exec(statement).all())
-        if ace_only is None:
-            return pilots
-        return [p for p in pilots if (p.name in ACE_PILOT_NAMES) == ace_only]
+        return list(session.exec(statement).all())
 
     @staticmethod
     def get_npc_pilot_by_id(session: Session, pilot_id: uuid.UUID) -> Pilot | None:
@@ -130,6 +131,28 @@ class PilotService:
             Pilot.is_npc == True,  # noqa: E712
         )
         return session.exec(statement).first()
+
+    @staticmethod
+    def count_owned_mobile_suits_by_user_id(
+        session: Session, user_ids: list[str]
+    ) -> dict[str, int]:
+        """複数NPCの所有機体数を一括取得する（管理者用、一覧表示のN+1回避）.
+
+        Args:
+            session: データベースセッション
+            user_ids: NPC の合成 user_id (npc-{uuid} 形式) のリスト
+
+        Returns:
+            dict[str, int]: user_id -> 所有機体数。0件のuser_idはキーに含まれない
+        """
+        if not user_ids:
+            return {}
+        statement = (
+            select(MobileSuit.user_id, func.count(MobileSuit.id))  # type: ignore[arg-type]
+            .where(MobileSuit.user_id.in_(user_ids))  # type: ignore[union-attr]
+            .group_by(MobileSuit.user_id)  # type: ignore[arg-type]
+        )
+        return dict(session.exec(statement).all())  # type: ignore[arg-type]
 
     @staticmethod
     def get_npc_owned_mobile_suits(session: Session, user_id: str) -> list[MobileSuit]:

--- a/backend/app/services/pilot_service.py
+++ b/backend/app/services/pilot_service.py
@@ -6,11 +6,19 @@ from datetime import UTC, datetime
 from sqlmodel import Session, select
 
 from app.core.gamedata import get_shop_listing_by_id
+from app.core.npc_data import ACE_PILOTS
 from app.core.skills import SKILL_COST, get_skill_definition
-from app.models.models import MobileSuit, Pilot
+from app.models.models import MobileSuit, NpcPilotUpdate, Pilot
 
 # レベルアップ時に付与するステータスポイント数
 STATUS_POINTS_PER_LEVEL: int = 2
+
+# npc_data.ACE_PILOTS に由来するパイロット名の集合。
+# エースはMobileSuit(user_id=None)として都度生成されPilotテーブルに永続化されないため、
+# 名前の一致による best-effort な識別に留める（Issue #441）。
+ACE_PILOT_NAMES: frozenset[str] = frozenset(
+    str(ace["pilot_name"]) for ace in ACE_PILOTS
+)
 
 
 class PilotService:
@@ -72,6 +80,111 @@ class PilotService:
         """
         statement = select(Pilot).where(Pilot.user_id == user_id, Pilot.is_npc == True)  # noqa: E712
         return self.session.exec(statement).first()
+
+    @staticmethod
+    def list_npc_pilots(
+        session: Session,
+        personality: str | None = None,
+        min_level: int | None = None,
+        max_level: int | None = None,
+        ace_only: bool | None = None,
+    ) -> list[Pilot]:
+        """NPCパイロット一覧を取得する（管理者用）.
+
+        Args:
+            session: データベースセッション
+            personality: 性格タイプで絞り込む (AGGRESSIVE/CAUTIOUS/SNIPER)
+            min_level: レベル下限（この値以上）
+            max_level: レベル上限（この値以下）
+            ace_only: True の場合エース由来のNPCのみ、False の場合通常NPCのみに絞り込む
+
+        Returns:
+            list[Pilot]: NPCパイロットのリスト
+        """
+        statement = select(Pilot).where(Pilot.is_npc == True)  # noqa: E712
+        if personality is not None:
+            statement = statement.where(Pilot.npc_personality == personality)
+        if min_level is not None:
+            statement = statement.where(Pilot.level >= min_level)
+        if max_level is not None:
+            statement = statement.where(Pilot.level <= max_level)
+
+        pilots = list(session.exec(statement).all())
+        if ace_only is None:
+            return pilots
+        return [p for p in pilots if (p.name in ACE_PILOT_NAMES) == ace_only]
+
+    @staticmethod
+    def get_npc_pilot_by_id(session: Session, pilot_id: uuid.UUID) -> Pilot | None:
+        """NPCパイロットをidで取得する（管理者用）.
+
+        Args:
+            session: データベースセッション
+            pilot_id: パイロットのUUID
+
+        Returns:
+            Pilot | None: NPCパイロット。見つからない場合は None
+        """
+        statement = select(Pilot).where(
+            Pilot.id == pilot_id,
+            Pilot.is_npc == True,  # noqa: E712
+        )
+        return session.exec(statement).first()
+
+    @staticmethod
+    def get_npc_owned_mobile_suits(session: Session, user_id: str) -> list[MobileSuit]:
+        """NPCパイロットが所有する機体一覧を取得する（管理者用）.
+
+        Args:
+            session: データベースセッション
+            user_id: NPC の合成 user_id (npc-{uuid} 形式)
+
+        Returns:
+            list[MobileSuit]: 所有機体のリスト
+        """
+        statement = select(MobileSuit).where(MobileSuit.user_id == user_id)
+        return list(session.exec(statement).all())
+
+    @staticmethod
+    def is_ace_pilot(pilot: Pilot) -> bool:
+        """パイロットがエースパイロット由来かどうかを判定する（名前一致によるbest-effort判定）.
+
+        Args:
+            pilot: 判定対象のパイロット
+
+        Returns:
+            bool: エース由来のNPCの場合 True
+        """
+        return pilot.name in ACE_PILOT_NAMES
+
+    @staticmethod
+    def update_npc_pilot(
+        session: Session, pilot_id: uuid.UUID, update_data: NpcPilotUpdate
+    ) -> Pilot | None:
+        """NPCパイロットのステータスを更新する（管理者用）.
+
+        Args:
+            session: データベースセッション
+            pilot_id: パイロットのUUID
+            update_data: 更新データ
+
+        Returns:
+            Pilot | None: 更新後のパイロット。見つからない場合は None
+        """
+        pilot = PilotService.get_npc_pilot_by_id(session, pilot_id)
+        if pilot is None:
+            return None
+
+        update_dict = update_data.model_dump(exclude_unset=True)
+        for key, value in update_dict.items():
+            setattr(pilot, key, value)
+        pilot.updated_at = datetime.now(UTC)
+
+        session.add(pilot)
+        session.commit()
+        session.refresh(pilot)
+
+        return pilot
 
     def get_or_create_pilot(self, user_id: str, name: str) -> Pilot:
         """パイロットを取得または作成する.

--- a/backend/main.py
+++ b/backend/main.py
@@ -81,6 +81,7 @@ app.include_router(teams.router)
 app.include_router(admin.router)
 app.include_router(admin.weapon_router)
 app.include_router(admin.simulation_router)
+app.include_router(admin.npc_router)
 app.include_router(player_weapons.router)
 
 # --- Response Schemas ---

--- a/backend/tests/unit/test_admin_npcs.py
+++ b/backend/tests/unit/test_admin_npcs.py
@@ -153,6 +153,39 @@ def test_list_npcs_ace_only_filter(client_admin, session):
     assert any(e["name"] == "Char Aznable" for e in data)
     assert not any(e["name"] == "Random Grunt" for e in data)
 
+    response = client_admin.get(
+        "/api/admin/npcs", headers=HEADERS, params={"ace_only": False}
+    )
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert all(not e["is_ace"] for e in data)
+    assert any(e["name"] == "Random Grunt" for e in data)
+    assert not any(e["name"] == "Char Aznable" for e in data)
+
+
+def test_count_owned_mobile_suits_by_user_id(session, npc_pilot_with_suit):
+    """複数NPCの所有機体数を一括取得できること（一覧表示のN+1回避用）."""
+    pilot, suit = npc_pilot_with_suit
+    other_suit = MobileSuit(
+        user_id=pilot.user_id,
+        name="Second Suit",
+        max_hp=800,
+        current_hp=800,
+        armor=50,
+        mobility=1.0,
+        weapons=[],
+        side="ENEMY",
+    )
+    session.add(other_suit)
+    session.commit()
+
+    counts = PilotService.count_owned_mobile_suits_by_user_id(
+        session, [pilot.user_id, "npc-nonexistent"]
+    )
+    assert counts[pilot.user_id] == 2
+    assert "npc-nonexistent" not in counts
+    assert PilotService.count_owned_mobile_suits_by_user_id(session, []) == {}
+
 
 # ===================== 詳細取得テスト =====================
 

--- a/backend/tests/unit/test_admin_npcs.py
+++ b/backend/tests/unit/test_admin_npcs.py
@@ -1,0 +1,255 @@
+"""管理者専用 NPC(Pilot) CRUD API のユニットテスト."""
+
+import os
+
+import pytest
+from fastapi import status
+from fastapi.testclient import TestClient
+
+# テスト用APIキーを強制的に設定（conftest より先に上書きするため setdefault ではなく直接代入）
+os.environ["ADMIN_API_KEY"] = "test_admin_key_12345"
+
+from app.models.models import MobileSuit
+from app.services.pilot_service import PilotService
+from main import app
+
+ADMIN_KEY = "test_admin_key_12345"
+HEADERS = {"X-API-Key": ADMIN_KEY}
+
+
+@pytest.fixture(name="client_admin")
+def client_admin_fixture(session):
+    """管理者テスト用クライアント（DBセッションオーバーライド付き）."""
+    from app.db import get_session
+
+    def get_session_override():
+        return session
+
+    app.dependency_overrides[get_session] = get_session_override
+    client = TestClient(app)
+    yield client
+    app.dependency_overrides.clear()
+
+
+@pytest.fixture(name="npc_pilot")
+def npc_pilot_fixture(session):
+    """テスト用NPCパイロットを1体作成する."""
+    pilot_service = PilotService(session)
+    pilot = pilot_service.create_npc_pilot("Test NPC", "AGGRESSIVE")
+    return pilot
+
+
+@pytest.fixture(name="npc_pilot_with_suit")
+def npc_pilot_with_suit_fixture(session, npc_pilot):
+    """テスト用NPCパイロットに機体を1体紐付ける."""
+    suit = MobileSuit(
+        user_id=npc_pilot.user_id,
+        name="Test NPC Suit",
+        max_hp=800,
+        current_hp=800,
+        armor=50,
+        mobility=1.0,
+        weapons=[],
+        side="ENEMY",
+        personality="AGGRESSIVE",
+    )
+    session.add(suit)
+    session.commit()
+    session.refresh(suit)
+    return npc_pilot, suit
+
+
+# ===================== 認証テスト =====================
+
+
+def test_list_requires_auth(client_admin):
+    """認証なしで一覧取得するとき 401/422 が返ること."""
+    response = client_admin.get("/api/admin/npcs")
+    assert response.status_code in (status.HTTP_401_UNAUTHORIZED, 422)
+
+
+def test_list_wrong_key(client_admin):
+    """不正なAPIキーで 401 が返ること."""
+    response = client_admin.get("/api/admin/npcs", headers={"X-API-Key": "wrong_key"})
+    assert response.status_code == status.HTTP_401_UNAUTHORIZED
+
+
+# ===================== 一覧取得テスト =====================
+
+
+def test_list_npcs_returns_only_npc_pilots(client_admin, npc_pilot, session):
+    """is_npc=False の通常パイロットは一覧に含まれないこと."""
+    from app.models.models import Pilot
+
+    session.add(Pilot(user_id="player-1", name="Player One", is_npc=False))
+    session.commit()
+
+    response = client_admin.get("/api/admin/npcs", headers=HEADERS)
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    names = [entry["name"] for entry in data]
+    assert "Test NPC" in names
+    assert "Player One" not in names
+
+
+def test_list_npcs_includes_mobile_suit_count(client_admin, npc_pilot_with_suit):
+    """所有機体数が一覧レスポンスに反映されること."""
+    pilot, _suit = npc_pilot_with_suit
+    response = client_admin.get("/api/admin/npcs", headers=HEADERS)
+    assert response.status_code == status.HTTP_200_OK
+    entry = next(e for e in response.json() if e["id"] == str(pilot.id))
+    assert entry["mobile_suit_count"] == 1
+
+
+def test_list_npcs_filter_by_personality(client_admin, session):
+    """性格タイプで絞り込めること."""
+    pilot_service = PilotService(session)
+    pilot_service.create_npc_pilot("Aggro NPC", "AGGRESSIVE")
+    pilot_service.create_npc_pilot("Sniper NPC", "SNIPER")
+
+    response = client_admin.get(
+        "/api/admin/npcs", headers=HEADERS, params={"personality": "SNIPER"}
+    )
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert all(e["npc_personality"] == "SNIPER" for e in data)
+    assert any(e["name"] == "Sniper NPC" for e in data)
+
+
+def test_list_npcs_filter_by_level_range(client_admin, session):
+    """レベル範囲で絞り込めること."""
+    pilot_service = PilotService(session)
+    low = pilot_service.create_npc_pilot("Low Level NPC", "AGGRESSIVE")
+    low.level = 2
+    session.add(low)
+    high = pilot_service.create_npc_pilot("High Level NPC", "AGGRESSIVE")
+    high.level = 20
+    session.add(high)
+    session.commit()
+
+    response = client_admin.get(
+        "/api/admin/npcs",
+        headers=HEADERS,
+        params={"min_level": 10, "max_level": 30},
+    )
+    assert response.status_code == status.HTTP_200_OK
+    names = [e["name"] for e in response.json()]
+    assert "High Level NPC" in names
+    assert "Low Level NPC" not in names
+
+
+def test_list_npcs_ace_only_filter(client_admin, session):
+    """ace_only フラグでエース由来NPCを絞り込めること（名前一致判定）."""
+    pilot_service = PilotService(session)
+    pilot_service.create_npc_pilot("Char Aznable", "AGGRESSIVE")
+    pilot_service.create_npc_pilot("Random Grunt", "AGGRESSIVE")
+
+    response = client_admin.get(
+        "/api/admin/npcs", headers=HEADERS, params={"ace_only": True}
+    )
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert all(e["is_ace"] for e in data)
+    assert any(e["name"] == "Char Aznable" for e in data)
+    assert not any(e["name"] == "Random Grunt" for e in data)
+
+
+# ===================== 詳細取得テスト =====================
+
+
+def test_get_npc_detail(client_admin, npc_pilot_with_suit):
+    """NPC詳細取得で所有機体一覧が含まれること."""
+    pilot, suit = npc_pilot_with_suit
+    response = client_admin.get(f"/api/admin/npcs/{pilot.id}", headers=HEADERS)
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["id"] == str(pilot.id)
+    assert len(data["mobile_suits"]) == 1
+    assert data["mobile_suits"][0]["id"] == str(suit.id)
+
+
+def test_get_npc_detail_not_found(client_admin):
+    """存在しないNPC idの場合 404 が返ること."""
+    import uuid
+
+    response = client_admin.get(f"/api/admin/npcs/{uuid.uuid4()}", headers=HEADERS)
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_get_npc_detail_excludes_player_pilot(client_admin, session):
+    """is_npc=False のパイロットidを指定した場合 404 が返ること."""
+    from app.models.models import Pilot
+
+    player = Pilot(user_id="player-2", name="Player Two", is_npc=False)
+    session.add(player)
+    session.commit()
+    session.refresh(player)
+
+    response = client_admin.get(f"/api/admin/npcs/{player.id}", headers=HEADERS)
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+# ===================== 更新テスト =====================
+
+
+def test_update_npc_stats(client_admin, npc_pilot):
+    """NPCのexp/credits/level等を更新できること."""
+    response = client_admin.put(
+        f"/api/admin/npcs/{npc_pilot.id}",
+        headers=HEADERS,
+        json={"level": 10, "exp": 500, "credits": 99999, "sht": 30},
+    )
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["level"] == 10
+    assert data["exp"] == 500
+    assert data["credits"] == 99999
+    assert data["sht"] == 30
+
+
+def test_update_npc_not_found(client_admin):
+    """存在しないNPC idを更新しようとした場合 404 が返ること."""
+    import uuid
+
+    response = client_admin.put(
+        f"/api/admin/npcs/{uuid.uuid4()}", headers=HEADERS, json={"level": 5}
+    )
+    assert response.status_code == status.HTTP_404_NOT_FOUND
+
+
+def test_update_npc_mobile_suit(client_admin, npc_pilot_with_suit):
+    """NPC所有機体のステータスを更新できること."""
+    pilot, suit = npc_pilot_with_suit
+    response = client_admin.put(
+        f"/api/admin/npcs/{pilot.id}/mobile-suits/{suit.id}",
+        headers=HEADERS,
+        json={"max_hp": 1200, "armor": 70},
+    )
+    assert response.status_code == status.HTTP_200_OK
+    data = response.json()
+    assert data["max_hp"] == 1200
+    assert data["armor"] == 70
+
+
+def test_update_npc_mobile_suit_not_owned(client_admin, npc_pilot, session):
+    """他のNPCが所有する機体を更新しようとした場合 404 が返ること."""
+    other_suit = MobileSuit(
+        user_id="npc-other",
+        name="Other NPC Suit",
+        max_hp=800,
+        current_hp=800,
+        armor=50,
+        mobility=1.0,
+        weapons=[],
+        side="ENEMY",
+    )
+    session.add(other_suit)
+    session.commit()
+    session.refresh(other_suit)
+
+    response = client_admin.put(
+        f"/api/admin/npcs/{npc_pilot.id}/mobile-suits/{other_suit.id}",
+        headers=HEADERS,
+        json={"max_hp": 1200},
+    )
+    assert response.status_code == status.HTTP_404_NOT_FOUND

--- a/docs/features/admin-npcs.md
+++ b/docs/features/admin-npcs.md
@@ -1,0 +1,181 @@
+# NPCデータ管理画面 — 管理者専用エディタ（Issue #441）
+
+## 概要
+
+NPC（`Pilot.is_npc=True`）を、通常ユーザと同じ `pilots`/`mobile_suits` テーブルを共用したまま、
+admin-tool から一覧・閲覧・編集できる管理画面。#171（NPC自律成長AIロジック）が実装されるまでの
+間の暫定運用、および実装後の挙動確認・チューニング用途を想定している。
+
+> [!NOTE]
+> `npc_data.py` の `ACE_PILOTS`（エースパイロットの静的マスタデータ）自体の編集は本Issueのスコープ外。
+> エースパイロットの `MobileSuit` は戦闘マッチング時に `user_id=None` の使い捨てレコードとして都度生成され
+> `Pilot` テーブルには永続化されないため、`ACE_PILOTS` 由来かどうかは `Pilot.name` と
+> `ACE_PILOTS[*].pilot_name` の一致による best-effort 判定（`PilotService.is_ace_pilot`）で識別している。
+> 恒久的な紐付け（例: `Pilot` にエースIDを持たせる等）が必要になった場合は別Issueで対応する。
+
+---
+
+## Backend API
+
+すべてのエンドポイントは `X-API-Key` ヘッダー（環境変数 `ADMIN_API_KEY`）による認証が必要。
+
+### エンドポイント一覧
+
+| メソッド | パス | 説明 |
+|---|---|---|
+| `GET` | `/api/admin/npcs` | NPCパイロット一覧取得（性格/レベル範囲/エースで絞り込み可） |
+| `GET` | `/api/admin/npcs/{pilot_id}` | NPCパイロット詳細取得（所有機体一覧付き） |
+| `PUT` | `/api/admin/npcs/{pilot_id}` | NPCパイロットのステータス更新 |
+| `PUT` | `/api/admin/npcs/{pilot_id}/mobile-suits/{ms_id}` | NPC所有機体のステータス更新 |
+
+### GET /api/admin/npcs
+
+クエリパラメータ（すべて省略可、AND条件で絞り込み）:
+
+| パラメータ | 型 | 説明 |
+|---|---|---|
+| `personality` | string | `AGGRESSIVE` / `CAUTIOUS` / `SNIPER` |
+| `min_level` | int | レベル下限（この値以上） |
+| `max_level` | int | レベル上限（この値以下） |
+| `ace_only` | bool | `true` でエース由来NPCのみ、`false` で通常NPCのみ |
+
+レスポンスは `NpcPilotEntry` の配列。`mobile_suit_count` は `MobileSuit.user_id == Pilot.user_id` で
+紐づく所有機体数。
+
+### GET /api/admin/npcs/{pilot_id}
+
+`NpcPilotDetail`（`NpcPilotEntry` に `mobile_suits: NpcMobileSuitEntry[]` を追加したもの）を返す。
+`is_npc=False` のパイロット、または存在しない `pilot_id` を指定した場合は `404`。
+
+### PUT /api/admin/npcs/{pilot_id}
+
+`NpcPilotUpdate`（`npc_personality` / `level` / `exp` / `credits` / `skill_points` / `status_points` /
+`sht` / `mel` / `intel` / `ref` / `tou` / `luk` / `awq`、すべて省略可）を受け取り、指定フィールドのみ更新する。
+更新後の `NpcPilotDetail` を返す。存在しない場合は `404`。
+
+### PUT /api/admin/npcs/{pilot_id}/mobile-suits/{ms_id}
+
+指定したNPCが所有する機体（`MobileSuit`）のステータスを更新する。リクエストボディは既存の
+`MobileSuitUpdate`（`app/models/models.py`）をそのまま流用しており、`name` / `max_hp` / `armor` /
+`mobility` / `tactics` / 各種適性・補正値などを部分更新できる。
+
+- `ms_id` が `pilot_id` の所有機体でない場合は `404` を返す（他NPCの機体を誤って編集できないようにするため）
+- 更新ロジックは `MobileSuitService.update_mobile_suit()`（プレイヤー機体編集用の既存メソッド）をそのまま再利用
+
+### ステータスコード
+
+| コード | 意味 |
+|---|---|
+| `200` | 成功 |
+| `401` | APIキー不正 |
+| `404` | 対象NPC / 所有機体が見つからない |
+| `422` | バリデーションエラー |
+
+---
+
+## データモデル
+
+### `Pilot`（既存テーブル、新規テーブル追加なし）
+
+NPCは `is_npc=True` の `Pilot` レコードとして永続化される。`user_id` は `npc-{uuid}` 形式の合成ID。
+本Issueで新たに管理画面から編集可能になったフィールド: `npc_personality` / `level` / `exp` / `credits` /
+`skill_points` / `status_points` / `sht` / `mel` / `intel` / `ref` / `tou` / `luk` / `awq`。
+
+### `MobileSuit`（既存テーブル）
+
+NPCの所有機体は `MobileSuit.user_id == Pilot.user_id` で紐づく。エース機体は `is_ace=True` /
+`ace_id` / `pilot_name` / `bounty_exp` / `bounty_credits` を持つが、前述の通りエース機体は
+`user_id=None` の使い捨てレコードとして生成されるため、通常は管理画面のNPC一覧・詳細には現れない
+（`select_npcs_for_room()` で永続化NPCとして再利用されたエース以外）。
+
+### `app/services/pilot_service.py` に追加した管理者用メソッド
+
+- `PilotService.list_npc_pilots(session, personality, min_level, max_level, ace_only)` — 一覧取得（フィルタ対応）
+- `PilotService.get_npc_pilot_by_id(session, pilot_id)` — idによる単体取得（`is_npc=True` のみ）
+- `PilotService.get_npc_owned_mobile_suits(session, user_id)` — 所有機体一覧取得
+- `PilotService.is_ace_pilot(pilot)` — `ACE_PILOTS` 由来かどうかの best-effort 判定（名前一致）
+- `PilotService.update_npc_pilot(session, pilot_id, update_data)` — ステータス更新
+
+既存の `PilotService` はインスタンスメソッド中心（`__init__(self, session)`）だが、上記の管理者用メソッドは
+`MobileSuitService` の管理者用CRUDメソッドと同じ `@staticmethod` パターンに揃えている。
+
+---
+
+## Frontend（`admin-tool/`）
+
+### ルーティング
+
+`/npcs`
+
+### コンポーネント構成
+
+```
+admin-tool/src/
+├── app/
+│   └── npcs/
+│       └── page.tsx               # NPC管理画面エントリーポイント
+├── components/
+│   └── admin/
+│       ├── NpcTable.tsx           # NPC一覧テーブル（ソート・フィルタ付き）
+│       └── NpcEditForm.tsx        # ステータス編集フォーム + 所有機体インライン編集
+└── hooks/
+    └── useAdminNpcs.ts            # 一覧/詳細取得・更新フック（SWR）
+```
+
+### NPC一覧テーブル（`NpcTable`）
+
+- 名前・性格・レベル・EXP・クレジット・所属機体数を表示
+- 各列ヘッダークリックでソート（昇順/降順）
+- 名前によるテキストフィルタ、性格タイプ・レベル範囲・エース/通常NPCによる絞り込み（サーバー側フィルタではなく
+  クライアント側で `npcs` 全件から絞り込む。既存の `MobileSuitTable` と同じ設計）
+- エース由来NPC（`is_ace=true`）は行内に `ACE` バッジを表示
+
+### 詳細編集フォーム（`NpcEditForm`）
+
+- `react-hook-form` + `zod` によるバリデーション（性格・レベル・EXP・クレジット・各種ポイント・SHT/MEL/INT/REF/TOU/LUK/AWQ）
+- 所有機体一覧を下部に表示し、機体ごとに最大HP・装甲・機動性をインライン編集して個別に保存可能
+  （`PUT /api/admin/npcs/{pilot_id}/mobile-suits/{ms_id}` を機体単位で呼び出す）
+
+> [!NOTE]
+> `NpcEditForm` は `MobileSuitEditForm` と同様、React Compiler の自動メモ化が `react-hook-form` の
+> 非制御 `<input>` への `reset()` を阻害する問題（Issue #388）を避けるため、コンポーネント関数内に
+> `"use no memo"` ディレクティブを付与している。
+
+### env vars / 起動方法
+
+`admin-mobile-suits.md` の「Frontend」セクションと共通（`NEXT_PUBLIC_API_URL` / `NEXT_PUBLIC_ADMIN_API_KEY`）。
+
+---
+
+## テスト
+
+### Backend
+
+```bash
+cd backend
+NEON_DATABASE_URL="sqlite:///test.db" ADMIN_API_KEY="test_admin_key_12345" python -m pytest tests/unit/test_admin_npcs.py -v
+```
+
+テスト内容 (`tests/unit/test_admin_npcs.py`):
+- 認証チェック（キーなし / 不正キー）
+- 一覧取得: `is_npc=False` のパイロットが含まれないこと、所有機体数の反映、性格/レベル範囲/`ace_only` フィルタ
+- 詳細取得: 所有機体一覧の反映、404（存在しないid / `is_npc=False`）
+- 更新: ステータス更新の反映、404（存在しないid）
+- 所有機体更新: ステータス反映、他NPC所有機体を編集しようとした場合の404
+
+---
+
+## 関連ファイル
+
+- `backend/app/routers/admin.py` — `npc_router`（NPC CRUD API）
+- `backend/app/services/pilot_service.py` — NPC管理者用メソッド・`ACE_PILOT_NAMES`
+- `backend/app/models/models.py` — `NpcPilotEntry` / `NpcPilotDetail` / `NpcPilotUpdate` / `NpcMobileSuitEntry`
+- `backend/app/core/npc_data.py` — `ACE_PILOTS`（エース識別の名前一致元データ）
+- `backend/main.py` — `app.include_router(admin.npc_router)`
+- `backend/tests/unit/test_admin_npcs.py` — NPC管理APIテスト
+- `admin-tool/src/app/npcs/page.tsx` — 管理画面
+- `admin-tool/src/hooks/useAdminNpcs.ts` — 一覧/詳細取得・更新フック
+- `admin-tool/src/components/admin/NpcTable.tsx` — NPC一覧テーブル
+- `admin-tool/src/components/admin/NpcEditForm.tsx` — ステータス編集フォーム
+- `admin-tool/src/types/admin.ts` — `NpcPilot` / `NpcPilotDetail` / `NpcPilotUpdate` / `NpcMobileSuit` 型定義
+- `admin-tool/src/app/page.tsx` — トップナビへのリンク追加


### PR DESCRIPTION
## Summary
- NPC（`Pilot.is_npc=True`）を admin-tool から一覧・詳細・編集できる管理画面を追加
- `GET/PUT /api/admin/npcs`, `GET /api/admin/npcs/{pilot_id}`, `PUT /api/admin/npcs/{pilot_id}/mobile-suits/{ms_id}` を追加
- 性格タイプ・レベル範囲・エース（`npc_data.ACE_PILOTS` 由来、名前一致によるbest-effort判定）で絞り込み可能
- NPCの exp/credits/level/各種ステータス、および所有 MobileSuit のステータス（最大HP/装甲/機動性）を編集可能

## Test plan
- [x] `cd backend && NEON_DATABASE_URL="sqlite:///test.db" ADMIN_API_KEY="test_admin_key_12345" python -m pytest tests/unit/test_admin_npcs.py -v`（14件すべてpass）
- [x] `cd backend && python -m pytest tests/unit --tb=short`（既存テストに regression なし。`test_battle_chatter.py::test_chatter_generation_for_npc` は本PRと無関係な既存のflaky乱数テスト）
- [x] `cd backend && ruff check` / `ruff format --check` / `mypy`（pre-commit hookで確認済み）
- [x] `cd admin-tool && npx tsc --noEmit`（新規ファイルにエラーなし。既存テストファイルの型エラーは本PR対象外）
- [x] `cd admin-tool && npm run build`（`/npcs` ルート生成確認）
- [x] `docs/features/admin-npcs.md` を追加

Closes #441

🤖 Generated with [Claude Code](https://claude.com/claude-code)