### PR TITLE
fix: 通常NPCのパイロット名を機体名から人名に変更

### DIFF
--- a/backend/alembic/versions/x7y8z9a0b1c2_backfill_npc_pilot_human_names.py
+++ b/backend/alembic/versions/x7y8z9a0b1c2_backfill_npc_pilot_human_names.py
@@ -13,8 +13,17 @@ Note:
     ため（今回のコード修正で新規NPCは app.core.npc_data.generate_npc_pilot_name()
     による人名を使うよう修正済み）。本マイグレーションは既存データの一括バックフィル。
 
-    エース由来のNPC（pilot_service.ACE_PILOT_NAMES）はすでに人名になっているため
-    対象外とする。ダウングレードでは元の機体名を復元できないため no-op とする。
+    対象は pilots.name が "... (NPC)" という機体名パターンに一致する行のみに限定する
+    （PRレビュー指摘）。is_npc=True の全件を無条件に書き換えると、エース由来の名前
+    （pilot_service.ACE_PILOT_NAMES）だけでなく、将来手動修正済みの通常NPCまで
+    再度ランダム名に上書きしてしまう恐れがあるため。
+
+    また pilots.name だけでなく、同じ user_id を持つ mobile_suits.pilot_name も
+    同一の人名で更新する（PRレビュー指摘）。mobile_suits.pilot_name は
+    battle_utils.py の一言ログ表示や MatchingService の永続化NPC再利用ログでも
+    参照されており、pilots.name だけ更新すると表示上は機体名のまま残ってしまうため。
+
+    ダウングレードでは元の機体名を復元できないため no-op とする。
 """
 
 import random
@@ -92,26 +101,38 @@ ACE_PILOT_NAMES = frozenset(
 
 
 def upgrade() -> None:
-    """機体名になっている通常NPCのpilots.nameをランダムな人名で置き換える."""
+    """機体名パターンになっている通常NPCのpilots.name/mobile_suits.pilot_nameを人名で置き換える."""
     bind = op.get_bind()
     pilots = sa.table(
         "pilots",
         sa.column("id", sa.Uuid),
+        sa.column("user_id", sa.String),
         sa.column("name", sa.String),
         sa.column("is_npc", sa.Boolean),
     )
+    mobile_suits = sa.table(
+        "mobile_suits",
+        sa.column("user_id", sa.String),
+        sa.column("pilot_name", sa.String),
+    )
     rows = bind.execute(
-        sa.select(pilots.c.id, pilots.c.name).where(pilots.c.is_npc.is_(True))
+        sa.select(pilots.c.id, pilots.c.user_id, pilots.c.name)
+        .where(pilots.c.is_npc.is_(True))
+        .where(pilots.c.name.notin_(ACE_PILOT_NAMES))
+        .where(pilots.c.name.like("% (NPC)"))
     ).fetchall()
 
     for row in rows:
-        if row.name in ACE_PILOT_NAMES:
-            continue
         new_name = (
             f"{random.choice(NPC_PILOT_FIRST_NAMES)} "
             f"{random.choice(NPC_PILOT_LAST_NAMES)}"
         )
         bind.execute(pilots.update().where(pilots.c.id == row.id).values(name=new_name))
+        bind.execute(
+            mobile_suits.update()
+            .where(mobile_suits.c.user_id == row.user_id)
+            .values(pilot_name=new_name)
+        )
 
 
 def downgrade() -> None:

--- a/backend/alembic/versions/x7y8z9a0b1c2_backfill_npc_pilot_human_names.py
+++ b/backend/alembic/versions/x7y8z9a0b1c2_backfill_npc_pilot_human_names.py
@@ -1,0 +1,119 @@
+"""backfill_npc_pilot_human_names.
+
+Revision ID: x7y8z9a0b1c2
+Revises: w6x7y8z9a0b1
+Create Date: 2026-08-13
+
+Note:
+    通常NPC（非エース）の pilots.name が機体名（例: "Zaku II (NPC)"）のまま
+    保存されており没入感を損ねていた問題の一括修正 (Issue #444)。
+    原因は matching_service.py の _create_npc_mobile_suit() が
+    MobileSuit.pilot_name を設定しておらず、pilot_name = npc_suit.pilot_name
+    or npc_suit.name のフォールバックで機体名がパイロット名に流用されていた
+    ため（今回のコード修正で新規NPCは app.core.npc_data.generate_npc_pilot_name()
+    による人名を使うよう修正済み）。本マイグレーションは既存データの一括バックフィル。
+
+    エース由来のNPC（pilot_service.ACE_PILOT_NAMES）はすでに人名になっているため
+    対象外とする。ダウングレードでは元の機体名を復元できないため no-op とする。
+"""
+
+import random
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "x7y8z9a0b1c2"
+down_revision: str | Sequence[str] | None = "w6x7y8z9a0b1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# npc_data.NPC_PILOT_FIRST_NAMES / NPC_PILOT_LAST_NAMES と同一の値を複製している。
+# マイグレーションはアプリコードから独立させ、将来アプリ側の名簿が変わっても
+# 過去のマイグレーションの再現性を壊さないようにするため。
+NPC_PILOT_FIRST_NAMES = [
+    "Jin",
+    "Marco",
+    "Elena",
+    "Kaito",
+    "Fenn",
+    "Sara",
+    "Dmitri",
+    "Youko",
+    "Leon",
+    "Nadia",
+    "Ryo",
+    "Ingrid",
+    "Theo",
+    "Mika",
+    "Otto",
+    "Renna",
+    "Hugo",
+    "Saya",
+    "Viktor",
+    "Aina",
+]
+
+NPC_PILOT_LAST_NAMES = [
+    "Reyes",
+    "Voss",
+    "Kagura",
+    "Halden",
+    "Iskandar",
+    "Brandt",
+    "Sumeragi",
+    "Falk",
+    "Orlov",
+    "Tessin",
+    "Nakada",
+    "Wexler",
+    "Ardin",
+    "Kessler",
+    "Blanc",
+    "Mizushima",
+    "Karlsen",
+    "Torres",
+    "Fenrir",
+    "Amagi",
+]
+
+# npc_data.ACE_PILOTS の pilot_name 一覧を複製（エースは対象外にするため）。
+ACE_PILOT_NAMES = frozenset(
+    [
+        "Char Aznable",
+        "Ramba Ral",
+        "Yazan Gable",
+        "Amuro Ray",
+        "Haman Karn",
+    ]
+)
+
+
+def upgrade() -> None:
+    """機体名になっている通常NPCのpilots.nameをランダムな人名で置き換える."""
+    bind = op.get_bind()
+    pilots = sa.table(
+        "pilots",
+        sa.column("id", sa.Uuid),
+        sa.column("name", sa.String),
+        sa.column("is_npc", sa.Boolean),
+    )
+    rows = bind.execute(
+        sa.select(pilots.c.id, pilots.c.name).where(pilots.c.is_npc.is_(True))
+    ).fetchall()
+
+    for row in rows:
+        if row.name in ACE_PILOT_NAMES:
+            continue
+        new_name = (
+            f"{random.choice(NPC_PILOT_FIRST_NAMES)} "
+            f"{random.choice(NPC_PILOT_LAST_NAMES)}"
+        )
+        bind.execute(pilots.update().where(pilots.c.id == row.id).values(name=new_name))
+
+
+def downgrade() -> None:
+    """データバックフィルのため元の機体名は復元できず no-op."""
+    pass

--- a/backend/app/core/npc_data.py
+++ b/backend/app/core/npc_data.py
@@ -1,10 +1,70 @@
 """NPC and Ace Pilot data definitions."""
 
+import random
+
 from app.models.models import Weapon
 
 # --- Personality Types ---
 
 PERSONALITY_TYPES = ["AGGRESSIVE", "CAUTIOUS", "SNIPER"]
+
+# --- NPC Pilot Name Generation ---
+# 通常NPC（非エース）のパイロット名。機体名をそのままパイロット名に流用していた
+# 問題（Issue #444）の修正用。組み合わせでランダムなパイロット名を生成する。
+
+NPC_PILOT_FIRST_NAMES = [
+    "Jin",
+    "Marco",
+    "Elena",
+    "Kaito",
+    "Fenn",
+    "Sara",
+    "Dmitri",
+    "Youko",
+    "Leon",
+    "Nadia",
+    "Ryo",
+    "Ingrid",
+    "Theo",
+    "Mika",
+    "Otto",
+    "Renna",
+    "Hugo",
+    "Saya",
+    "Viktor",
+    "Aina",
+]
+
+NPC_PILOT_LAST_NAMES = [
+    "Reyes",
+    "Voss",
+    "Kagura",
+    "Halden",
+    "Iskandar",
+    "Brandt",
+    "Sumeragi",
+    "Falk",
+    "Orlov",
+    "Tessin",
+    "Nakada",
+    "Wexler",
+    "Ardin",
+    "Kessler",
+    "Blanc",
+    "Mizushima",
+    "Karlsen",
+    "Torres",
+    "Fenrir",
+    "Amagi",
+]
+
+
+def generate_npc_pilot_name() -> str:
+    """通常NPC用のランダムなパイロット名(名 姓)を生成する."""
+    first = random.choice(NPC_PILOT_FIRST_NAMES)
+    last = random.choice(NPC_PILOT_LAST_NAMES)
+    return f"{first} {last}"
+
 
 # --- Battle Chatter (Personality-based dialogue) ---
 

--- a/backend/app/services/matching_service.py
+++ b/backend/app/services/matching_service.py
@@ -8,7 +8,7 @@ from typing import Any, cast
 
 from sqlmodel import Session, select
 
-from app.core.npc_data import ACE_PILOTS, PERSONALITY_TYPES
+from app.core.npc_data import ACE_PILOTS, PERSONALITY_TYPES, generate_npc_pilot_name
 from app.models.models import (
     BattleEntry,
     BattleRoom,
@@ -367,6 +367,7 @@ class MatchingService:
 
         npc = MobileSuit(
             name=name,
+            pilot_name=generate_npc_pilot_name(),
             max_hp=max_hp,
             current_hp=max_hp,
             armor=armor,

--- a/docs/features/admin-npcs.md
+++ b/docs/features/admin-npcs.md
@@ -2,7 +2,7 @@
 
 ## パイロット名について（Issue #444）
 
-通常NPC（非エース）の `Pilot.name` は `app/core/npc_data.py` の `generate_npc_pilot_name()`
+通常NPC（非エース）の `Pilot.name` は `backend/app/core/npc_data.py` の `generate_npc_pilot_name()`
 （`NPC_PILOT_FIRST_NAMES` × `NPC_PILOT_LAST_NAMES` からランダムに1件ずつ選び `"名 姓"` を生成、400通り）
 で採番される。`MatchingService._create_npc_mobile_suit()` が生成する `MobileSuit.pilot_name` にこの値を
 設定しており、NPCパイロット作成時（`create_room_matches()` 内の
@@ -10,8 +10,13 @@
 
 以前は `MobileSuit.pilot_name` が未設定のままだったため、上記フォールバックにより機体名
 （例: `"Zaku II (NPC)"`）がパイロット名として保存されてしまっていた。既存データはマイグレーション
-`alembic/versions/x7y8z9a0b1c2_backfill_npc_pilot_human_names.py` で一括バックフィル済み
-（エース由来NPCは `ACE_PILOT_NAMES` に含まれる名前のため対象外）。
+`backend/alembic/versions/x7y8z9a0b1c2_backfill_npc_pilot_human_names.py` で一括バックフィル済み
+（対象は `pilots.name` が `"... (NPC)"` 形式の機体名パターンに一致する行のみ。エース由来NPCや、
+既に手動で人名へ修正済みの行を誤って上書きしないための絞り込み）。バックフィルは `pilots.name` だけでなく、
+同じ `user_id` を持つ `mobile_suits.pilot_name` にも同一の人名を書き込む。`mobile_suits.pilot_name` は
+バトルログ表示（`battle_utils.py` の `f"[{pilot_name}]の{actor.name}"`）やNPC再利用時のログ
+（`MatchingService.select_npcs_for_room` 経由の再利用）でも参照されるため、`pilots.name` のみ更新すると
+これらの表示が機体名のまま残ってしまう。
 
 エースNPCのパイロット名は引き続き `npc_data.py` の `ACE_PILOTS[*]["pilot_name"]`（例: `"Char Aznable"`）
 由来で、本セクションの対象外。

--- a/docs/features/admin-npcs.md
+++ b/docs/features/admin-npcs.md
@@ -1,5 +1,21 @@
 # NPCデータ管理画面 — 管理者専用エディタ（Issue #441）
 
+## パイロット名について（Issue #444）
+
+通常NPC（非エース）の `Pilot.name` は `app/core/npc_data.py` の `generate_npc_pilot_name()`
+（`NPC_PILOT_FIRST_NAMES` × `NPC_PILOT_LAST_NAMES` からランダムに1件ずつ選び `"名 姓"` を生成、400通り）
+で採番される。`MatchingService._create_npc_mobile_suit()` が生成する `MobileSuit.pilot_name` にこの値を
+設定しており、NPCパイロット作成時（`create_room_matches()` 内の
+`pilot_name = npc_suit.pilot_name or npc_suit.name`）にそのまま使われる。
+
+以前は `MobileSuit.pilot_name` が未設定のままだったため、上記フォールバックにより機体名
+（例: `"Zaku II (NPC)"`）がパイロット名として保存されてしまっていた。既存データはマイグレーション
+`alembic/versions/x7y8z9a0b1c2_backfill_npc_pilot_human_names.py` で一括バックフィル済み
+（エース由来NPCは `ACE_PILOT_NAMES` に含まれる名前のため対象外）。
+
+エースNPCのパイロット名は引き続き `npc_data.py` の `ACE_PILOTS[*]["pilot_name"]`（例: `"Char Aznable"`）
+由来で、本セクションの対象外。
+
 ## 概要
 
 NPC（`Pilot.is_npc=True`）を、通常ユーザと同じ `pilots`/`mobile_suits` テーブルを共用したまま、


### PR DESCRIPTION
## Summary
- 通常NPC（非エース）の `Pilot.name` が搭乗機体名（例: "Zaku II (NPC)"）と同一になっていた不具合を修正 (closes #444)
- 原因: `MatchingService._create_npc_mobile_suit()` が `MobileSuit.pilot_name` を設定しておらず、`pilot_name = npc_suit.pilot_name or npc_suit.name` のフォールバックで機体名がパイロット名に流用されていた
- `app/core/npc_data.py` に `generate_npc_pilot_name()`（名20種 × 姓20種、400通り）を追加し、新規NPC生成時に `pilot_name` を設定するよう修正
- 既存の非エースNPCレコードをAlembicマイグレーションで一括バックフィル（`x7y8z9a0b1c2_backfill_npc_pilot_human_names.py`。downgradeは元の機体名を復元できないためno-op）
- `docs/features/admin-npcs.md` にパイロット名生成ロジックの説明を追記

## Test plan
- [x] `cd backend && python -m pytest tests/unit -k "npc or matching or pilot" --tb=short -q` — 全パス
- [x] `ruff check` / `ruff format` / `mypy` — pre-commitフック経由でパス
- [x] `alembic heads` — 単一headに正しくチェーンすることを確認
- [x] マイグレーション本体（`alembic upgrade head`）は共有Neon DBへの書き込みのためマージ後にユーザー側で実行

🤖 Generated with [Claude Code](https://claude.com/claude-code)