### PR TITLE
perf: マッチング処理のNPC補充DBラウンドトリップをroom_sizeに依存しない形へ削減

### DIFF
--- a/backend/app/services/matching_service.py
+++ b/backend/app/services/matching_service.py
@@ -145,7 +145,6 @@ class MatchingService:
                     )
                     npc_suit.current_hp = npc_suit.max_hp
                     self.session.add(npc_suit)
-                    self.session.flush()
 
                     _coerce_suit_json_fields(npc_suit)
                     snapshot = npc_suit.model_dump()
@@ -165,21 +164,22 @@ class MatchingService:
                     )
 
                 # 残りは新規NPCで埋める
+                # MobileSuit.id / Pilot.id は default_factory (uuid4) でPython側で
+                # 即時採番されるため、IDを得るためのflushは不要。パイロット作成も
+                # 1体ごとのcommitを避け、add_all() + 1回のflushにまとめる。
                 pilot_service = PilotService(self.session)
                 for _ in range(new_count):
                     npc_suit = self._create_npc_mobile_suit()
-                    self.session.add(npc_suit)
-                    self.session.flush()  # IDを取得するためにflush
 
-                    # 新規NPC用のパイロットレコードを作成
+                    # 新規NPC用のパイロットレコードを作成（DBアクセスなし）
                     pilot_name = npc_suit.pilot_name or npc_suit.name
                     personality = npc_suit.personality or "AGGRESSIVE"
-                    npc_pilot = pilot_service.create_npc_pilot(pilot_name, personality)
+                    npc_pilot = pilot_service.build_npc_pilot(pilot_name, personality)
 
                     # 機体を NPC パイロットの user_id に紐付ける
                     npc_suit.user_id = npc_pilot.user_id
                     self.session.add(npc_suit)
-                    self.session.flush()
+                    self.session.add(npc_pilot)
 
                     _coerce_suit_json_fields(npc_suit)
                     snapshot = npc_suit.model_dump()
@@ -195,6 +195,9 @@ class MatchingService:
                     )
                     self.session.add(npc_entry)
                     entries.append(npc_entry)
+
+                # ここまでの新規 MobileSuit/Pilot/BattleEntry をまとめて1回のflushで送信
+                self.session.flush()
 
             # ルームのステータスを更新
             room.status = "WAITING"
@@ -233,17 +236,26 @@ class MatchingService:
         # ランダムにシャッフルして必要数を選択
         selected_pilots = random.sample(npc_pilots, min(count, len(npc_pilots)))
 
-        result = []
+        # 選択したパイロット全員分の機体を1回のクエリで一括取得（N+1解消）
+        user_ids = [pilot.user_id for pilot in selected_pilots]
+        suit_statement = (
+            select(MobileSuit)
+            .where(MobileSuit.user_id.in_(user_ids))  # type: ignore[union-attr]
+            .where(MobileSuit.side == "ENEMY")
+        )
+        suits = list(self.session.exec(suit_statement).all())
+
+        # user_id ごとに最初の1体を対応付ける（従来の .first() と同じ選定結果）
+        suit_by_user_id: dict[str | None, MobileSuit] = {}
+        for suit in suits:
+            if suit.user_id not in suit_by_user_id:
+                suit_by_user_id[suit.user_id] = suit
+
+        result: list[tuple[MobileSuit, Pilot]] = []
         for pilot in selected_pilots:
-            # このパイロットの user_id に紐づく機体を取得
-            suit_statement = (
-                select(MobileSuit)
-                .where(MobileSuit.user_id == pilot.user_id)
-                .where(MobileSuit.side == "ENEMY")
-            )
-            suit = self.session.exec(suit_statement).first()
-            if suit:
-                result.append((suit, pilot))
+            found_suit = suit_by_user_id.get(pilot.user_id)
+            if found_suit:
+                result.append((found_suit, pilot))
 
         return result
 

--- a/backend/app/services/matching_service.py
+++ b/backend/app/services/matching_service.py
@@ -166,7 +166,7 @@ class MatchingService:
                 # 残りは新規NPCで埋める
                 # MobileSuit.id / Pilot.id は default_factory (uuid4) でPython側で
                 # 即時採番されるため、IDを得るためのflushは不要。パイロット作成も
-                # 1体ごとのcommitを避け、add_all() + 1回のflushにまとめる。
+                # 1体ごとのcommitを避け、ループ内でadd()を積み上げてから1回のflushにまとめる。
                 pilot_service = PilotService(self.session)
                 for _ in range(new_count):
                     npc_suit = self._create_npc_mobile_suit()

--- a/backend/app/services/pilot_service.py
+++ b/backend/app/services/pilot_service.py
@@ -44,18 +44,22 @@ class PilotService:
         """
         return level * 100
 
-    def create_npc_pilot(self, name: str, personality: str) -> Pilot:
-        """NPC パイロットを新規作成する.
+    def build_npc_pilot(self, name: str, personality: str) -> Pilot:
+        """NPC パイロットのレコードをメモリ上に構築する（DBアクセスなし）.
+
+        `Pilot.id`/`user_id` はここで確定するため、呼び出し側で複数体を
+        `add_all()` してから1回の `flush()`/`commit()` にまとめられる
+        （大量生成時の DB ラウンドトリップ削減）。
 
         Args:
             name: NPC パイロット名
             personality: NPC の性格 (AGGRESSIVE/CAUTIOUS/SNIPER)
 
         Returns:
-            Pilot: 作成された NPC パイロット
+            Pilot: セッションにはまだ追加されていない NPC パイロット
         """
         npc_user_id = f"npc-{uuid.uuid4().hex}"
-        pilot = Pilot(
+        return Pilot(
             user_id=npc_user_id,
             name=name,
             is_npc=True,
@@ -64,6 +68,18 @@ class PilotService:
             exp=0,
             credits=0,
         )
+
+    def create_npc_pilot(self, name: str, personality: str) -> Pilot:
+        """NPC パイロットを新規作成し、即座にDBへ永続化する.
+
+        Args:
+            name: NPC パイロット名
+            personality: NPC の性格 (AGGRESSIVE/CAUTIOUS/SNIPER)
+
+        Returns:
+            Pilot: 作成された NPC パイロット
+        """
+        pilot = self.build_npc_pilot(name, personality)
         self.session.add(pilot)
         self.session.commit()
         self.session.refresh(pilot)

--- a/backend/scripts/matching_scale_bench.py
+++ b/backend/scripts/matching_scale_bench.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+# backend/scripts/matching_scale_bench.py
+"""マッチングフェーズのDBラウンドトリップ計測ベンチマーク（Issue #448）.
+
+`MatchingService.create_rooms()` の NPC補充処理（永続化NPC取得のN+1、
+新規NPC生成ループの `session.flush()` 多発）を最適化した効果を確認するため、
+room_size = 8 / 50 / 100 でルームを1部屋ずつ作成し、SQL発行回数と処理時間を
+計測する。in-memory SQLite を使うため Neon への実レイテンシは再現できないが、
+「クエリ発行回数が room_size に対して線形に膨れ上がらないか」は確認できる。
+
+Usage:
+    python scripts/matching_scale_bench.py
+    python scripts/matching_scale_bench.py --sizes 8,50,100
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import os
+import sys
+import time
+import uuid
+from datetime import UTC, datetime
+
+from sqlalchemy import event
+from sqlmodel import Session, SQLModel, create_engine
+
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+from app.db import json_serializer
+from app.models.models import (
+    BattleEntry,
+    BattleRoom,
+    MobileSuit,
+    Pilot,
+    Vector3,
+    Weapon,
+)
+from app.services.matching_service import MatchingService
+
+
+def _seed_persistent_npc_pool(session: Session, count: int) -> None:
+    """既存の永続化NPC（Pilot + MobileSuit）を count 体分あらかじめDBに投入する."""
+    for i in range(count):
+        user_id = f"npc-pool-{uuid.uuid4().hex[:8]}"
+        pilot = Pilot(
+            user_id=user_id,
+            name=f"Persistent NPC {i}",
+            is_npc=True,
+            npc_personality="AGGRESSIVE",
+            level=1,
+            exp=0,
+            credits=0,
+        )
+        suit = MobileSuit(
+            name=f"Persistent NPC Suit {i}",
+            max_hp=800,
+            current_hp=800,
+            armor=40,
+            mobility=1.0,
+            position=Vector3(x=0, y=0, z=0),
+            weapons=[
+                Weapon(
+                    id=f"npc_pool_weapon_{i}",
+                    name="Heat Hawk",
+                    power=120,
+                    range=100,
+                    accuracy=80,
+                )
+            ],
+            side="ENEMY",
+            user_id=user_id,
+        )
+        session.add(pilot)
+        session.add(suit)
+    session.commit()
+
+
+def _seed_room(session: Session, player_count: int) -> BattleRoom:
+    """OPENルームを1つ作成し、player_count人分のプレイヤーエントリーを詰める."""
+    room = BattleRoom(status="OPEN", scheduled_at=datetime.now(UTC))
+    session.add(room)
+    session.flush()
+
+    for i in range(player_count):
+        user_id = f"player-{uuid.uuid4().hex[:8]}"
+        suit = MobileSuit(
+            name=f"Player Suit {i}",
+            max_hp=1000,
+            current_hp=1000,
+            armor=50,
+            mobility=1.0,
+            position=Vector3(x=0, y=0, z=0),
+            weapons=[
+                Weapon(
+                    id=f"weapon_{i}",
+                    name="Beam Rifle",
+                    power=100,
+                    range=500,
+                    accuracy=80,
+                )
+            ],
+            side="PLAYER",
+            user_id=user_id,
+        )
+        session.add(suit)
+        session.flush()
+
+        entry = BattleEntry(
+            user_id=user_id,
+            room_id=room.id,
+            mobile_suit_id=suit.id,
+            mobile_suit_snapshot=suit.model_dump(),
+            is_npc=False,
+        )
+        session.add(entry)
+
+    session.commit()
+    return room
+
+
+def bench_room_size(room_size: int, player_count: int) -> tuple[int, float]:
+    """指定 room_size で1ルームぶんの create_rooms() を実行し、(SQL発行回数, 秒) を返す."""
+    engine = create_engine("sqlite:///:memory:", json_serializer=json_serializer)
+    SQLModel.metadata.create_all(engine)
+
+    query_count = 0
+
+    def _count_queries(*_args: object, **_kwargs: object) -> None:
+        nonlocal query_count
+        query_count += 1
+
+    event.listen(engine, "before_cursor_execute", _count_queries)
+
+    with Session(engine) as session:
+        # 永続化NPC再利用の効果を測るため、あらかじめ再利用対象のNPCプールを用意しておく
+        # （npc_persistence_rate=0.5 で半数が再利用対象になる想定のため room_size 分用意）
+        _seed_persistent_npc_pool(session, room_size)
+        _seed_room(session, player_count)
+
+        query_count = 0  # 計測対象は create_rooms() 呼び出し以降のみ
+        matching_service = MatchingService(session, room_size=room_size)
+
+        start = time.perf_counter()
+        with contextlib.redirect_stdout(io.StringIO()):
+            matching_service.create_rooms()
+        elapsed = time.perf_counter() - start
+
+    return query_count, elapsed
+
+
+def main() -> None:
+    """CLI エントリポイント: 引数を解析しベンチマークを実行して結果を表示する."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--sizes",
+        type=str,
+        default="8,50,100",
+        help="カンマ区切りの room_size 一覧（デフォルト: 8,50,100）",
+    )
+    parser.add_argument(
+        "--player-count",
+        type=int,
+        default=1,
+        help="事前投入するプレイヤーエントリー数（残りはNPCで補充される、デフォルト: 1）",
+    )
+    args = parser.parse_args()
+
+    sizes = [int(s.strip()) for s in args.sizes.split(",") if s.strip()]
+
+    print(f"{'room_size':>10} | {'sql queries':>12} | {'elapsed sec':>12}")
+    print("-" * 40)
+    for size in sizes:
+        query_count, elapsed = bench_room_size(size, args.player_count)
+        print(f"{size:>10} | {query_count:>12} | {elapsed:>12.4f}")
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/features/matching-batch-performance.md
+++ b/docs/features/matching-batch-performance.md
@@ -27,7 +27,7 @@ NPC補充処理は、`room_size` を増やすとNeon（チーム共有のリモ�
 
 ## 計測用ベンチマーク（`backend/scripts/matching_scale_bench.py`）
 
-DBを使わないシミュレーションベンチ（`sim_scale_bench.py`、Issue #446）とは別に、
+DBを使わないシミュレーションベンチ（`backend/scripts/simulation/sim_scale_bench.py`、Issue #446）とは別に、
 in-memory SQLiteでマッチングフェーズのSQL発行回数・処理時間を計測するスクリプトを用意した。
 Neonへの実レイテンシは再現できないが、「ルームサイズに対してクエリ発行回数が線形に増えていないか」は確認できる。
 

--- a/docs/features/matching-batch-performance.md
+++ b/docs/features/matching-batch-performance.md
@@ -1,0 +1,51 @@
+# マッチングバッチのNPC補充パフォーマンス最適化 (Issue #448)
+
+`MatchingService.create_rooms()`（`backend/app/services/matching_service.py`）の
+NPC補充処理は、`room_size` を増やすとNeon（チーム共有のリモートDB）へのDBラウンドトリップ数が
+線形に増加する実装になっていた。`room_size=50〜100` への引き上げを見据え、ラウンドトリップ回数を
+ルーム内のNPC数に依存しない形へ最適化した。
+
+## 変更点
+
+### 1. 永続化NPC取得のN+1解消（`select_npcs_for_room()`）
+
+選択したNPCパイロットごとに `MobileSuit` を個別クエリで取得していた箇所を、
+`MobileSuit.user_id.in_(user_ids)` による一括クエリに変更した。
+「ランダムにNPCパイロットをサンプリングしてから対応機体を取得する」という選定順序・確率分布は変更していない
+（`user_id` ごとに最初の1体を対応付ける点も従来の `.first()` と同じ選定結果になる）。
+
+### 2. 新規NPC生成ループのバルク化（`create_rooms()`）
+
+- `MobileSuit.id` / `Pilot.id` はどちらも `default_factory=uuid.uuid4` でPython側のオブジェクト構築時に
+  即時採番される（DBのAUTO INCREMENTに依存しない）ため、IDを得るための `session.flush()` はそもそも不要だった。
+- `PilotService.create_npc_pilot()` はNPCパイロット1体ごとに `session.commit()` していたため、
+  新規NPC生成数だけコミットが発生していた。DBへの追加なしにPilotレコードを構築するだけの
+  `PilotService.build_npc_pilot()` を新設し、`create_rooms()` 側は `session.add()` を積み上げるだけにして、
+  ループ終了後に1回の `session.flush()` にまとめた（`create_npc_pilot()` 自体は既存の呼び出し元
+  （管理画面・テスト等、即時のDB確定を期待する箇所）向けにそのまま残してある）。
+- 既存の永続化NPC再利用ループも同様に、1体ごとの `session.flush()` を廃止した。
+
+## 計測用ベンチマーク（`backend/scripts/matching_scale_bench.py`）
+
+DBを使わないシミュレーションベンチ（`sim_scale_bench.py`、Issue #446）とは別に、
+in-memory SQLiteでマッチングフェーズのSQL発行回数・処理時間を計測するスクリプトを用意した。
+Neonへの実レイテンシは再現できないが、「ルームサイズに対してクエリ発行回数が線形に増えていないか」は確認できる。
+
+```bash
+cd backend
+source .venv/bin/activate
+python scripts/matching_scale_bench.py
+# python scripts/matching_scale_bench.py --sizes 8,50,100 --player-count 1
+```
+
+### 最適化後の計測結果例（in-memory SQLite）
+
+| room_size | SQL発行回数 | 処理時間(sec) |
+|---|---|---|
+| 8 | 10 | 0.0075 |
+| 50 | 10 | 0.0175 |
+| 100 | 10 | 0.0302 |
+
+`room_size` を8→100に引き上げてもSQL発行回数は一定（10クエリ）のまま。最適化前の実装では
+NPC1体ごとに「一括取得できない個別クエリ」「機体flush」「NPCパイロットの個別commit」が発生していたため、
+NPC数に比例してクエリ数が増加していた。


### PR DESCRIPTION
## Summary
- `select_npcs_for_room()` のNPCパイロットごとの個別クエリを `user_id IN (...)` の一括クエリに変更（N+1解消）。選定順序・確率分布は変更なし。
- `create_rooms()` の新規NPC生成ループを見直し、1体ごとの `session.flush()`（機体ID取得用）と `PilotService.create_npc_pilot()` 内の1体ごとの `session.commit()` を排除。`MobileSuit.id`/`Pilot.id` はどちらも `default_factory=uuid.uuid4` でPython側で即時採番されるため、IDを得るためのflushはそもそも不要だった。DBに書き込まずにPilotレコードを構築するだけの `PilotService.build_npc_pilot()` を新設し、ループ終了後の1回の `flush()` にまとめた。
- 永続化NPC再利用ループも同様に1体ごとの `flush()` を廃止。
- `backend/scripts/matching_scale_bench.py` を追加し、room_size 8/50/100 での `create_rooms()` のSQL発行回数・処理時間を計測できるようにした（in-memory SQLite、Neonの実レイテンシは再現しないが「ラウンドトリップ数がroom_sizeに対して線形に増えないか」は確認できる）。
- `docs/features/matching-batch-performance.md` を追加し、変更内容とベンチマーク結果を記載。

計測結果（最適化後）: room_size 8/50/100 いずれもSQL発行回数は10クエリで一定。

## Test plan
- [x] `cd backend && python -m pytest tests/unit --tb=short` → 730 passed, 1 xfailed
- [x] `ruff check` / `mypy` (pre-commit hook経由でパス)
- [x] `python scripts/matching_scale_bench.py` で room_size=8/50/100 のSQL発行回数が一定であることを確認

Closes #448

🤖 Generated with [Claude Code](https://claude.com/claude-code)