### PR TITLE
feat: バトルシミュレーションの定員デフォルトを8→50へ引き上げ

### DIFF
--- a/backend/app/services/matching_service.py
+++ b/backend/app/services/matching_service.py
@@ -38,7 +38,7 @@ class MatchingService:
     def __init__(
         self,
         session: Session,
-        room_size: int = 8,
+        room_size: int = 50,
         ace_spawn_rate: float = 0.05,
         npc_persistence_rate: float = 0.5,
     ):
@@ -46,7 +46,7 @@ class MatchingService:
 
         Args:
             session: データベースセッション
-            room_size: 1ルームあたりの定員（デフォルト: 8機）
+            room_size: 1ルームあたりの定員（デフォルト: 50機）
             ace_spawn_rate: エースパイロットの出現確率（デフォルト: 5%）
             npc_persistence_rate: 既存の永続化NPCを再利用する割合（デフォルト: 50%）
         """

--- a/docs/features/matching-batch-performance.md
+++ b/docs/features/matching-batch-performance.md
@@ -49,3 +49,10 @@ python scripts/matching_scale_bench.py
 `room_size` を8→100に引き上げてもSQL発行回数は一定（10クエリ）のまま。最適化前の実装では
 NPC1体ごとに「一括取得できない個別クエリ」「機体flush」「NPCパイロットの個別commit」が発生していたため、
 NPC数に比例してクエリ数が増加していた。
+
+## デフォルト定員の引き上げ
+
+上記の検証結果を踏まえ、`MatchingService.room_size` のデフォルト値を8機から50機へ引き上げた。
+`backend/scripts/run_batch.py` の `_save_battle_results`（デイリーバトルロイヤル用バッチ、
+`.github/workflows/scheduled-battle.yaml` から定期実行）は `MatchingService(session)` とデフォルト引数で
+呼んでいるため、本番の定員はこの変更により実際に50機へ引き上がる。


### PR DESCRIPTION
## Summary
- `MatchingService.room_size` のデフォルト値を8機から50機へ引き上げ
- 既存のO(N²)対策（#446, #447, #450, #453, #454）とマッチングバッチのDBラウンドトリップ削減（`docs/features/matching-batch-performance.md`）により room_size=50/100 規模のパフォーマンスは既に検証済みであることを踏まえた変更
- `backend/scripts/run_batch.py` の `_save_battle_results`（デイリーバトルロイヤル用バッチ）はデフォルト引数でMatchingServiceを呼んでいるため、本番の定員が実際に50へ引き上がる

## Test plan
- [x] `pytest tests/unit/test_matching_service.py tests/unit/test_npc_persistence.py tests/unit/test_npc_personality_and_ace.py` が全通過（既存テストはroom_sizeを明示指定しているため影響なし）
- [ ] room_size=50規模でのゲームバランス確認（別途ユーザー側で確認予定）

Closes #458

🤖 Generated with [Claude Code](https://claude.com/claude-code)