### PR TITLE
fix: マッチングバッチのbattle_entries FK違反を修正

### DIFF
--- a/backend/app/services/matching_service.py
+++ b/backend/app/services/matching_service.py
@@ -164,39 +164,9 @@ class MatchingService:
                     )
 
                 # 残りは新規NPCで埋める
-                # MobileSuit.id / Pilot.id は default_factory (uuid4) でPython側で
-                # 即時採番されるため、IDを得るためのflushは不要。パイロット作成も
-                # 1体ごとのcommitを避け、ループ内でadd()を積み上げてから1回のflushにまとめる。
-                pilot_service = PilotService(self.session)
-                for _ in range(new_count):
-                    npc_suit = self._create_npc_mobile_suit()
+                entries.extend(self._fill_with_new_npcs(room, new_count))
 
-                    # 新規NPC用のパイロットレコードを作成（DBアクセスなし）
-                    pilot_name = npc_suit.pilot_name or npc_suit.name
-                    personality = npc_suit.personality or "AGGRESSIVE"
-                    npc_pilot = pilot_service.build_npc_pilot(pilot_name, personality)
-
-                    # 機体を NPC パイロットの user_id に紐付ける
-                    npc_suit.user_id = npc_pilot.user_id
-                    self.session.add(npc_suit)
-                    self.session.add(npc_pilot)
-
-                    _coerce_suit_json_fields(npc_suit)
-                    snapshot = npc_suit.model_dump()
-                    snapshot["npc_pilot_level"] = npc_pilot.level
-
-                    # NPCエントリーを作成
-                    npc_entry = BattleEntry(
-                        user_id=npc_pilot.user_id,
-                        room_id=room.id,
-                        mobile_suit_id=npc_suit.id,
-                        mobile_suit_snapshot=snapshot,
-                        is_npc=True,
-                    )
-                    self.session.add(npc_entry)
-                    entries.append(npc_entry)
-
-                # ここまでの新規 MobileSuit/Pilot/BattleEntry をまとめて1回のflushで送信
+                # ここまでの新規 BattleEntry（および永続化NPC側の更新分）をまとめて送信
                 self.session.flush()
 
             # ルームのステータスを更新
@@ -213,6 +183,64 @@ class MatchingService:
 
         print(f"\nマッチング完了: {len(created_rooms)} ルーム")
         return created_rooms
+
+    def _fill_with_new_npcs(
+        self, room: BattleRoom, new_count: int
+    ) -> list[BattleEntry]:
+        """新規NPC（機体・パイロット）を生成し、ルームのエントリーとして追加する.
+
+        MobileSuit.id / Pilot.id は default_factory (uuid4) でPython側で即時採番される
+        ため、IDを得るためのflushは不要。パイロット作成も1体ごとのcommitを避け、
+        ループ内でadd()を積み上げる。ただし BattleEntry.mobile_suit_id は MobileSuit
+        との relationship() を定義していないため、SQLAlchemyのflushはテーブル間の
+        INSERT順序を保証しない（add()した順序通りにはならない）。MobileSuit/Pilotを
+        先にflushしてDBへ反映してから BattleEntry を作成・addすることで、
+        battle_entries_mobile_suit_id_fkey 違反を防ぐ（Issue #461）。
+
+        Args:
+            room: エントリー先のバトルルーム
+            new_count: 新規生成するNPC数
+
+        Returns:
+            作成された BattleEntry のリスト
+        """
+        pilot_service = PilotService(self.session)
+        new_npcs: list[tuple[MobileSuit, Pilot]] = []
+        for _ in range(new_count):
+            npc_suit = self._create_npc_mobile_suit()
+
+            # 新規NPC用のパイロットレコードを作成（DBアクセスなし）
+            pilot_name = npc_suit.pilot_name or npc_suit.name
+            personality = npc_suit.personality or "AGGRESSIVE"
+            npc_pilot = pilot_service.build_npc_pilot(pilot_name, personality)
+
+            # 機体を NPC パイロットの user_id に紐付ける
+            npc_suit.user_id = npc_pilot.user_id
+            self.session.add(npc_suit)
+            self.session.add(npc_pilot)
+            new_npcs.append((npc_suit, npc_pilot))
+
+        # BattleEntry を作成する前に MobileSuit/Pilot をDBへ反映する
+        if new_npcs:
+            self.session.flush()
+
+        new_entries: list[BattleEntry] = []
+        for npc_suit, npc_pilot in new_npcs:
+            _coerce_suit_json_fields(npc_suit)
+            snapshot = npc_suit.model_dump()
+            snapshot["npc_pilot_level"] = npc_pilot.level
+
+            npc_entry = BattleEntry(
+                user_id=npc_pilot.user_id,
+                room_id=room.id,
+                mobile_suit_id=npc_suit.id,
+                mobile_suit_snapshot=snapshot,
+                is_npc=True,
+            )
+            self.session.add(npc_entry)
+            new_entries.append(npc_entry)
+
+        return new_entries
 
     def select_npcs_for_room(self, count: int) -> list[tuple[MobileSuit, Pilot]]:
         """DBから既存の永続化NPCをランダムに選択する.

--- a/docs/features/matching-batch-performance.md
+++ b/docs/features/matching-batch-performance.md
@@ -56,3 +56,30 @@ NPC数に比例してクエリ数が増加していた。
 `backend/scripts/run_batch.py` の `_save_battle_results`（デイリーバトルロイヤル用バッチ、
 `.github/workflows/scheduled-battle.yaml` から定期実行）は `MatchingService(session)` とデフォルト引数で
 呼んでいるため、本番の定員はこの変更により実際に50機へ引き上がる。
+
+## `relationship()` 未定義によるINSERT順序の不定性（Issue #461）
+
+上記の「新規NPC生成ループのバルク化」で、新規 `MobileSuit`/`Pilot`/`BattleEntry` を1回の
+`session.flush()` にまとめた際、`BattleEntry.mobile_suit_id` が参照する `MobileSuit` より
+先に `BattleEntry` がINSERTされ `battle_entries_mobile_suit_id_fkey` 違反になる不具合が
+本番で発生した（room_sizeを8→50へ引き上げた直後に顕在化）。
+
+`backend/app/models/models.py` では `MobileSuit`/`Pilot`/`BattleEntry` 間に SQLModel/SQLAlchemy の
+`relationship()` を一切定義しておらず、`Field(foreign_key=...)` によるスキーマレベルのFK制約しか
+持たない。**`relationship()` が無い場合、SQLAlchemyのflushは複数テーブルへのINSERT順序を
+`session.add()` した順序や実際のFK依存関係に基づいては決定しない**（同一クラスのオブジェクトを
+まとめてバルクINSERTする際のテーブル間の順序は事実上不定）。add()した順に親→子で並べていても
+子テーブルのINSERTが先に発行されるケースを再現テスト（`sqlite3` + `PRAGMA foreign_keys=ON`）で
+確認済み。本ベンチスクリプト（in-memory SQLite、既定でFK制約を有効化していない）はSQL発行回数の
+計測が目的で、この順序不定性を検出できていなかった。
+
+対策として、新規NPC生成ループを「`MobileSuit`/`Pilot` の生成・add・flush」→「その結果を使った
+`BattleEntry` の生成・add」の2段階に分割し、`BattleEntry` がINSERTされる前に参照先の
+`MobileSuit` が確実にDBへ反映されるようにした。ラウンドトリップは1回増える（NPC生成が発生する
+ルームにつき2回のflush）が、`room_size` に比例して増えるものではないため、Issue #448 で狙った
+「NPC数に依存しないラウンドトリップ数」という性質自体は維持している。
+
+**今後 `MobileSuit`/`Pilot`/`BattleEntry` のような「新規作成した親を新規作成した子が同一flush内で
+参照する」パターンを書く際は、`relationship()` を定義しない限りテーブル間のINSERT順序を
+SQLAlchemyに委ねてはいけない**。親をflushしてIDをDBへ確定させてから子を作成するか、
+`relationship()` を定義してORMに依存関係を教えるかのいずれかが必要。


### PR DESCRIPTION
## Summary
- 本番Cloud Run Job（`msbs-next-batch-prod`）が `battle_entries_mobile_suit_id_fkey` 違反で失敗していた不具合を修正 (#461)
- `MobileSuit`/`Pilot`/`BattleEntry` 間に SQLAlchemy `relationship()` が定義されておらず、PR #448 で導入した一括 `session.flush()` ではテーブル間のINSERT順序が保証されないため、`BattleEntry` が参照先の `MobileSuit` より先にINSERTされることがあった（`sqlite3` + `PRAGMA foreign_keys=ON` での再現テストで確認済み）
- 新規NPC生成処理を `_fill_with_new_npcs()` に切り出し、「`MobileSuit`/`Pilot` を生成・add・flush」→「その結果を使って `BattleEntry` を生成・add」の2段階に分割することで、`BattleEntry` INSERT時に参照先が確実にDBへ反映されているようにした
- `docs/features/matching-batch-performance.md` に原因と対策の詳細を追記

## Test plan
- [x] `cd backend && python -m pytest tests/unit --tb=short` が全件パス
- [x] 独立した再現スクリプト（in-memory SQLite + `PRAGMA foreign_keys=ON`）で、修正前のパターンでFK違反が再現し、修正後のパターンで解消することを確認
- [ ] 本番デプロイ後、Cloud Run Jobs (`msbs-next-batch-prod`) の次回定期実行が正常終了することを確認

Fixes #461

🤖 Generated with [Claude Code](https://claude.com/claude-code)