### PR TITLE
feat: バトルエンジン変更時にローカル完結のシミュレーションCIを追加

### DIFF
--- a/.github/workflows/backend-ci.yaml
+++ b/.github/workflows/backend-ci.yaml
@@ -33,6 +33,14 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Check for engine changes
+        uses: dorny/paths-filter@v3
+        id: engine-diff
+        with:
+          filters: |
+            engine:
+              - 'backend/app/engine/**'
+
       - name: Setup python 3.11
         uses: actions/setup-python@v5
         with:
@@ -56,6 +64,10 @@ jobs:
 
       - name: Run tests (pytest)
         run: pytest
+
+      - name: Engine simulation smoke test
+        if: steps.engine-diff.outputs.engine == 'true'
+        run: python scripts/simulation/engine_ci_smoke.py
 
   deploy:
     needs: test

--- a/backend/scripts/simulation/engine_ci_smoke.py
+++ b/backend/scripts/simulation/engine_ci_smoke.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+# backend/scripts/simulation/engine_ci_smoke.py
+"""バトルエンジン変更時のCIスモークテスト（DB不要）.
+
+`app/engine/**` を変更したPRでmainへのマージ前に、実際に
+`BattleSimulator` を複数サイズ・複数ラウンドで完走させ、例外なく
+決着するかを確認する。Neon/Cloud Runなど外部インフラには一切
+接続せず、合成ユニット（`sim_scale_bench.py` と同じビルダー）で
+完結する。
+
+注意: このエンジンは戦闘処理（命中判定・ターゲット選定など）に
+`random`/`np.random.default_rng()` を非シード化のまま使っており、
+現状シード固定による再現性は無い。そのため本スクリプトは「同一
+構成をNラウンド繰り返す」ことで揺らぎを吸収する方式を取る
+（ユニット配置のみ `_build_units()` 内部で固定シード=42）。
+
+失敗条件（exit code 1）:
+- いずれかのラウンドで例外が発生した場合
+- 全ラウンドが `--max-steps` に到達し、1件も決着しなかった場合
+  （個別の引き分け・大規模構成での長期化は正常systemなので、
+  全滅した場合のみ「エンジンが根本的に壊れている」signalとして扱う）
+
+Usage:
+    python scripts/simulation/engine_ci_smoke.py
+    python scripts/simulation/engine_ci_smoke.py --sizes 2,8,20 --rounds 3
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import time
+import traceback
+
+# パスを通す
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from app.engine.simulation import BattleSimulator
+from scripts.simulation.sim_scale_bench import _build_units
+
+
+def _determine_win_team(sim: BattleSimulator) -> str:
+    """チームごとの生存状況から決着チームIDを返す（複数チーム対応）."""
+    alive_team_ids = {u.team_id for u in sim.units if u.current_hp > 0}
+    if len(alive_team_ids) == 1:
+        return next(iter(alive_team_ids))
+    return "DRAW"
+
+
+def _run_one(room_size: int, max_steps: int, dt: float) -> dict:
+    """1回分のバトルを完走させ、結果を辞書で返す（例外はそのまま伝播させる）."""
+    player, enemies = _build_units(room_size)
+    sim = BattleSimulator(player, enemies)
+
+    start = time.perf_counter()
+    step_count = 0
+    for _ in range(max_steps):
+        if sim.is_finished:
+            break
+        sim.step(dt=dt)
+        step_count += 1
+    wall_clock = time.perf_counter() - start
+
+    finished = sim.is_finished and step_count < max_steps
+    return {
+        "room_size": room_size,
+        "step_count": step_count,
+        "sim_elapsed_sec": round(step_count * dt, 1),
+        "wall_clock_sec": round(wall_clock, 2),
+        "finished": finished,
+        "win_team": _determine_win_team(sim) if finished else "TIMEOUT",
+    }
+
+
+def main() -> int:
+    """CLI引数を解釈し、全構成のスモークテストを実行してexit codeを返す."""
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--sizes",
+        type=str,
+        default="2,8,20",
+        help="カンマ区切りの room_size 一覧（デフォルト: 2,8,20）",
+    )
+    parser.add_argument(
+        "--rounds",
+        type=int,
+        default=3,
+        help="サイズごとの繰り返し回数（デフォルト: 3。戦闘処理は非シード化のため"
+        "ラウンドごとに結果が揺らぐ）",
+    )
+    parser.add_argument(
+        "--max-steps",
+        type=int,
+        default=2000,
+        help="1ラウンドあたりの最大ステップ数（デフォルト: 2000 = 200秒相当）",
+    )
+    parser.add_argument("--dt", type=float, default=0.1, help="時間ステップ幅（秒）")
+    args = parser.parse_args()
+
+    sizes = [int(s) for s in args.sizes.split(",")]
+
+    results: list[dict] = []
+    crashed = False
+
+    print(
+        f"{'room_size':>9} {'round':>6} {'steps':>7} {'sim_sec':>8} {'wall_sec':>9} {'result':>10}"
+    )
+    for room_size in sizes:
+        for round_idx in range(args.rounds):
+            try:
+                result = _run_one(room_size, args.max_steps, args.dt)
+            except Exception:
+                crashed = True
+                print(f"{room_size:>9} {round_idx:>6}  CRASHED")
+                traceback.print_exc()
+                continue
+
+            results.append(result)
+            outcome = result["win_team"] if result["finished"] else "TIMEOUT"
+            print(
+                f"{result['room_size']:>9} {round_idx:>6} "
+                f"{result['step_count']:>7} {result['sim_elapsed_sec']:>8} "
+                f"{result['wall_clock_sec']:>9} {outcome:>10}"
+            )
+
+    if crashed:
+        print("\nNG: シミュレーション実行中に例外が発生しました。")
+        return 1
+
+    if results and not any(r["finished"] for r in results):
+        print(
+            f"\nNG: 全 {len(results)} ラウンドが max_steps={args.max_steps} に到達し、"
+            "1件も決着しませんでした（エンジンの根本的な不具合の可能性）。"
+        )
+        return 1
+
+    timeouts = [r for r in results if not r["finished"]]
+    if timeouts:
+        print(
+            f"\n注意: {len(timeouts)}/{len(results)} ラウンドが max_steps 未決着でした"
+            "（個別の長期化は許容範囲内）。"
+        )
+
+    print(f"\nOK: {len(results)} ラウンド完走（例外なし）。")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/features/engine-ci-smoke-test.md
+++ b/docs/features/engine-ci-smoke-test.md
@@ -1,0 +1,58 @@
+# バトルエンジン変更時のCIスモークテスト
+
+`backend/app/engine/**` を変更したPRで、mainへのマージ前に実際に `BattleSimulator` を
+完走させて例外・決着不能を検出するCIステップを追加した。
+
+## 経緯
+
+Cloud Run Jobs のマッチングバッチ実行が実際に失敗した際（`battle_entries_mobile_suit_id_fkey`
+違反、別件）の対応の中で、「エンジン変更をmainへマージする前に、実際にシミュレーションを
+走らせて確認できるとよい」という提案が出た。Cloud Run上で実行するアプローチも検討したが、
+以下の理由からローカル完結（DB・GCP不使用）の方針を採用した。
+
+- `NEON_DATABASE_URL` はチーム共有の本番Neon DBを指しており（`backend/CLAUDE.md`参照）、
+  PRごとのCIから共有DBに接続するのは事故リスクが大きい
+- Cloud Run実行にはGCPサービスアカウント鍵をCIに持ち込む必要があり、権限管理のコストが増える
+- `backend/scripts/simulation/sim_scale_bench.py`（Issue #446）のように、このエンジンは
+  合成ユニットを使えばDB不要で完結するシミュレーションが既に可能
+
+## 実装
+
+### `backend/scripts/simulation/engine_ci_smoke.py`
+
+`sim_scale_bench.py` の `_build_units()`（合成ユニットビルダー）を再利用し、複数サイズ
+（デフォルト: 2/8/20機）× 複数ラウンド（デフォルト: 3回）で `BattleSimulator` を完走まで
+実行する。DB・外部APIには一切接続しない。
+
+失敗条件（exit code 1）:
+- いずれかのラウンドで例外が発生した場合
+- 全ラウンドが `--max-steps`（デフォルト2000、200秒相当）に到達し、1件も決着しなかった場合
+  （エンジンが根本的に壊れているsignal。個別ラウンドの長期化・引き分けは正常な揺らぎとして許容する）
+
+**このエンジンには現状シード固定による再現性が無い**（`app/engine/combat.py` 等の命中判定・
+ターゲット選定処理が `random`/`np.random.default_rng()` を非シード化のまま使っている）。
+そのため「同一シードで再現する」のではなく「同一構成をNラウンド繰り返して揺らぎを吸収する」
+方式を取っている。ユニット配置のみ `_build_units()` 内部の固定シード(42)で決定的。
+
+ローカル実行:
+
+```bash
+cd backend
+python scripts/simulation/engine_ci_smoke.py
+python scripts/simulation/engine_ci_smoke.py --sizes 2,8,20 --rounds 5
+```
+
+### `.github/workflows/backend-ci.yaml`
+
+`dorny/paths-filter@v3` で `backend/app/engine/**` の変更有無を検出し、変更があった場合のみ
+`engine_ci_smoke.py` を実行するステップを `test` ジョブに追加した。既存の `pytest` 実行後に
+配置しており、通常のユニットテストが通った上でのエンジン完走確認という位置づけ。
+
+## スコープ外・今後の課題
+
+- パフォーマンス回帰の検出（`sim_scale_bench.py --sizes 8,50,100` のような処理時間比較）は
+  本CIには含めていない。CI環境のマシン性能はローカル/本番と異なりばらつくため、固定閾値での
+  判定は誤検知が多くなると判断した。パフォーマンス検証は各Issue対応時に手動で
+  `sim_scale_bench.py`/`spawn_scale_bench.py` を実行する既存の運用を継続する。
+- 勝率・撃破数の偏りなどバランス面の警告（`BALANCE_WARN_*`）もCIの合否には含めていない。
+  バランス変化はエンジン変更の意図した結果であることが多く、機械的にブロックすべきではないため。


### PR DESCRIPTION
## Summary
- `backend/app/engine/**` を変更したPRで、mainへのマージ前に実際に `BattleSimulator` を完走させて例外・決着不能を検出するCIステップを追加 (#463)
- `backend/scripts/simulation/engine_ci_smoke.py`: 既存の `sim_scale_bench.py` の合成ユニットビルダーを再利用し、DB・GCPに一切接続せず複数サイズ(2/8/20機)×複数ラウンド(3回)で完走まで実行する
- `.github/workflows/backend-ci.yaml`: `dorny/paths-filter@v3` で `backend/app/engine/**` の変更有無を検出し、変更がある場合のみ `test` ジョブ内で実行
- `docs/features/engine-ci-smoke-test.md` に経緯・実装・スコープ外事項（パフォーマンス回帰検出・バランス警告は対象外）を追記

Cloud Run上での実行も検討したが、`NEON_DATABASE_URL` がチーム共有の本番Neon DBを指しておりPRごとのCIから接続するのは事故リスクが大きいこと、GCPサービスアカウント鍵の管理コストが増えることから、ローカル完結の方針を採用した。

このエンジンには現状シード固定による再現性が無い（命中判定・ターゲット選定処理が `random`/`np.random` を非シード化のまま使用）ため、「同一構成をNラウンド繰り返して揺らぎを吸収する」方式にしている。

## Test plan
- [x] `python scripts/simulation/engine_ci_smoke.py --sizes 2,8,20 --rounds 2` をローカル実行し、例外なく完走・exit code 0を確認
- [x] `ruff check` / `ruff format --check` / `mypy` が通ることを確認
- [x] `.github/workflows/backend-ci.yaml` のYAML構文を確認
- [ ] このPR自体は `app/engine/**` を変更していないため、実際にCI上でスモークテストが実行されることは別途エンジン変更を伴うPRで確認する

Fixes #463

🤖 Generated with [Claude Code](https://claude.com/claude-code)