### PR TITLE
fix: getBattleSnapshotを差分更新方式にしバトル終盤のスローモーション化を解消

### DIFF
--- a/docs/features/battle-viewer-improvement.md
+++ b/docs/features/battle-viewer-improvement.md
@@ -347,3 +347,37 @@ Phase 3（ビジュアル強化）
 
 **影響ファイル:**
 - `frontend/src/components/history/BattleDetailModal.tsx`
+
+---
+
+## getBattleSnapshotの差分更新キャッシュ（Issue #465）
+
+`getBattleSnapshot()` は再生タイムスタンプが進むたびに `logs[0]` から現在時刻まで毎回全走査してユニット状態
+（位置・HP・EN・弾薬・ターゲット・クールダウン基準時刻）を再構築していた。呼び出し元（`BattleViewer/index.tsx`）
+は自機×2（現在＋1ステップ前）＋敵ユニット×2×N が100msごとに呼ばれるため、1ティックあたりの計算量が
+「ユニット数 × ログ長」に比例して増加し、バトル終盤・敵ユニットが多いほど再生がスローモーション化していた。
+また、クールダウン判定用の直近ATTACK探索も配列末尾からの逆走査で、`currentTimestamp` より未来のログも
+対象に含めてしまう不具合があった。
+
+**修正:** `getBattleSnapshot()` に任意の `SnapshotCache`（`Map<string, SnapshotCacheEntry>`）を渡せるようにし、
+「前回どこまでログを読んだか（`nextIndex`）＋その時点の状態」をキャッシュエントリとして保持する差分更新方式に
+変更した。再生が進行するだけ（`currentTimestamp` が単調増加するだけ）であれば、前回のスキャン位置から続きの
+ログのみを走査すればよく、O(全ログ長)だった1回あたりの計算量が「前回呼び出しからの経過分のログ数」に減る。
+`currentTimestamp` が巻き戻った場合（シーク操作・巻き戻しボタン等）や `logs` 参照が変わった場合（別バトルの
+表示）は自動的に先頭からの全走査にフォールバックする。クールダウン判定の直近ATTACK基準時刻もこの前方走査中に
+更新するよう変更し、逆走査を廃止すると同時に未来ログを誤って参照していた不具合も解消した。
+
+`cache` を渡さない場合は従来どおり無状態（毎回全走査）で動作するため、API 互換性は維持している。
+
+`BattleViewer/index.tsx` では `useRef` でコンポーネントインスタンスに紐づく `SnapshotCache` を1つ保持し、
+自機・各敵ユニットに渡している。「現在時刻」用と「1ステップ前（`SIMULATION_STEP_S`）」用は再生中どちらも
+時間軸上を単調に前進するが同じキーで混在させると干渉するため、`` `${id}:prev` `` のように別キーを与えて
+独立したキャッシュエントリとして扱っている。
+
+呼び出し元 `BattleViewer/index.tsx` 自体（`useMemo` を使わず毎レンダーで `getBattleSnapshot` を呼んでいる点）
+のメモ化は別Issueで対応予定。今回の修正は `getBattleSnapshot()` 内部のアルゴリズムのみを対象にしている。
+
+**影響ファイル:**
+- `frontend/src/components/BattleViewer/hooks/useBattleSnapshot.ts`
+- `frontend/src/components/BattleViewer/index.tsx`
+- `frontend/tests/unit/battleSnapshot.test.ts`

--- a/frontend/src/components/BattleViewer/hooks/useBattleSnapshot.ts
+++ b/frontend/src/components/BattleViewer/hooks/useBattleSnapshot.ts
@@ -35,91 +35,142 @@ export interface UnitSnapshot {
     targetId?: string;
 }
 
-// 現在のタイムスタンプ時点での情報を計算する関数（Hookではない）
-export function getBattleSnapshot(
-    targetId: string,
-    initialMs: MobileSuit,
-    logs: BattleLog[],
-    currentTimestamp: number
-): UnitSnapshot {
-    let pos = initialMs.position;
-    let hp = initialMs.max_hp; // 戦闘開始時は満タンと仮定
-    let en = initialMs.max_en || DEFAULT_MAX_EN;
+/**
+ * getBattleSnapshot の差分更新用キャッシュエントリ。
+ * 「前回どこまでログを読んだか（nextIndex）」と「その時点の状態」を保持し、
+ * 再生が進む（currentTimestamp が増える）限りは続きからのみ走査すればよいようにする。
+ */
+interface SnapshotCacheEntry {
+    /** このエントリがどの logs 配列に対して計算されたものか（バトルが変われば作り直す） */
+    logs: BattleLog[];
+    /** 直近に計算した currentTimestamp */
+    timestamp: number;
+    /** 次に走査すべき logs のインデックス（このインデックスより前は処理済み） */
+    nextIndex: number;
+    pos: { x: number; y: number; z: number };
+    hp: number;
+    en: number;
+    ammo: Record<string, number>;
+    heading?: number;
+    prevHeadingTs?: number;
+    unitTargetId?: string;
+    lastVelocity?: { x: number; y: number; z: number };
+    lastVelocityPos?: { x: number; y: number; z: number };
+    lastVelocityTs?: number;
+    /** 直近（currentTimestamp以下）の自ユニットのATTACK発生時刻。クールダウン判定用 */
+    lastAttackTimestamp: number;
+}
+
+/** targetId（+任意のサフィックス）ごとに SnapshotCacheEntry を保持するキャッシュ */
+export type SnapshotCache = Map<string, SnapshotCacheEntry>;
+
+function createInitialEntry(initialMs: MobileSuit, logs: BattleLog[]): SnapshotCacheEntry {
     const ammo: Record<string, number> = {};
-    const warnings: WarningType[] = [];
-    let heading: number | undefined = undefined;
-    let prevHeadingTs: number | undefined = undefined;
-    let unitTargetId: string | undefined = undefined;
-    // 物理補間用: velocity_snapshot を持つ最後のログの情報を保持
-    let lastVelocity: { x: number; y: number; z: number } | undefined = undefined;
-    let lastVelocityPos: { x: number; y: number; z: number } | undefined = undefined;
-    let lastVelocityTs: number | undefined = undefined;
-    
-    // 武器の初期弾数を設定
     initialMs.weapons.forEach(weapon => {
         if (weapon.max_ammo !== null && weapon.max_ammo !== undefined) {
             ammo[weapon.id] = weapon.max_ammo;
         }
     });
+    return {
+        logs,
+        timestamp: -Infinity,
+        nextIndex: 0,
+        pos: initialMs.position,
+        hp: initialMs.max_hp, // 戦闘開始時は満タンと仮定
+        en: initialMs.max_en || DEFAULT_MAX_EN,
+        ammo,
+        lastAttackTimestamp: 0,
+    };
+}
 
-    // 開始から現在タイムスタンプまでのログを走査して状態を再現
-    for (const log of logs) {
+// 現在のタイムスタンプ時点での情報を計算する関数（Hookではない）
+//
+// cache を渡すと「前回状態＋前回スキャン位置」を保持した差分更新になり、
+// 再生が進行するだけ（currentTimestamp が単調増加するだけ）であれば
+// 前回処理済みのログを読み直さずに続きから走査する（Issue #465）。
+// cache を渡さない場合や、currentTimestamp が巻き戻った場合（シーク操作等）は
+// 従来どおり先頭からの全走査で状態を再構築する。
+// cacheKey 省略時は targetId をキーに使う（同一ユニットで複数の基準時刻を追う場合に指定する）。
+export function getBattleSnapshot(
+    targetId: string,
+    initialMs: MobileSuit,
+    logs: BattleLog[],
+    currentTimestamp: number,
+    cache?: SnapshotCache,
+    cacheKey: string = targetId
+): UnitSnapshot {
+    const cached = cache?.get(cacheKey);
+    const canResume =
+        cached !== undefined &&
+        cached.logs === logs &&
+        currentTimestamp >= cached.timestamp - TIMESTAMP_EPSILON;
+    const entry = canResume ? cached! : createInitialEntry(initialMs, logs);
+
+    // 前回のスキャン位置（nextIndex）から続きを走査して状態を差分更新する
+    for (let i = entry.nextIndex; i < logs.length; i++) {
+        const log = logs[i];
         if (log.timestamp > currentTimestamp + TIMESTAMP_EPSILON) break;
+        entry.nextIndex = i + 1;
 
         // 位置更新
         if (log.actor_id === targetId && log.position_snapshot) {
-            pos = log.position_snapshot;
+            entry.pos = log.position_snapshot;
         }
 
         // velocity_snapshot を記録（ログ間の物理補間用）
         if (log.actor_id === targetId && log.velocity_snapshot) {
-            lastVelocity = log.velocity_snapshot;
-            lastVelocityPos = log.position_snapshot;
-            lastVelocityTs = log.timestamp;
+            entry.lastVelocity = log.velocity_snapshot;
+            entry.lastVelocityPos = log.position_snapshot;
+            entry.lastVelocityTs = log.timestamp;
         }
 
         // 向き更新（自ユニットのログに heading フィールドがあれば取得）
         if (log.actor_id === targetId && log.heading !== undefined) {
-            heading = log.heading;
-            prevHeadingTs = log.timestamp;
+            entry.heading = log.heading;
+            entry.prevHeadingTs = log.timestamp;
         }
 
         // ターゲット更新（TARGET_SELECTION ログから現在のターゲットを追跡）
         if (log.actor_id === targetId && log.action_type === "TARGET_SELECTION" && log.target_id) {
-            unitTargetId = log.target_id;
+            entry.unitTargetId = log.target_id;
         }
 
         // HP更新
         if (log.action_type === "DAMAGE" && log.actor_id === targetId && log.damage) {
-            hp -= log.damage;
+            entry.hp -= log.damage;
         }
         if ((log.action_type === "ATTACK" || log.action_type === "MELEE_COMBO") && log.target_id === targetId && log.damage) {
-            hp -= log.damage;
+            entry.hp -= log.damage;
         }
-        
-        // リソース消費: log.weapon_id から実際に使用した武器を特定する
+
+        // リソース消費・クールダウン基準時刻の更新: log.weapon_id から実際に使用した武器を特定する
         // weapon_id が無い古いログについては後方互換のため先頭武器を使用したと仮定する
         if (log.action_type === "ATTACK" && log.actor_id === targetId) {
+            entry.lastAttackTimestamp = log.timestamp;
             const weapon = log.weapon_id
                 ? initialMs.weapons.find(w => w.id === log.weapon_id) ?? initialMs.weapons[0]
                 : initialMs.weapons[0];
             if (weapon) {
                 if (weapon.en_cost) {
-                    en = Math.max(0, en - weapon.en_cost);
+                    entry.en = Math.max(0, entry.en - weapon.en_cost);
                 }
-                if (weapon.max_ammo && ammo[weapon.id] !== undefined) {
-                    ammo[weapon.id] = Math.max(0, ammo[weapon.id] - 1);
+                if (weapon.max_ammo && entry.ammo[weapon.id] !== undefined) {
+                    entry.ammo[weapon.id] = Math.max(0, entry.ammo[weapon.id] - 1);
                 }
             }
         }
     }
-    
+    entry.timestamp = currentTimestamp;
+
     // heading補間: 前後のheadingログの間を線形補間してスムーズな向き変化を実現する
-    if (heading !== undefined && prevHeadingTs !== undefined) {
-        for (const log of logs) {
-            if (log.timestamp <= currentTimestamp + TIMESTAMP_EPSILON) continue;
+    // entry.nextIndex より前は処理済み（=currentTimestamp以下）なので、未来側の探索は
+    // そこから始めればよく、毎回先頭から探し直す必要はない
+    let heading = entry.heading;
+    if (heading !== undefined && entry.prevHeadingTs !== undefined) {
+        for (let i = entry.nextIndex; i < logs.length; i++) {
+            const log = logs[i];
             if (log.actor_id === targetId && log.heading !== undefined) {
-                const t = (currentTimestamp - prevHeadingTs) / (log.timestamp - prevHeadingTs);
+                const t = (currentTimestamp - entry.prevHeadingTs) / (log.timestamp - entry.prevHeadingTs);
                 heading = lerpAngle(heading, log.heading, Math.max(0, Math.min(1, t)));
                 break;
             }
@@ -131,48 +182,53 @@ export function getBattleSnapshot(
     // （撃破後など velocity_snapshot の更新が止まった場合に、古い速度ベクトルのまま
     // 無限に外挿されて実際の位置から大きくズレるのを防ぐ。この場合 pos は上のループで
     // 設定済みの最後の position_snapshot のままになる）
-    if (lastVelocity && lastVelocityTs !== undefined && lastVelocityPos !== undefined) {
-        const dt = currentTimestamp - lastVelocityTs;
+    let pos = entry.pos;
+    if (entry.lastVelocity && entry.lastVelocityTs !== undefined && entry.lastVelocityPos !== undefined) {
+        const dt = currentTimestamp - entry.lastVelocityTs;
         if (dt > 0 && dt <= MAX_VELOCITY_EXTRAPOLATION_SECONDS) {
             pos = {
-                x: lastVelocityPos.x + lastVelocity.x * dt,
-                y: lastVelocityPos.y + lastVelocity.y * dt,
-                z: lastVelocityPos.z + lastVelocity.z * dt,
+                x: entry.lastVelocityPos.x + entry.lastVelocity.x * dt,
+                y: entry.lastVelocityPos.y + entry.lastVelocity.y * dt,
+                z: entry.lastVelocityPos.z + entry.lastVelocity.z * dt,
             };
         }
     }
 
     // 警告状態を判定
+    const warnings: WarningType[] = [];
     // EN不足: EN_WARNING_THRESHOLD以下
     const maxEn = initialMs.max_en || DEFAULT_MAX_EN;
-    if (maxEn > 0 && en / maxEn < EN_WARNING_THRESHOLD) {
+    if (maxEn > 0 && entry.en / maxEn < EN_WARNING_THRESHOLD) {
         warnings.push('energy');
     }
-    
+
     // 弾切れ: 第1武器の弾薬が0
     const firstWeapon = initialMs.weapons[0];
     if (firstWeapon && firstWeapon.max_ammo !== null && firstWeapon.max_ammo !== undefined) {
-        if (ammo[firstWeapon.id] === 0) {
+        if (entry.ammo[firstWeapon.id] === 0) {
             warnings.push('ammo');
         }
     }
-    
+
     // クールダウン判定（簡易版：最後の攻撃から一定時間以内）
     // 注: より正確な実装には武器ごとのクールダウン追跡が必要
-    let lastAttackTimestamp = 0;
-    for (let i = logs.length - 1; i >= 0; i--) {
-        if (logs[i].action_type === "ATTACK" && logs[i].actor_id === targetId) {
-            lastAttackTimestamp = logs[i].timestamp;
-            break;
-        }
-    }
     // cool_down_turn を秒換算（1ターン = 0.1s）
     const cooldownSeconds = (firstWeapon?.cool_down_turn || 0) * 0.1;
-    if (cooldownSeconds > 0 && currentTimestamp - lastAttackTimestamp < cooldownSeconds) {
+    if (cooldownSeconds > 0 && currentTimestamp - entry.lastAttackTimestamp < cooldownSeconds) {
         warnings.push('cooldown');
     }
 
-    return { pos, hp: Math.max(0, hp), en, ammo, warnings, heading, targetId: unitTargetId };
+    if (cache) cache.set(cacheKey, entry);
+
+    return {
+        pos,
+        hp: Math.max(0, entry.hp),
+        en: entry.en,
+        ammo: { ...entry.ammo },
+        warnings,
+        heading,
+        targetId: entry.unitTargetId,
+    };
 }
 
 /**

--- a/frontend/src/components/BattleViewer/hooks/useBattleSnapshot.ts
+++ b/frontend/src/components/BattleViewer/hooks/useBattleSnapshot.ts
@@ -57,7 +57,7 @@ interface SnapshotCacheEntry {
     lastVelocity?: { x: number; y: number; z: number };
     lastVelocityPos?: { x: number; y: number; z: number };
     lastVelocityTs?: number;
-    /** 直近（currentTimestamp以下）の自ユニットのATTACK発生時刻。クールダウン判定用 */
+    /** 直近（currentTimestamp以下）の自ユニットのATTACK発生時刻。クールダウン判定用（未攻撃時は -Infinity） */
     lastAttackTimestamp: number;
 }
 
@@ -79,7 +79,10 @@ function createInitialEntry(initialMs: MobileSuit, logs: BattleLog[]): SnapshotC
         hp: initialMs.max_hp, // 戦闘開始時は満タンと仮定
         en: initialMs.max_en || DEFAULT_MAX_EN,
         ammo,
-        lastAttackTimestamp: 0,
+        // 未攻撃時に 0 を使うと、戦闘開始直後（currentTimestamp が小さい）でも
+        // 「直近0秒に攻撃した」とみなされクールダウン警告が誤表示されるため、
+        // 「まだ攻撃していない」ことを表す -Infinity で初期化する
+        lastAttackTimestamp: -Infinity,
     };
 }
 

--- a/frontend/src/components/BattleViewer/index.tsx
+++ b/frontend/src/components/BattleViewer/index.tsx
@@ -40,6 +40,14 @@ export default function BattleViewer({
     // コンポーネントインスタンスを跨いで同じ Map を使い回す必要がある。
     // "現在時刻" 用と "1ステップ前" 用でキーを分け、両者が独立して単調に進行できるようにする。
     const snapshotCacheRef = useRef<SnapshotCache>(new Map());
+    // BattleDetailModal 等はコンポーネントを再マウントせずに別バトルの logs を渡す場合があるため、
+    // logs 参照が変わったらキャッシュを丸ごと作り直し、旧バトル分のエントリがMapに残り続けて
+    // メモリが増え続けるのを防ぐ
+    const lastLogsRef = useRef<BattleLog[] | null>(null);
+    if (lastLogsRef.current !== logs) {
+        snapshotCacheRef.current = new Map();
+        lastLogsRef.current = logs;
+    }
     const snapshotCache = snapshotCacheRef.current;
 
     // 状態計算（純粋関数として抽出）

--- a/frontend/src/components/BattleViewer/index.tsx
+++ b/frontend/src/components/BattleViewer/index.tsx
@@ -2,9 +2,9 @@
 
 "use client";
 
-import { useMemo, useState } from "react";
+import { useMemo, useRef, useState } from "react";
 import { BattleLog, MobileSuit, Obstacle } from "@/types/battle";
-import { getBattleSnapshot, getDetectedUnits } from "./hooks/useBattleSnapshot";
+import { getBattleSnapshot, getDetectedUnits, SnapshotCache } from "./hooks/useBattleSnapshot";
 import { useBattleEvents } from "./hooks/useBattleEvents";
 import { BattleScene } from "./scene/BattleScene";
 import { BattleOverlay } from "./ui/BattleOverlay";
@@ -35,14 +35,21 @@ export default function BattleViewer({
     // LOS 表示のトグルステート（デフォルト: OFF）
     const [showLos, setShowLos] = useState(false);
 
+    // getBattleSnapshot の差分更新キャッシュ（Issue #465）。
+    // 再生（100ms毎の再レンダー）中は前回スキャン位置から続きだけを走査するため、
+    // コンポーネントインスタンスを跨いで同じ Map を使い回す必要がある。
+    // "現在時刻" 用と "1ステップ前" 用でキーを分け、両者が独立して単調に進行できるようにする。
+    const snapshotCacheRef = useRef<SnapshotCache>(new Map());
+    const snapshotCache = snapshotCacheRef.current;
+
     // 状態計算（純粋関数として抽出）
-    const playerSnapshot = getBattleSnapshot(player.id, player, logs, currentTimestamp);
-    const playerPrevSnapshot = getBattleSnapshot(player.id, player, logs, currentTimestamp - SIMULATION_STEP_S);
+    const playerSnapshot = getBattleSnapshot(player.id, player, logs, currentTimestamp, snapshotCache);
+    const playerPrevSnapshot = getBattleSnapshot(player.id, player, logs, currentTimestamp - SIMULATION_STEP_S, snapshotCache, `${player.id}:prev`);
     const playerState = { ...playerSnapshot, prevHp: playerPrevSnapshot.hp };
 
     const enemyStates = enemies.map(enemy => {
-        const snapshot = getBattleSnapshot(enemy.id, enemy, logs, currentTimestamp);
-        const prevSnapshot = getBattleSnapshot(enemy.id, enemy, logs, currentTimestamp - SIMULATION_STEP_S);
+        const snapshot = getBattleSnapshot(enemy.id, enemy, logs, currentTimestamp, snapshotCache);
+        const prevSnapshot = getBattleSnapshot(enemy.id, enemy, logs, currentTimestamp - SIMULATION_STEP_S, snapshotCache, `${enemy.id}:prev`);
         return { enemy, state: { ...snapshot, prevHp: prevSnapshot.hp } };
     });
 

--- a/frontend/tests/unit/battleSnapshot.test.ts
+++ b/frontend/tests/unit/battleSnapshot.test.ts
@@ -106,4 +106,18 @@ describe("getBattleSnapshot: 差分更新キャッシュ（Issue #465）", () =>
         expect(current).toEqual(getBattleSnapshot("unit-1", msWithWeapon, logs, 3.5));
         expect(prev).toEqual(getBattleSnapshot("unit-1", msWithWeapon, logs, 2.5));
     });
+
+    it("まだ一度も攻撃していない戦闘開始直後はクールダウン警告を誤って出さない", () => {
+        // cool_down_turn=3（0.3秒）に対し、ATTACKログが1件も無い状態で currentTimestamp=0.1 を計算する。
+        // lastAttackTimestamp の初期値を 0 のままにすると 0.1 - 0 = 0.1 < 0.3 となり誤検知してしまう。
+        const noAttackLogs: BattleLog[] = [
+            { timestamp: 0.05, actor_id: "unit-1", action_type: "MOVE", message: "m", position_snapshot: { x: 0, y: 0, z: 0 }, velocity_snapshot: { x: 0, y: 0, z: 0 } },
+        ];
+        const cache: SnapshotCache = new Map();
+        const cached = getBattleSnapshot("unit-1", msWithWeapon, noAttackLogs, 0.1, cache);
+        const fresh = getBattleSnapshot("unit-1", msWithWeapon, noAttackLogs, 0.1);
+        expect(cached.warnings).not.toContain("cooldown");
+        expect(fresh.warnings).not.toContain("cooldown");
+        expect(cached).toEqual(fresh);
+    });
 });

--- a/frontend/tests/unit/battleSnapshot.test.ts
+++ b/frontend/tests/unit/battleSnapshot.test.ts
@@ -1,7 +1,8 @@
 import { describe, it, expect } from "vitest";
-import { getBattleSnapshot } from "@/components/BattleViewer/hooks/useBattleSnapshot";
+import { getBattleSnapshot, SnapshotCache } from "@/components/BattleViewer/hooks/useBattleSnapshot";
 import { BattleLog } from "@/types/battle";
 import { MobileSuit } from "@/types/mobileSuit";
+import { Weapon } from "@/types/weapon";
 
 /** テスト用の最小構成MS */
 const baseMs: MobileSuit = {
@@ -52,5 +53,57 @@ describe("getBattleSnapshot: velocity外挿のdt上限", () => {
         const snapshot = getBattleSnapshot("unit-1", baseMs, logs, 55.0);
         expect(snapshot.pos.x).toBe(10);
         expect(snapshot.pos.z).toBe(10);
+    });
+});
+
+describe("getBattleSnapshot: 差分更新キャッシュ（Issue #465）", () => {
+    const weapon: Weapon = {
+        id: "w1",
+        name: "Test Weapon",
+        power: 10,
+        range: 100,
+        accuracy: 80,
+        max_ammo: 5,
+        en_cost: 10,
+        cool_down_turn: 3,
+    };
+    const msWithWeapon: MobileSuit = { ...baseMs, weapons: [weapon], max_en: 100 };
+
+    /** 位置・HP・EN・弾薬・向き・ターゲットが変化する一連のログ */
+    const logs: BattleLog[] = [
+        { timestamp: 1.0, actor_id: "unit-1", action_type: "MOVE", message: "m", position_snapshot: { x: 1, y: 0, z: 0 }, velocity_snapshot: { x: 1, y: 0, z: 0 }, heading: 10 },
+        { timestamp: 2.0, actor_id: "unit-1", action_type: "TARGET_SELECTION", message: "t", position_snapshot: { x: 1, y: 0, z: 0 }, target_id: "enemy-1" },
+        { timestamp: 3.0, actor_id: "unit-1", action_type: "ATTACK", message: "a", position_snapshot: { x: 1, y: 0, z: 0 }, target_id: "enemy-1", weapon_id: "w1" },
+        { timestamp: 4.0, actor_id: "enemy-1", action_type: "ATTACK", message: "a2", position_snapshot: { x: 0, y: 0, z: 0 }, target_id: "unit-1", damage: 50 },
+        { timestamp: 5.0, actor_id: "unit-1", action_type: "MOVE", message: "m2", position_snapshot: { x: 5, y: 0, z: 0 }, velocity_snapshot: { x: 0, y: 0, z: 0 }, heading: 90 },
+        { timestamp: 6.0, actor_id: "unit-1", action_type: "ATTACK", message: "a3", position_snapshot: { x: 5, y: 0, z: 0 }, target_id: "enemy-1", weapon_id: "w1" },
+    ];
+
+    it("キャッシュを使って時系列順に進めた結果は、毎回全走査した結果と一致する", () => {
+        const cache: SnapshotCache = new Map();
+        const timestamps = [0.5, 1.5, 2.5, 3.5, 4.5, 5.5, 6.5];
+        for (const ts of timestamps) {
+            const cached = getBattleSnapshot("unit-1", msWithWeapon, logs, ts, cache);
+            const fresh = getBattleSnapshot("unit-1", msWithWeapon, logs, ts);
+            expect(cached).toEqual(fresh);
+        }
+    });
+
+    it("シーク（巻き戻し）が発生してもキャッシュなしの結果と一致する", () => {
+        const cache: SnapshotCache = new Map();
+        const timestamps = [6.5, 5.5, 1.0, 4.5, 0.0, 6.5];
+        for (const ts of timestamps) {
+            const cached = getBattleSnapshot("unit-1", msWithWeapon, logs, ts, cache);
+            const fresh = getBattleSnapshot("unit-1", msWithWeapon, logs, ts);
+            expect(cached).toEqual(fresh);
+        }
+    });
+
+    it("キーが異なれば同一ユニットでも独立したキャッシュとして扱われる（currentTimestamp / prevTimestamp の並走に対応）", () => {
+        const cache: SnapshotCache = new Map();
+        const current = getBattleSnapshot("unit-1", msWithWeapon, logs, 3.5, cache, "unit-1");
+        const prev = getBattleSnapshot("unit-1", msWithWeapon, logs, 2.5, cache, "unit-1:prev");
+        expect(current).toEqual(getBattleSnapshot("unit-1", msWithWeapon, logs, 3.5));
+        expect(prev).toEqual(getBattleSnapshot("unit-1", msWithWeapon, logs, 2.5));
     });
 });


### PR DESCRIPTION
## Summary
- `getBattleSnapshot()` が毎ティック `logs[0]` から全走査してユニット状態を再構築していたため、バトルが進行するほど・敵ユニットが多いほど1ティックあたりの計算量（ユニット数×ログ長）が増加し、再生がスローモーション化していた問題を修正
- 「前回どこまでログを読んだか（`nextIndex`）＋前回状態」を保持する `SnapshotCache` を任意で渡せるようにし、再生が単調に進む間は続きのログのみを走査する差分更新方式に変更（シークで巻き戻った場合は自動的に全走査へフォールバック）
- ついでにクールダウン判定用の直近ATTACK探索（配列末尾からの逆走査、`currentTimestamp` より未来のログも拾ってしまうバグあり）を、前方走査中に基準時刻を更新する方式に置き換えて解消
- `cache` を渡さない場合は従来どおり無状態（毎回全走査）で動作するため、既存の呼び出し・テストとのAPI互換性を維持
- `BattleViewer/index.tsx` は `useRef` でコンポーネントインスタンスに紐づくキャッシュを1つ保持し、自機・各敵ユニット、「現在時刻」「1ステップ前」それぞれ独立したキーで利用する

呼び出し元 `BattleViewer/index.tsx` 自体の `useMemo` 化（Issueで別対応予定とされている部分）は本PRのスコープ外。

Closes #465

## Test plan
- [x] `cd frontend && ./node_modules/.bin/tsc --noEmit`
- [x] `cd frontend && npx vitest run tests/unit/battleSnapshot.test.ts`（キャッシュあり/なし・シーク・キー分離の一致性を検証する新規テストを追加）
- [x] `cd frontend && npx vitest run tests/unit/`（既存スイート全体、224件パス）

🤖 Generated with [Claude Code](https://claude.com/claude-code)