### PR TITLE
fix: BattleViewer再生パフォーマンスの追加改善（rAF化・重複ログフィルタ解消）

### DIFF
--- a/docs/features/battle-viewer-improvement.md
+++ b/docs/features/battle-viewer-improvement.md
@@ -399,3 +399,47 @@ Phase 3（ビジュアル強化）
 
 **影響ファイル:**
 - `frontend/src/components/BattleViewer/index.tsx`
+
+---
+
+## 再生クロックのrAF化・重複ログフィルタの解消（Issue #467）
+
+Issue #465/#466 対応後も残っていた、優先度の低い追加の非効率箇所3件に対応。
+
+### 1. TurnController — 再生クロックをrequestAnimationFrameベースに変更
+
+`TurnController.tsx` の再生クロックは `setInterval(..., 100)` で固定100msごとにシム時間を+0.1s進める実装
+だった。`setInterval` はタイマー精度の遅延を自動補正しないため、負荷が高い環境ではコールバックの発火間隔が
+100msより伸び、再生が実時間から遅れて乖離し続ける可能性があった。
+
+**修正:** `requestAnimationFrame` + フレーム間の経過時間を積算する方式に変更した。前フレームからの経過秒数
+を `elapsedSinceLastStep` に積算し、0.1s分溜まるごとに（複数ステップ分たまっていればまとめて）シム時間を
+進める。1フレームが遅延しても、次フレームで経過時間を正しく積算し直すため、遅延分を自動的に取り戻せる。
+
+### 2. HpBar — 同種の全ログフィルタの重複実行を解消
+
+`HpBar.tsx` はダメージフラッシュ判定のために `logs.filter(log => Math.abs(log.timestamp - currentTimestamp) < 1e-9)`
+をユニットごと（自機+敵の数だけ）に重複実行していた。`useBattleEvents.ts` 側でも同種のタイムスタンプフィルタを
+既に計算済みだったため、二重計算になっていた。
+
+**修正:** `BattleViewer/index.tsx` で現在タイムスタンプ分のログフィルタ（`timestampLogs`）を `useMemo` で
+一度だけ計算し、`useBattleEvents`（フィルタ済み配列を受け取る形に変更）と `BattleOverlay`→`HpBar` の両方に
+共有して渡すよう統一した。`HpBar` の `logs` propは `timestampLogs`（フィルタ済み配列）に置き換え、コンポーネント
+内部でのフィルタ処理を削除した。
+
+### 3. BattleLogViewer — 全ログフィルタをuseMemo化
+
+`BattleLogViewer.tsx` は `filterRelevantLogs(logs)`（`useBattleLogic.ts` で `useCallback` 化済み）の呼び出し
+結果を `useMemo` していなかったため、`currentTimestamp` が変わるたび（再生中は100msごと）にログ全体を毎回
+`filter` し直していた。`filterRelevantLogs` 自体は `currentTimestamp` に依存しないため、本来は再計算不要だった。
+
+**修正:** `displayedLogs = filterRelevantLogs(logs)` を `useMemo(() => filterRelevantLogs(logs), [filterRelevantLogs, logs])`
+でラップした。
+
+**影響ファイル:**
+- `frontend/src/components/history/TurnController.tsx`
+- `frontend/src/components/history/BattleLogViewer.tsx`
+- `frontend/src/components/BattleViewer/ui/HpBar.tsx`
+- `frontend/src/components/BattleViewer/ui/BattleOverlay.tsx`
+- `frontend/src/components/BattleViewer/hooks/useBattleEvents.ts`
+- `frontend/src/components/BattleViewer/index.tsx`

--- a/frontend/src/components/BattleViewer/hooks/useBattleEvents.ts
+++ b/frontend/src/components/BattleViewer/hooks/useBattleEvents.ts
@@ -13,12 +13,14 @@ export interface BattleEventsResult {
     attackingUnitIds: Set<string>;
 }
 
+/**
+ * @param timestampLogs 現在タイムスタンプ分にフィルタ済みのログ（呼び出し元で計算し、他コンポーネントと共有する。Issue #467）
+ */
 export function useBattleEvents(
-    logs: BattleLog[],
-    currentTimestamp: number
+    timestampLogs: BattleLog[]
 ): BattleEventsResult {
     return useMemo(() => {
-        const currentTimestampLogs = logs.filter(log => Math.abs(log.timestamp - currentTimestamp) < 1e-9);
+        const currentTimestampLogs = timestampLogs;
         const battleEventMap = new Map<string, BattleEventEffect | null>();
 
         // Pass 1: ユニットの位置マップを構築（攻撃ライン描画のターゲット座標取得用）
@@ -159,5 +161,5 @@ export function useBattleEvents(
         }
 
         return { events: battleEventMap, attackingUnitIds };
-    }, [logs, currentTimestamp]);
+    }, [timestampLogs]);
 }

--- a/frontend/src/components/BattleViewer/index.tsx
+++ b/frontend/src/components/BattleViewer/index.tsx
@@ -74,8 +74,15 @@ export default function BattleViewer({
         [enemyStates, detectedIds]
     );
     
+    // 現在タイムスタンプ分のログ。useBattleEvents と BattleOverlay(HpBar) の両方が同じ
+    // フィルタ結果を必要とするため、ここで一度だけ計算して共有する（Issue #467）
+    const timestampLogs = useMemo(
+        () => logs.filter(log => Math.abs(log.timestamp - currentTimestamp) < 1e-9),
+        [logs, currentTimestamp]
+    );
+
     // バトルイベントの取得（攻撃中ユニット ID セットを含む）(Issue #365)
-    const { events: battleEventMap, attackingUnitIds } = useBattleEvents(logs, currentTimestamp);
+    const { events: battleEventMap, attackingUnitIds } = useBattleEvents(timestampLogs);
 
     const playerEvent = battleEventMap.get(player.id) || null;
     const enemyEvents = enemies.map(enemy => ({
@@ -127,7 +134,7 @@ export default function BattleViewer({
                 enemyStates={visibleEnemyStates}
                 environment={environment}
                 currentTimestamp={currentTimestamp}
-                logs={logs}
+                timestampLogs={timestampLogs}
                 showLos={showLos}
                 onToggleLos={() => setShowLos(v => !v)}
             />

--- a/frontend/src/components/BattleViewer/ui/BattleOverlay.tsx
+++ b/frontend/src/components/BattleViewer/ui/BattleOverlay.tsx
@@ -20,7 +20,8 @@ interface BattleOverlayProps {
     enemyStates: Array<{ enemy: MobileSuit; state: UnitState }>;
     environment: string;
     currentTimestamp: number;
-    logs: BattleLog[];
+    /** 現在タイムスタンプ分にフィルタ済みのログ（呼び出し元で計算済み。Issue #467） */
+    timestampLogs: BattleLog[];
     /** LOS 表示の現在の状態 */
     showLos: boolean;
     /** LOS 表示トグルのコールバック */
@@ -33,7 +34,7 @@ export function BattleOverlay({
     enemyStates,
     environment,
     currentTimestamp,
-    logs,
+    timestampLogs,
     showLos,
     onToggleLos,
 }: BattleOverlayProps) {
@@ -52,7 +53,7 @@ export function BattleOverlay({
                         colorFunc={getHpBarColor}
                         currentTimestamp={currentTimestamp}
                         unitId={player.id}
-                        logs={logs}
+                        timestampLogs={timestampLogs}
                     />
                     
                     {/* EN Display */}
@@ -89,7 +90,7 @@ export function BattleOverlay({
                             colorFunc={getEnemyHpBarColor}
                             currentTimestamp={currentTimestamp}
                             unitId={enemy.id}
-                            logs={logs}
+                            timestampLogs={timestampLogs}
                         />
                     </div>
                 ))}

--- a/frontend/src/components/BattleViewer/ui/HpBar.tsx
+++ b/frontend/src/components/BattleViewer/ui/HpBar.tsx
@@ -6,43 +6,43 @@ import { useState, useEffect, useRef } from "react";
 import { BattleLog } from "@/types/battle";
 
 // HPバーコンポーネント（ダメージフラッシュ効果付き）
-export function HpBar({ 
-    current, 
-    max, 
-    colorFunc, 
+export function HpBar({
+    current,
+    max,
+    colorFunc,
     currentTimestamp,
     unitId,
-    logs
-}: { 
-    current: number; 
-    max: number; 
+    timestampLogs
+}: {
+    current: number;
+    max: number;
     colorFunc: (ratio: number) => string;
     currentTimestamp: number;
     unitId: string;
-    logs: BattleLog[];
+    /** 現在タイムスタンプ分のログ（呼び出し元で事前フィルタ済み。Issue #467） */
+    timestampLogs: BattleLog[];
 }) {
     const [flash, setFlash] = useState(false);
     const prevTimestampRef = useRef(currentTimestamp);
-    
+
     useEffect(() => {
         // タイムスタンプが変わったときにダメージを受けたかチェック
         if (currentTimestamp !== prevTimestampRef.current) {
-            const timestampLogs = logs.filter(log => Math.abs(log.timestamp - currentTimestamp) < 1e-9);
-            const tookDamage = timestampLogs.some(log => 
+            const tookDamage = timestampLogs.some(log =>
                 (log.action_type === "ATTACK" && log.target_id === unitId && log.damage && log.damage > 0) ||
                 (log.action_type === "DAMAGE" && log.actor_id === unitId && log.damage && log.damage > 0)
             );
-            
+
             if (tookDamage) {
                 // Note: This is intentional for triggering damage flash animation
                 // eslint-disable-next-line react-hooks/set-state-in-effect
                 setFlash(true);
                 setTimeout(() => setFlash(false), 300);
             }
-            
+
             prevTimestampRef.current = currentTimestamp;
         }
-    }, [currentTimestamp, unitId, logs]);
+    }, [currentTimestamp, unitId, timestampLogs]);
     
     const ratio = current / max;
     const bgColor = colorFunc(ratio);

--- a/frontend/src/components/history/BattleLogViewer.tsx
+++ b/frontend/src/components/history/BattleLogViewer.tsx
@@ -1,7 +1,7 @@
 /* frontend/src/components/history/BattleLogViewer.tsx */
 "use client";
 
-import { useEffect, useRef } from "react";
+import { useEffect, useMemo, useRef } from "react";
 import { BattleLog } from "@/types/battle";
 import { formatBattleLog } from "@/utils/logFormatter";
 import { IS_PRODUCTION } from "@/constants";
@@ -44,7 +44,9 @@ export default function BattleLogViewer({
     }
   }, [currentTimestamp]);
 
-  const displayedLogs = filterRelevantLogs(logs);
+  // filterRelevantLogs 自体は useCallback 化されているが、呼び出し側でメモ化しないと
+  // currentTimestamp が変わるたび（=再生中は100msごと）にログ全体を毎回フィルタし直してしまう（Issue #467）
+  const displayedLogs = useMemo(() => filterRelevantLogs(logs), [filterRelevantLogs, logs]);
   const seenTimestamps = new Set<number>();
 
   return (

--- a/frontend/src/components/history/TurnController.tsx
+++ b/frontend/src/components/history/TurnController.tsx
@@ -44,10 +44,11 @@ export default function TurnController({ currentTimestamp, maxTimestamp, onTimes
       elapsedSinceLastStep += (frameTime - lastFrameTime) / 1000;
       lastFrameTime = frameTime;
 
-      // 100msごとの再生ステップに相当する経過時間が溜まったら、その分だけまとめて進める
-      if (elapsedSinceLastStep >= 0.1) {
-        const stepsToAdvance = Math.floor(elapsedSinceLastStep / 0.1);
-        elapsedSinceLastStep -= stepsToAdvance * 0.1;
+      // stepごとの再生ステップに相当する経過時間が溜まったら、その分だけまとめて進める
+      // （閾値を step 自体から算出することで、step を変更した場合も再生クロックと整合する）
+      if (elapsedSinceLastStep >= step) {
+        const stepsToAdvance = Math.floor(elapsedSinceLastStep / step);
+        elapsedSinceLastStep -= stepsToAdvance * step;
 
         const next = Math.round((currentTimestampRef.current + step * stepsToAdvance) * 10) / 10;
         if (next >= maxTimestamp) {

--- a/frontend/src/components/history/TurnController.tsx
+++ b/frontend/src/components/history/TurnController.tsx
@@ -26,17 +26,44 @@ export default function TurnController({ currentTimestamp, maxTimestamp, onTimes
   useEffect(() => {
     if (!isPlaying) return;
 
-    const interval = setInterval(() => {
-      const next = Math.round((currentTimestampRef.current + step) * 10) / 10;
-      if (next >= maxTimestamp) {
-        onTimestampChangeRef.current(maxTimestamp);
-        setIsPlaying(false);
-      } else {
+    // requestAnimationFrame + 経過時間ベースで駆動する。setInterval(固定100ms)は
+    // 処理落ちがあっても遅延を自動補正しないため、負荷が高い環境では再生が実時間から
+    // 乖離し続けていた（Issue #467）。rAFのタイムスタンプ差分から経過秒数を積算することで、
+    // 1フレームが遅れても次フレームでまとめて追いつける。
+    let rafId: number;
+    let lastFrameTime: number | null = null;
+    let elapsedSinceLastStep = 0;
+
+    const tick = (frameTime: number) => {
+      if (lastFrameTime === null) {
+        lastFrameTime = frameTime;
+        rafId = requestAnimationFrame(tick);
+        return;
+      }
+
+      elapsedSinceLastStep += (frameTime - lastFrameTime) / 1000;
+      lastFrameTime = frameTime;
+
+      // 100msごとの再生ステップに相当する経過時間が溜まったら、その分だけまとめて進める
+      if (elapsedSinceLastStep >= 0.1) {
+        const stepsToAdvance = Math.floor(elapsedSinceLastStep / 0.1);
+        elapsedSinceLastStep -= stepsToAdvance * 0.1;
+
+        const next = Math.round((currentTimestampRef.current + step * stepsToAdvance) * 10) / 10;
+        if (next >= maxTimestamp) {
+          onTimestampChangeRef.current(maxTimestamp);
+          setIsPlaying(false);
+          return;
+        }
         onTimestampChangeRef.current(next);
       }
-    }, 100);
 
-    return () => clearInterval(interval);
+      rafId = requestAnimationFrame(tick);
+    };
+
+    rafId = requestAnimationFrame(tick);
+
+    return () => cancelAnimationFrame(rafId);
   }, [isPlaying, maxTimestamp]);
 
   const handlePlayPause = () => {


### PR DESCRIPTION
## Summary
Issue #467（#465/#466対応後のバックログ）で挙げられた3件の追加非効率箇所に対応。

- **TurnController**: 再生クロックを`setInterval`固定100ms駆動から`requestAnimationFrame`+経過時間積算ベースに変更。タイマー精度の遅延を自動補正しないという`setInterval`の弱点を解消し、負荷が高い環境でも再生の実時間からの乖離が起きにくくなった
- **HpBar**: ユニットごとに重複実行していた全ログのタイムスタンプフィルタを、`BattleViewer/index.tsx`側で一度だけ計算した`timestampLogs`を`useBattleEvents`と共有する形に統一
- **BattleLogViewer**: 未メモ化だった`filterRelevantLogs(logs)`の呼び出しを`useMemo`でラップし、`currentTimestamp`変更のたびに（=再生中100msごとに）ログ全体を再フィルタしていた無駄を解消

Closes #467

## Test plan
- [x] `cd frontend && ./node_modules/.bin/tsc --noEmit` が成功すること
- [x] `npx eslint` 該当ファイルでエラーが出ないこと
- [x] `cd frontend && npx vitest run tests/unit/` が全件パスすること（225 tests）
- [x] `docs/features/battle-viewer-improvement.md` にIssue #467対応内容を追記

🤖 Generated with [Claude Code](https://claude.com/claude-code)