### PR TITLE
fix: Battle Historyの撃破数を自機の撃破数に修正

### DIFF
--- a/backend/app/engine/battle_digest.py
+++ b/backend/app/engine/battle_digest.py
@@ -8,6 +8,7 @@ LLM等の外部呼び出しは行わない。
 """
 
 import random
+import uuid
 from dataclasses import dataclass
 
 from app.models.models import BattleLog, MobileSuit
@@ -53,6 +54,29 @@ def _damage_severity(player_survived: bool, min_hp_percent: int) -> str:
     if min_hp_percent >= 30:
         return "中破"
     return "大破"
+
+
+def compute_unit_kills(logs: list[BattleLog], unit_id: uuid.UUID) -> int:
+    """指定ユニットが自ら撃破した数をログから集計する.
+
+    `DESTROYED` ログの `actor_id` は被撃破ユニット自身であり撃破者の情報を
+    持たない。`_process_destruction`（combat.py）は撃破に至った
+    `ATTACK`/`MELEE_COMBO` ログを追加した直後に呼ばれるため、`DESTROYED` ログの
+    直前のログが同じ対象への `ATTACK`/`MELEE_COMBO` であれば、その `actor_id` が
+    撃破者とみなせる。
+    """
+    kills = 0
+    for i, log in enumerate(logs):
+        if log.action_type != "DESTROYED" or i == 0:
+            continue
+        prev = logs[i - 1]
+        if (
+            prev.action_type in ("ATTACK", "MELEE_COMBO")
+            and prev.target_id == log.actor_id
+            and prev.actor_id == unit_id
+        ):
+            kills += 1
+    return kills
 
 
 def compute_digest_stats(

--- a/backend/main.py
+++ b/backend/main.py
@@ -14,6 +14,7 @@ from sqlmodel import Session, desc, select
 # DB関連
 from app.core.auth import get_current_user, get_current_user_optional
 from app.db import get_session
+from app.engine.battle_digest import compute_unit_kills
 from app.engine.battle_utils import serialize_obstacles, strip_debug_fields
 from app.engine.simulation import BattleSimulator
 from app.models.models import (
@@ -272,7 +273,7 @@ async def simulate_battle(
     # 6. 勝者判定と撃墜数カウント
     winner_id = None
     win_loss = "DRAW"
-    kills = sum(1 for e in enemies if e.current_hp <= 0)
+    kills = compute_unit_kills(sim.logs, player.id)
 
     if player.current_hp > 0 and all(e.current_hp <= 0 for e in enemies):
         # プレイヤー勝利

--- a/backend/scripts/run_batch.py
+++ b/backend/scripts/run_batch.py
@@ -19,6 +19,7 @@ sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 from sqlmodel import Session, select
 
 from app.db import engine
+from app.engine.battle_digest import compute_unit_kills
 from app.engine.battle_utils import serialize_obstacles, strip_debug_fields
 from app.engine.simulation import BattleSimulator
 from app.models.models import (
@@ -193,7 +194,7 @@ def _run_simulation(
         enemy_units: 敵ユニットリスト
 
     Returns:
-        (シミュレーター, 勝利フラグ, 撃墜数, 消費ステップ数)
+        (シミュレーター, 勝利フラグ, プレイヤー自身の撃墜数, 消費ステップ数)
     """
     simulator = BattleSimulator(player_unit, enemy_units, battlefield=BattleField())
 
@@ -209,7 +210,7 @@ def _run_simulation(
     # 勝敗判定 (team_idベース: プレイヤーのteam_idが生存していれば勝利)
     alive_team_ids = {u.team_id for u in simulator.units if u.current_hp > 0}
     primary_player_win = player_unit.team_id in alive_team_ids
-    kills = sum(1 for e in enemy_units if e.current_hp <= 0)
+    kills = compute_unit_kills(simulator.logs, player_unit.id)
 
     return simulator, primary_player_win, kills, steps_used
 
@@ -221,7 +222,6 @@ def _save_battle_results(
     npc_entries: list[BattleEntry],
     simulator: BattleSimulator,
     primary_player_win: bool,
-    kills: int,
     player_unit: MobileSuit,
     enemy_units: list[MobileSuit],
     steps_used: int = 0,
@@ -235,7 +235,6 @@ def _save_battle_results(
         npc_entries: NPCエントリーリスト
         simulator: シミュレーター
         primary_player_win: 勝利フラグ
-        kills: 撃墜数
         player_unit: プレイヤーユニット（スナップショット保存用。実バトルでは
             シミュレーションによって current_hp 等が最終状態まで更新済み）
         enemy_units: 敵ユニットリスト（スナップショット保存用。同上）
@@ -264,7 +263,8 @@ def _save_battle_results(
         entry_unit = _convert_snapshot_to_mobile_suit(entry.mobile_suit_snapshot)
         entry_team_id = _resolve_team_id(entry_unit)
         individual_win_loss = "WIN" if entry_team_id in alive_team_ids else "LOSE"
-        individual_kills = kills if individual_win_loss == "WIN" else 0
+        entry_kills = compute_unit_kills(simulator.logs, entry_unit.id)
+        individual_kills = entry_kills if individual_win_loss == "WIN" else 0
 
         # 報酬の計算と付与（BattleResult作成前にlevel_beforeを確定）
         exp_gained = 0
@@ -425,7 +425,6 @@ def _process_room(session: Session, room: BattleRoom) -> None:
         npc_entries,
         simulator,
         primary_player_win,
-        kills,
         player_unit,
         enemy_units,
         steps_used,

--- a/backend/scripts/run_batch.py
+++ b/backend/scripts/run_batch.py
@@ -263,8 +263,11 @@ def _save_battle_results(
         entry_unit = _convert_snapshot_to_mobile_suit(entry.mobile_suit_snapshot)
         entry_team_id = _resolve_team_id(entry_unit)
         individual_win_loss = "WIN" if entry_team_id in alive_team_ids else "LOSE"
-        entry_kills = compute_unit_kills(simulator.logs, entry_unit.id)
-        individual_kills = entry_kills if individual_win_loss == "WIN" else 0
+        # 勝敗に関わらず自機の撃破数をそのまま使う（main.py のソロミッション経路と
+        # 揃える）。敗北時に0へ丸めると、LOSE時のダイジェストタグ判定
+        # （kills>=1 なら「力戦及ばず」）が常に「完敗」にしかならず、報酬の
+        # 撃墜ボーナスも失われてしまう（Copilotレビュー指摘、PR #472）。
+        individual_kills = compute_unit_kills(simulator.logs, entry_unit.id)
 
         # 報酬の計算と付与（BattleResult作成前にlevel_beforeを確定）
         exp_gained = 0

--- a/backend/tests/unit/test_run_batch.py
+++ b/backend/tests/unit/test_run_batch.py
@@ -174,7 +174,7 @@ def test_save_battle_results_sets_detail_fields(in_memory_session):
 
 
 def test_save_battle_results_lose(in_memory_session):
-    """敗北時は kills=0、報酬が少ないこと."""
+    """敗北時は撃破ログが無ければ kills=0、報酬が少ないこと."""
     from sqlmodel import select
 
     from scripts.run_batch import _convert_snapshot_to_mobile_suit, _save_battle_results
@@ -225,6 +225,85 @@ def test_save_battle_results_lose(in_memory_session):
     assert result.kills == 0
     assert result.is_read is False
     assert result.ms_snapshot["name"] == "Loser Zaku"
+
+
+def test_save_battle_results_lose_with_kills_are_preserved(in_memory_session):
+    """敗北しても自機が撃破した数はkillsに残ること（撃墜ボーナス・ダイジェスト用）.
+
+    以前は LOSE 時に個別撃破数を一律0へ丸めていたため、報酬の撃墜ボーナスが
+    失われるだけでなく、LOSE時のダイジェストタグ判定（kills>=1で「力戦及ばず」、
+    kills==0で「完敗」）が常に「完敗」にしかならない不具合があった（PR #472
+    Copilotレビュー指摘）。
+    """
+    from sqlmodel import select
+
+    from scripts.run_batch import _convert_snapshot_to_mobile_suit, _save_battle_results
+
+    session = in_memory_session
+    room = _make_room(session)
+
+    snapshot = _make_snapshot("Doomed Zaku")
+    snapshot["team_id"] = str(uuid4())  # 生存チームに含まれないID
+
+    entry = _make_entry(session, room, "user_doomed", snapshot)
+
+    player_unit = _convert_snapshot_to_mobile_suit(dict(snapshot))
+    player_unit.side = "PLAYER"
+    player_unit.team_id = snapshot["team_id"]
+    player_unit.current_hp = 0  # 敗北（撃破された）
+
+    # 生存ユニットに entry のチームIDを含めない（敗北）が、道連れに1機撃破している
+    other_unit = MobileSuit(
+        name="Other",
+        max_hp=1000,
+        current_hp=500,
+        armor=50,
+        mobility=1.0,
+        position=Vector3(x=0, y=0, z=0),
+        weapons=[Weapon(id="w2", name="Rifle", power=50, range=300, accuracy=70)],
+    )
+    other_unit.team_id = str(uuid4())
+
+    destroyed_enemy_id = uuid4()
+    logs = [
+        BattleLog(
+            timestamp=0.0,
+            actor_id=player_unit.id,
+            action_type="ATTACK",
+            target_id=destroyed_enemy_id,
+            message="attack",
+            position_snapshot=Vector3(x=0, y=0, z=0),
+        ),
+        BattleLog(
+            timestamp=0.1,
+            actor_id=destroyed_enemy_id,
+            action_type="DESTROYED",
+            message="destroyed",
+            position_snapshot=Vector3(x=0, y=0, z=0),
+        ),
+    ]
+    simulator = _make_simulator_mock([other_unit], logs=logs)
+
+    _save_battle_results(
+        session=session,
+        room=room,
+        player_entries=[entry],
+        npc_entries=[],
+        simulator=simulator,
+        primary_player_win=False,
+        player_unit=player_unit,
+        enemy_units=[other_unit],
+    )
+
+    results = list(
+        session.exec(select(BattleResult).where(BattleResult.room_id == room.id)).all()
+    )
+    assert len(results) == 1
+    result = results[0]
+
+    assert result.win_loss == "LOSE"
+    assert result.kills == 1
+    assert result.digest_tag == "力戦及ばず"
 
 
 def test_save_battle_results_snapshot_immutability(in_memory_session):

--- a/backend/tests/unit/test_run_batch.py
+++ b/backend/tests/unit/test_run_batch.py
@@ -9,6 +9,7 @@ from sqlmodel import Session, SQLModel, create_engine
 from app.db import json_serializer
 from app.models.models import (
     BattleEntry,
+    BattleLog,
     BattleResult,
     BattleRoom,
     MobileSuit,
@@ -113,11 +114,32 @@ def test_save_battle_results_sets_detail_fields(in_memory_session):
     alive_unit.current_hp = 500
     alive_unit.team_id = snapshot["team_id"]
 
-    simulator = _make_simulator_mock([alive_unit])
-
     player_unit = _convert_snapshot_to_mobile_suit(dict(snapshot))
     player_unit.side = "PLAYER"
     player_unit.team_id = snapshot["team_id"]
+
+    # player_unit が撃破した敵1機ぶんのログ（ATTACK直後にDESTROYEDが続く場合、
+    # DESTROYEDログのactor_idは被撃破ユニット自身のため、直前のATTACKログの
+    # actor_idが撃破者とみなされる）
+    destroyed_enemy_id = uuid4()
+    logs = [
+        BattleLog(
+            timestamp=0.0,
+            actor_id=player_unit.id,
+            action_type="ATTACK",
+            target_id=destroyed_enemy_id,
+            message="attack",
+            position_snapshot=Vector3(x=0, y=0, z=0),
+        ),
+        BattleLog(
+            timestamp=0.0,
+            actor_id=destroyed_enemy_id,
+            action_type="DESTROYED",
+            message="destroyed",
+            position_snapshot=Vector3(x=0, y=0, z=0),
+        ),
+    ]
+    simulator = _make_simulator_mock([alive_unit], logs=logs)
 
     _save_battle_results(
         session=session,
@@ -126,7 +148,6 @@ def test_save_battle_results_sets_detail_fields(in_memory_session):
         npc_entries=[],
         simulator=simulator,
         primary_player_win=True,
-        kills=1,
         player_unit=player_unit,
         enemy_units=[],
     )
@@ -190,7 +211,6 @@ def test_save_battle_results_lose(in_memory_session):
         npc_entries=[],
         simulator=simulator,
         primary_player_win=False,
-        kills=0,
         player_unit=player_unit,
         enemy_units=[other_unit],
     )
@@ -237,7 +257,6 @@ def test_save_battle_results_snapshot_immutability(in_memory_session):
         npc_entries=[],
         simulator=simulator,
         primary_player_win=True,
-        kills=0,
         player_unit=player_unit,
         enemy_units=[],
     )
@@ -292,7 +311,6 @@ def test_save_battle_results_sets_digest_fields(in_memory_session):
         npc_entries=[],
         simulator=simulator,
         primary_player_win=True,
-        kills=1,
         player_unit=player_unit,
         enemy_units=[],
         steps_used=5,
@@ -311,3 +329,95 @@ def test_save_battle_results_sets_digest_fields(in_memory_session):
     assert result.min_hp_percent == 10
     assert result.player_survived is True
     assert result.pilot_ms_name == "Digest Gundam"
+
+
+def test_save_battle_results_kills_are_per_unit_not_team_wide(in_memory_session):
+    """勝利チームの各プレイヤーには自分が撃破した数だけが記録されること.
+
+    以前は _run_simulation が敵陣営全体の撃破数を1つだけ計算し、勝利した
+    プレイヤー全員に同じ値がコピーされていた（フィールド全体の撃破数）。
+    この回帰テストは、同じ勝利チームの2人のプレイヤーがそれぞれ異なる数の
+    敵を撃破した場合に、各自の BattleResult.kills が自分の撃破数のみを
+    反映することを確認する。
+    """
+    from sqlmodel import select
+
+    from scripts.run_batch import _convert_snapshot_to_mobile_suit, _save_battle_results
+
+    session = in_memory_session
+    room = _make_room(session)
+
+    team_id = str(uuid4())
+
+    snapshot_a = _make_snapshot("Ace Gundam")
+    snapshot_a["team_id"] = team_id
+    entry_a = _make_entry(session, room, "user_ace", snapshot_a)
+
+    snapshot_b = _make_snapshot("Support Gundam")
+    snapshot_b["team_id"] = team_id
+    entry_b = _make_entry(session, room, "user_support", snapshot_b)
+
+    player_unit_a = _convert_snapshot_to_mobile_suit(dict(snapshot_a))
+    player_unit_a.side = "PLAYER"
+    player_unit_a.team_id = team_id
+
+    player_unit_b = _convert_snapshot_to_mobile_suit(dict(snapshot_b))
+    player_unit_b.side = "PLAYER"
+    player_unit_b.team_id = team_id
+
+    # A が2機、B が0機撃破。両者とも勝利チームに属する。
+    enemy_id_1 = uuid4()
+    enemy_id_2 = uuid4()
+    logs = [
+        BattleLog(
+            timestamp=0.0,
+            actor_id=player_unit_a.id,
+            action_type="ATTACK",
+            target_id=enemy_id_1,
+            message="attack1",
+            position_snapshot=Vector3(x=0, y=0, z=0),
+        ),
+        BattleLog(
+            timestamp=0.1,
+            actor_id=enemy_id_1,
+            action_type="DESTROYED",
+            message="destroyed1",
+            position_snapshot=Vector3(x=0, y=0, z=0),
+        ),
+        BattleLog(
+            timestamp=0.2,
+            actor_id=player_unit_a.id,
+            action_type="ATTACK",
+            target_id=enemy_id_2,
+            message="attack2",
+            position_snapshot=Vector3(x=0, y=0, z=0),
+        ),
+        BattleLog(
+            timestamp=0.3,
+            actor_id=enemy_id_2,
+            action_type="DESTROYED",
+            message="destroyed2",
+            position_snapshot=Vector3(x=0, y=0, z=0),
+        ),
+    ]
+    simulator = _make_simulator_mock([player_unit_a, player_unit_b], logs=logs)
+
+    _save_battle_results(
+        session=session,
+        room=room,
+        player_entries=[entry_a, entry_b],
+        npc_entries=[],
+        simulator=simulator,
+        primary_player_win=True,
+        player_unit=player_unit_a,
+        enemy_units=[player_unit_b],
+    )
+
+    results = {
+        r.user_id: r
+        for r in session.exec(
+            select(BattleResult).where(BattleResult.room_id == room.id)
+        ).all()
+    }
+    assert results["user_ace"].kills == 2
+    assert results["user_support"].kills == 0

--- a/docs/features/battle-history-digest.md
+++ b/docs/features/battle-history-digest.md
@@ -31,6 +31,25 @@ HPは回復要素がない（`simulation.py`/`combat.py` に repair 処理なし
 
 ---
 
+## `kills`（撃破数）は自機が撃破した数（Issue #471）
+
+`BattleResult.kills` は「自機（そのプレイヤーのユニット）が撃破した敵機の数」であり、フィールド全体
+（勝利チーム全体）の撃破数ではない。`backend/scripts/run_batch.py` のバッチ実行（デイリーバトルロイヤル等、
+複数プレイヤーが同時に参加するルーム戦）では、以前は敵陣営全体の撃破数を1つだけ計算し、勝利したプレイヤー
+全員に同じ値をコピーしていたため、実際には1機も撃破していない勝者にもチームメイトの戦果込みの数が表示される
+不具合があった。
+
+`app/engine/battle_digest.py` の `compute_unit_kills(logs, unit_id)` が、`sim.logs`/`simulator.logs` から
+指定ユニット自身の撃破数を集計する共通ヘルパー。`DESTROYED` ログの `actor_id` は被撃破ユニット自身であり
+撃破者の情報を持たないため、`_process_destruction`（`combat.py`）が撃破に至った `ATTACK`/`MELEE_COMBO` ログを
+追加した直後に呼ばれる実装上の性質を利用し、「`DESTROYED` ログの直前のログが同一対象への
+`ATTACK`/`MELEE_COMBO` であれば、そのログの `actor_id` を撃破者とみなす」というロジックで撃破者を特定している。
+
+`main.py`（ソロミッション）・`run_batch.py`（バッチ、プレイヤーごとに個別集計）の両方の `BattleResult`
+生成箇所がこの `compute_unit_kills()` を経由する。
+
+---
+
 ## BattleResult の追加カラム
 
 いずれも nullable。マイグレーション前の既存レコードは全カラム `NULL` のままで、バックフィルは行わない


### PR DESCRIPTION
## Summary
- Battle History の「撃破」数がフィールド全体（勝利チーム全体）の撃破数になっており、実際には撃破していないプレイヤーにもチームメイトの戦果込みの数が表示されていた不具合を修正 (#471)
- `backend/scripts/run_batch.py`（デイリーバトルロイヤル等の複数プレイヤー参加バッチ）で、敵陣営全体の撃破数を1つだけ計算し勝利プレイヤー全員にコピーしていたロジックを、プレイヤーごとの個別集計に変更
- `BattleLog` から撃破者を特定する `compute_unit_kills()`（`backend/app/engine/battle_digest.py`）を新設し、`main.py`（ソロミッション）・`run_batch.py`（バッチ）の両方の `BattleResult` 生成箇所で共通利用（`backend/CLAUDE.md` に記載の「BattleResult生成箇所は2つあり、両方修正が必要」という既知のパターンに従った）

## Test plan
- [x] `cd backend && python -m pytest tests/unit --tb=short`（751 passed, 1 xfailed）
- [x] `tests/unit/test_run_batch.py` に、勝利チームの2人のプレイヤーがそれぞれ異なる撃破数を持つケースの回帰テストを追加
- [x] `python -m py_compile main.py scripts/run_batch.py app/engine/battle_digest.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)