### PR TITLE
fix: 武器改造後の装備換装画面ランク乖離を解消 (#476)

### DIFF
--- a/backend/app/services/weapon_engineering_service.py
+++ b/backend/app/services/weapon_engineering_service.py
@@ -6,7 +6,8 @@ from typing import NamedTuple
 from sqlalchemy.orm import attributes
 from sqlmodel import Session
 
-from app.models.models import Pilot, PlayerWeapon, WeaponCustomStats
+from app.models.models import MobileSuit, Pilot, PlayerWeapon, WeaponCustomStats
+from app.services.weapon_service import WeaponService
 
 
 class _WeaponStatConfig(NamedTuple):
@@ -208,6 +209,13 @@ class WeaponEngineeringService:
 
         self.session.add(player_weapon)
         self.session.add(pilot)
+
+        if player_weapon.equipped_ms_id is not None:
+            mobile_suit = self.session.get(MobileSuit, player_weapon.equipped_ms_id)
+            if mobile_suit is not None:
+                WeaponService.resync_mobile_suit_weapons(self.session, mobile_suit)
+                self.session.add(mobile_suit)
+
         self.session.commit()
         self.session.refresh(player_weapon)
         self.session.refresh(pilot)

--- a/backend/tests/test_weapon_engineering.py
+++ b/backend/tests/test_weapon_engineering.py
@@ -332,3 +332,60 @@ def test_entry_creation_resyncs_equipped_weapon_upgrades(client, session, pilot:
 
     session.refresh(mobile_suit)
     assert mobile_suit.weapons[0]["power"] == 110  # 100 + 5*2
+
+
+def test_upgrade_stat_resyncs_equipped_mobile_suit_weapons(
+    session: Session, pilot: Pilot
+) -> None:
+    """装備中の武器を改造した直後に MobileSuit.weapons へ反映されることを確認.
+
+    ロードアウト画面(MobileSuit.weapons由来)と武器改造モーダル(PlayerWeapon由来)の
+    ランク表示が乖離するバグの回帰テスト。エントリー登録を待たず、改造APIの
+    呼び出し時点で即座に MobileSuit.weapons が最新の実効値になっている必要がある。
+    """
+    mobile_suit = MobileSuit(
+        user_id=pilot.user_id,
+        name="Test Zaku",
+        max_hp=800,
+        current_hp=800,
+        armor=50,
+        mobility=1.0,
+        weapons=[
+            {
+                "id": "zaku_mg",
+                "name": "Zaku Machine Gun",
+                "power": 100,
+                "range": 400,
+                "accuracy": 60,
+            }
+        ],
+        side="PLAYER",
+    )
+    session.add(mobile_suit)
+    session.commit()
+    session.refresh(mobile_suit)
+
+    player_weapon = PlayerWeapon(
+        user_id=pilot.user_id,
+        master_weapon_id="zaku_mg",
+        base_snapshot={
+            "id": "zaku_mg",
+            "name": "Zaku Machine Gun",
+            "power": 100,
+            "range": 400,
+            "accuracy": 60,
+            "type": "PHYSICAL",
+        },
+        custom_stats={},
+        equipped_ms_id=mobile_suit.id,
+        equipped_slot=0,
+    )
+    session.add(player_weapon)
+    session.commit()
+    session.refresh(player_weapon)
+
+    service = WeaponEngineeringService(session)
+    service.upgrade_stat(str(player_weapon.id), "power_bonus", pilot, steps=2)
+
+    session.refresh(mobile_suit)
+    assert mobile_suit.weapons[0]["power"] == 110  # 100 + 5*2

--- a/docs/features/weapon-data-model.md
+++ b/docs/features/weapon-data-model.md
@@ -113,6 +113,8 @@ return Weapon(**merged)
 
 装備時の dual-write（`equip_weapon`）だけでは、装備中の武器を後から改造しても `MobileSuit.weapons` に反映されない。これを解消するため `WeaponService.resync_mobile_suit_weapons(session, mobile_suit)` を新設し、バトルエントリー登録時（`app/routers/entries.py` の `create_entry`、機体スナップショットを保存する直前）に呼び出すことで、**再装備しなくてもバトル開始前に改造差分が反映される**。
 
+**Issue #476 追記**: 上記のバトルエントリー時resyncだけでは、装備換装（Loadout）画面の威力/命中ランク表示（`MobileSuit.weapons[slot]` を参照）が改造直後に更新されず、次のバトルエントリーまで古いランクのまま表示され続ける不具合があった。武器改造モーダル（`PlayerWeapon.base_snapshot + custom_stats` を都度計算する実効値を参照）とのランク表示乖離として顕在化した。これを解消するため、`WeaponEngineeringService.upgrade_stat()` 内でも改造対象の `PlayerWeapon.equipped_ms_id` が設定されている場合（＝装備中）は `WeaponService.resync_mobile_suit_weapons()` を呼び出し、改造完了と同時に `MobileSuit.weapons` を再同期するようにした。バトルエントリー時のresyncは引き続き保持している（安全のための二重呼び出しだが、`resync_mobile_suit_weapons` は冪等な全量再計算のため無害）。
+
 ### フロントエンド
 
 - `frontend/src/types/shop.ts`: `WeaponUpgradeRequest` / `WeaponUpgradeResponse` / `WeaponUpgradePreview` 型を追加


### PR DESCRIPTION
## Summary
- 装備中の武器を「武器改造」モーダルで強化しても、装備換装（LOADOUT）画面の威力/命中ランクが改造前のまま表示され続けるバグを修正
- 原因: `MobileSuit.weapons`（装備換装画面が参照するJSONスナップショット）を再同期する `WeaponService.resync_mobile_suit_weapons()` が、バトルエントリー登録時にしか呼ばれておらず、武器改造API（`WeaponEngineeringService.upgrade_stat`）からは呼ばれていなかった
- 修正: `upgrade_stat()` 内で、対象武器が装備中（`equipped_ms_id` が設定済み）であれば改造コミット時に `resync_mobile_suit_weapons()` を呼び出すようにした
- MS（機体）側の armor/mobility/max_hp 等の改造は `MobileSuit` の実カラムを直接読み書きする単一ソース設計であり、同様の不具合は存在しないことを確認済み（対象外）

Closes #476

## Test plan
- [x] `cd backend && python -m pytest tests/test_weapon_engineering.py --tb=short` — 新規追加した回帰テスト `test_upgrade_stat_resyncs_equipped_mobile_suit_weapons` を含め全16件パス
- [x] `cd backend && python -m pytest tests/unit tests/test_weapon_engineering.py --tb=short` — 既存スイート含め全件パス（既知のxfail 1件除く、リグレッションなし）
- [x] `docs/features/weapon-data-model.md` を更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)