### PR TITLE
fix: バトルビューア初期表示位置がバトル終了時の最終位置になる不具合を修正

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -179,6 +179,33 @@ def _build_enemies_from_config(enemy_configs: list[dict]) -> list[MobileSuit]:
     return enemies
 
 
+def _snapshot_spawn_positions(
+    player: MobileSuit, enemies: list[MobileSuit]
+) -> tuple[Vector3, dict[uuid.UUID, Vector3]]:
+    """スポーン領域適用直後（戦闘開始前）の位置を退避する.
+
+    `sim.step()` はplayer/enemiesオブジェクトを直接書き換えるため、戦闘ループ後には
+    バトル終了時点の最終位置になってしまう。BattleViewerのt=0初期表示にはスポーン位置が
+    必要なため、レスポンス構築前に元へ戻せるようここで退避しておく。
+    """
+    return (
+        player.position.model_copy(),
+        {enemy.id: enemy.position.model_copy() for enemy in enemies},
+    )
+
+
+def _restore_spawn_positions(
+    player: MobileSuit,
+    enemies: list[MobileSuit],
+    spawn_positions: tuple[Vector3, dict[uuid.UUID, Vector3]],
+) -> None:
+    """player_info/enemies_info/ms_snapshotに反映する位置をスポーン位置へ戻す."""
+    player_spawn_position, enemy_spawn_positions = spawn_positions
+    player.position = player_spawn_position
+    for enemy in enemies:
+        enemy.position = enemy_spawn_positions[enemy.id]
+
+
 @app.get("/health")
 def health() -> dict[str, str]:
     """ヘルスチェック."""
@@ -262,6 +289,8 @@ async def simulate_battle(
         npc_pilot_stats=npc_pilot_stats,
         battlefield=BattleField(),
     )
+    spawn_positions = _snapshot_spawn_positions(player, enemies)
+
     max_steps = 50
     steps_used = 0
     for _ in range(max_steps):
@@ -269,6 +298,11 @@ async def simulate_battle(
             break
         sim.step()
         steps_used += 1
+
+    # player_info/enemies_info/ms_snapshot にはバトル後の最終位置ではなくスポーン位置を
+    # 反映する（BattleViewerが再生開始前=t=0時点でこの位置を初期表示に使うため。
+    # 最終位置のままだとフィールド外にMSが表示されるバグになる）
+    _restore_spawn_positions(player, enemies, spawn_positions)
 
     # 6. 勝者判定と撃墜数カウント
     winner_id = None

--- a/backend/main.py
+++ b/backend/main.py
@@ -299,11 +299,6 @@ async def simulate_battle(
         sim.step()
         steps_used += 1
 
-    # player_info/enemies_info/ms_snapshot にはバトル後の最終位置ではなくスポーン位置を
-    # 反映する（BattleViewerが再生開始前=t=0時点でこの位置を初期表示に使うため。
-    # 最終位置のままだとフィールド外にMSが表示されるバグになる）
-    _restore_spawn_positions(player, enemies, spawn_positions)
-
     # 6. 勝者判定と撃墜数カウント
     winner_id = None
     win_loss = "DRAW"
@@ -376,6 +371,13 @@ async def simulate_battle(
         steps_used=steps_used,
         max_steps=max_steps,
     )
+
+    # player_info/enemies_info/ms_snapshot にはバトル後の最終位置ではなくスポーン位置を
+    # 反映する（BattleViewerが再生開始前=t=0時点でこの位置を初期表示に使うため。
+    # 最終位置のままだとフィールド外にMSが表示されるバグになる）。勝敗判定・報酬計算・
+    # ダイジェスト集計（compute_battle_digest_fields）はバトル後の最終状態を前提とする
+    # ため、これらの集計処理より後、レスポンス構築の直前でのみ位置を戻す。
+    _restore_spawn_positions(player, enemies, spawn_positions)
 
     # 10. バトル結果をDBに保存（リプレイ用スナップショット・詳細情報含む）
     obstacles_data = serialize_obstacles(sim.obstacles)

--- a/docs/features/battle-viewer-improvement.md
+++ b/docs/features/battle-viewer-improvement.md
@@ -443,3 +443,34 @@ Issue #465/#466 対応後も残っていた、優先度の低い追加の非効�
 - `frontend/src/components/BattleViewer/ui/BattleOverlay.tsx`
 - `frontend/src/components/BattleViewer/hooks/useBattleEvents.ts`
 - `frontend/src/components/BattleViewer/index.tsx`
+
+---
+
+## 初期表示位置がバトル終了時の最終位置になっていた不具合（Issue #478）
+
+BattleViewerを起動した直後（再生開始前、`currentTimestamp = 0`）、MSがフィールド・地形グリッド・
+障害物メッシュの範囲外に配置されて表示される不具合があった。
+
+**原因:** `backend/main.py` の `simulate_battle` エンドポイントでは、`player`/`enemies`
+オブジェクトが `sim.step()`（最大50ステップ）によってバトル中に直接（同一オブジェクト参照のまま）
+書き換えられる。レスポンスとして返す `BattleResponse.player_info`/`enemies_info` および
+`BattleResult.player_info`/`enemies_info`/`ms_snapshot` を構築する時点では、これらのオブジェクトの
+`position` フィールドに**バトル終了時点の最終位置**が入ってしまっていた。
+
+`useBattleSnapshot.ts` の `createInitialEntry()`（`pos: initialMs.position`）は、再生開始前の
+初期表示位置としてこの `position` をそのまま使用する。再生ログの走査でその後 `position_snapshot`
+を持つログに遭遇するまでは、このバトル終了時点の最終位置（＝スポーン領域やフィールド範囲と無関係な
+場所）がそのまま表示され続けるため、MSがメッシュ外に配置されて見える不具合になっていた。
+
+なお、対象ユニットが一度も行動せず・撃破もされないまま戦闘が終わった場合、そのユニットの
+`actor_id` を持つログが1件も生成されないケースもあり（調査で確認済み）、その場合は再生を通じて
+一度も `position` が上書きされない。
+
+**修正:** `BattleSimulator` 初期化直後（`_apply_spawn_zones()` 適用済み・戦闘ループ開始前）の
+`position` をスポーン位置として退避しておき、`sim.step()` ループ終了後、レスポンス用オブジェクトの
+`position` をこのスポーン位置へ戻すようにした。`current_hp` など位置以外のフィールドは引き続き
+バトル終了時点の最終値のまま返す（デジェスト計算・フロントエンド他画面のいずれも `position` を
+参照していないことを事前に確認済み）。
+
+**影響ファイル:**
+- `backend/main.py`


### PR DESCRIPTION
## Summary
- `simulate_battle`（`backend/main.py`）では `player`/`enemies` オブジェクトが `sim.step()` によって直接書き換えられるため、レスポンスの `player_info`/`enemies_info`/`ms_snapshot` に**バトル終了時点の最終位置**が入ってしまい、BattleViewerの再生開始前（t=0）にMSがフィールド・地形グリッド・障害物メッシュの外側に表示される不具合があった
- `BattleSimulator` 初期化直後（スポーン領域適用済み・戦闘ループ開始前）の位置を退避しておき、`sim.step()` ループ終了後にレスポンス用オブジェクトの `position` をスポーン位置へ戻すよう修正
- `current_hp` など位置以外のフィールドは引き続きバトル終了時点の最終値のまま返す（デジェスト計算・フロントエンド他画面のいずれも `position` を参照していないことを事前調査で確認済み）
- `docs/features/battle-viewer-improvement.md` に原因・修正内容を追記

Closes #478

## Test plan
- [x] `python -m py_compile main.py`
- [x] `cd backend && python -m pytest tests/test_api_structure.py tests/unit --tb=short -q` が全てパス
- [x] pre-commit hook（ruff / ruff format / mypy）がパス