### PR TITLE
fix: Cloud Runバックエンドのメモリ上限を512MiBから1Giに引き上げ

### DIFF
--- a/.github/workflows/backend-deploy.yaml
+++ b/.github/workflows/backend-deploy.yaml
@@ -25,6 +25,7 @@ on:
 env:
   REGION: asia-northeast1
   MIN_INSTANCES: 0
+  MEMORY: 1Gi
   REPOSITORY: msbs-next
   IMAGE_NAME: msbs-next-api
   CLOUD_RUN_SERVICE: msbs-next-api-prod
@@ -71,6 +72,7 @@ jobs:
         run: |
           gcloud run deploy ${{ env.CLOUD_RUN_SERVICE }} \
             --min-instances=${{ env.MIN_INSTANCES }} \
+            --memory=${{ env.MEMORY }} \
             --image=${{ env.REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT_ID }}/${{ env.REPOSITORY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} \
             --region=${{ env.REGION }} \
             --project=${{ secrets.GCP_PROJECT_ID }} \

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -129,9 +129,9 @@
             }
         },
         {
-            "label": "GCloud Auth Application Default Login",
+            "label": "GCloud Auth Application Login MSBS Project",
             "type": "shell",
-            "command": "gcloud auth application-default login",
+            "command": "source ${workspaceFolder}/backend/.env && gcloud auth application-default login --project=${MSBS_GCP_PROJECT_ID}",
             "problemMatcher": [],
             "presentation": {
                 "group": "terraform",


### PR DESCRIPTION
## Summary
- 本番Cloud Run (`msbs-next-api-prod`) がメモリ上限512MiBを継続的に超過し、コンテナがOOM Killされていた
- OOM Kill時の不正な503レスポンス（`CORSMiddleware`を通過しないためCORSヘッダーなし）が、ブラウザ側で「CORSポリシーによるブロック」として誤報告されていた（実際はCORS設定の問題ではない）
- 応急対応として本番サービスは既に `gcloud run services update --memory=1Gi` で復旧済み。本PRはデプロイワークフローに `--memory=1Gi` を追加し、次回以降のデプロイでも維持されるようにする

## Root cause
Cloud Runログで `Memory limit of 512 MiB exceeded` → `503 (malformed response / connection error)` が07:01〜07:11の間に10回以上発生していることを確認。直前のリビジョン(00067)では発生していなかったため、直近マージ(#480, #482, #484: 武器/MS購入画面へのフレーバーテキスト・レーダーチャート追加)後にベースラインメモリ使用量が512MiB境界を超えたと考えられる。コード調査の結果、明確なメモリリークは見つからず、既存のベースラインフットプリント(numpy等)がわずかな追加で上限を超えた可能性が高い。

## Test plan
- [x] 本番へ `--memory=1Gi` を適用し、複数回のAPIリクエストで200が安定して返ることを確認
- [x] 新リビジョンのログで `Memory limit` エラーが再発していないことを確認
- [ ] 次回のCI/CDデプロイでワークフローの `--memory=1Gi` が正しく適用されることを確認

## Follow-up
- 恒久対応として `tracemalloc`/`memray` 等でベースラインメモリ使用量をプロファイリングし、増加要因を特定することを推奨