### PR TITLE
fix: バトルログ取得API(/logs)のOOMを解消

### DIFF
--- a/backend/main.py
+++ b/backend/main.py
@@ -8,6 +8,8 @@ from fastapi import Depends, FastAPI, HTTPException
 if TYPE_CHECKING:
     from app.engine.calculator import PilotStats
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.middleware.gzip import GZipMiddleware
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel
 from sqlmodel import Session, desc, select
 
@@ -69,6 +71,7 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+app.add_middleware(GZipMiddleware, minimum_size=1000)
 
 # Routerの登録
 app.include_router(mobile_suits.router)
@@ -509,8 +512,15 @@ async def get_battle_detail(
 async def get_battle_logs(
     battle_id: str,
     session: Session = Depends(get_session),
-) -> list[BattleLog]:
-    """バトルリプレイ用ログを取得する（遅延ロード）."""
+) -> JSONResponse:
+    """バトルリプレイ用ログを取得する（遅延ロード）.
+
+    大規模バトル（room_size=50/100等）ではログが数万〜十数万件に及び、
+    DBのdictをBattleLogオブジェクト化→response_modelで再バリデーション、
+    という経路だとオブジェクト生成のオーバーヘッドでOOMする（Issue #486）。
+    保存時点で既にBattleLog相当のJSON互換dictとして検証済みのため、
+    ここではオブジェクト化を挟まずそのままJSONResponseで返す。
+    """
     try:
         battle_uuid = uuid.UUID(battle_id)
     except ValueError as e:
@@ -521,10 +531,10 @@ async def get_battle_logs(
         raise HTTPException(status_code=404, detail="Battle not found")
 
     if battle.battle_log_id is None:
-        return []
+        return JSONResponse([])
 
     log_record = session.get(BattleLogRecord, battle.battle_log_id)
     if not log_record:
-        return []
+        return JSONResponse([])
 
-    return [BattleLog(**entry) for entry in log_record.logs]
+    return JSONResponse(log_record.logs)

--- a/backend/main.py
+++ b/backend/main.py
@@ -520,6 +520,12 @@ async def get_battle_logs(
     という経路だとオブジェクト生成のオーバーヘッドでOOMする（Issue #486）。
     保存時点で既にBattleLog相当のJSON互換dictとして検証済みのため、
     ここではオブジェクト化を挟まずそのままJSONResponseで返す。
+
+    注意: デコレータの `response_model=list[BattleLog]` はOpenAPIドキュメント上の
+    型情報を示すためだけに残しており、実行時のバリデーション/シリアライズには
+    使われない（Response インスタンスを直接返す場合、FastAPIはresponse_modelを
+    スキップするため）。レスポンスの型を変更する場合は、実データとこの
+    アノテーションの両方を必ず一致させて更新すること。
     """
     try:
         battle_uuid = uuid.UUID(battle_id)

--- a/docs/features/battle-log-feature.md
+++ b/docs/features/battle-log-feature.md
@@ -167,3 +167,33 @@ export function useBattleLogic(
 ### `formatBattleLogs(logs, isProduction, playerId): DisplayLog[]`
 
 `BattleLog[]` を `DisplayLog[]` に変換する。本番モード時はデバッグログ除外と自機フォーカスフィルタを適用する。
+
+---
+
+## バックエンド: `GET /api/battles/{battle_id}/logs`（遅延ロード配信）
+
+バトルログは `battle_results` とは別テーブル `battle_logs`（`BattleLogRecord`, `backend/app/models/models.py`）に
+バトルセッション単位で1レコード保存されており、`GET /api/battles/{battle_id}/logs` がリプレイ表示時にのみ
+`battle_results.battle_log_id` 経由で遅延ロードする（一覧表示の `GET /api/battles` には含まれない）。
+
+### レスポンス生成はDBの検証済みdictをそのまま返す（Pydanticオブジェクト化しない）
+
+`backend/main.py` の `get_battle_logs` は、DBから取得した `list[dict]` を `BattleLog(**entry)` で
+Pydanticオブジェクト化せず、`JSONResponse(log_record.logs)` でそのまま返す。保存時点で
+`strip_debug_fields`（`app/engine/battle_utils.py`）により既にBattleLog相当のJSON互換dictとして
+確定しているため、配信時に再度オブジェクト化・再バリデーションする意味がない。
+
+`room_size=50/100` 規模のバトルはログが10万件を超えることがあり、
+「DBのdict → `BattleLog`オブジェクト → `response_model`再バリデーション → JSON」という
+従来の経路ではオブジェクト生成のオーバーヘッドでCloud Run（メモリ上限1GiB）がOOMする
+不具合が実際に発生した（Issue #486）。本番の実データ（110,648件のログ、TOAST圧縮後12.67MB）で
+比較した結果、オブジェクト化を挟む従来経路はレスポンス生成だけで約560MBの追加メモリを要したのに対し、
+dictを直接返す経路は約66MBで済んだ（実測、`resource.getrusage().ru_maxrss` ベース）。
+
+新たにこのエンドポイントのレスポンス生成ロジックを変更する場合、`BattleLog(**entry)` のような
+オブジェクト化を経由するdiffは大規模バトルでのメモリ悪化に直結するため避けること。
+
+### GZip圧縮
+
+`main.py` に `GZipMiddleware`（`minimum_size=1000`）を追加済み。上記110,648件のレスポンスは
+86MB→約4.9MBまで圧縮される（転送量対策であり、上記メモリ問題そのものの対策ではない）。


### PR DESCRIPTION
## Summary
- `GET /api/battles/{battle_id}/logs` が DB から取得済みの検証済み dict を `BattleLog(**entry)` でオブジェクト化 → `response_model` で再バリデーション、という経路を通っており、大規模バトル（room_size=50/100、ログ10万件超）でオブジェクト生成のオーバーヘッドにより Cloud Run（メモリ上限1GiB）が OOM し 500 を返していた（フロントには CORS エラーとして表示される）
- 保存時点で既に `strip_debug_fields`（`app/engine/battle_utils.py`）により BattleLog 相当の JSON 互換 dict として確定しているため、配信時のオブジェクト化を撤廃し `JSONResponse` でそのまま返すよう変更
- あわせて `GZipMiddleware` を追加（転送量対策、メモリ問題そのものへの対策ではない）

## 実測（本番の実データ: 110,648件のログ、TOAST圧縮後12.67MB）
| | 修正前 | 修正後 |
|---|---|---|
| レスポンス生成の追加メモリ | 約560MB | 約66MB |
| レスポンスサイズ（gzip後） | 86MB（無圧縮） | 4.9MB |

修正前後で対象の battle_id に対し `TestClient` 経由で実際に `/logs` を叩き、200 OK・全110,648件・データ内容が一致することを確認済み（`fuzzy_scores` キーが存在しなくなる点のみ差分だが、元々 `null` 固定でフロントの型も optional のため影響なし）。

## Test plan
- [x] `cd backend && python -m pytest tests/unit --tb=short` 全件パス
- [x] 本番実データ（110,648件ログの battle_id）に対し `TestClient` で `/api/battles/{id}/logs` を実行し、200 OK・データ内容の一致・メモリ使用量の削減を確認
- [x] pre-commit（ruff / ruff format / mypy）通過

Closes #486

🤖 Generated with [Claude Code](https://claude.com/claude-code)