### PR TITLE
battle_logs.logs を JSONB へ移行しストレージ効率を改善する

### DIFF
--- a/backend/alembic/versions/a5b6c7d8e9f0_migrate_battle_logs_logs_to_jsonb.py
+++ b/backend/alembic/versions/a5b6c7d8e9f0_migrate_battle_logs_logs_to_jsonb.py
@@ -34,7 +34,7 @@ Note:
 
     GINインデックス（`CREATE INDEX ... USING GIN (logs)`）はIssue本文で「任意」とされていたが、
     Neon実DBで作成してみたところインデックスサイズが約20MBとテーブル本体とほぼ同じになった
-    （ログ内の全キー・全階層をインデックス化するため）。現時点で具体的な検索ユースケードが
+    （ログ内の全キー・全階層をインデックス化するため）。現時点で具体的な検索ユースケースが
     未定な一方でストレージ削減が目的の一つであるため、本Issueでは作成しない方針とした
     （将来actor/action_type等の検索要件が具体化した時点で別途追加を検討する）。
 
@@ -84,11 +84,22 @@ def _archive_and_delete_oversized_battle_logs(bind: sa.Connection) -> None:
     if not rows:
         return
 
-    _BACKUP_DIR.mkdir(parents=True, exist_ok=True)
+    try:
+        _BACKUP_DIR.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        raise RuntimeError(
+            f"バックアップ出力先ディレクトリの作成に失敗しました: {_BACKUP_DIR}"
+        ) from exc
+
     manifest = []
     for log_id, room_id, mission_id, created_at, logs_text, logs_size in rows:
         backup_path = _BACKUP_DIR / f"{log_id}.json"
-        backup_path.write_text(logs_text, encoding="utf-8")
+        try:
+            backup_path.write_text(logs_text, encoding="utf-8")
+        except OSError as exc:
+            raise RuntimeError(
+                f"バックアップファイルの書き込みに失敗しました: {backup_path}"
+            ) from exc
         manifest.append(
             {
                 "id": str(log_id),
@@ -108,9 +119,14 @@ def _archive_and_delete_oversized_battle_logs(bind: sa.Connection) -> None:
         bind.execute(sa.text("DELETE FROM battle_logs WHERE id = :id"), {"id": log_id})
 
     manifest_path = _BACKUP_DIR / "manifest.json"
-    manifest_path.write_text(
-        json.dumps(manifest, ensure_ascii=False, indent=2), encoding="utf-8"
-    )
+    try:
+        manifest_path.write_text(
+            json.dumps(manifest, ensure_ascii=False, indent=2), encoding="utf-8"
+        )
+    except OSError as exc:
+        raise RuntimeError(
+            f"バックアップmanifestの書き込みに失敗しました: {manifest_path}"
+        ) from exc
 
 
 def upgrade() -> None:

--- a/backend/alembic/versions/a5b6c7d8e9f0_migrate_battle_logs_logs_to_jsonb.py
+++ b/backend/alembic/versions/a5b6c7d8e9f0_migrate_battle_logs_logs_to_jsonb.py
@@ -1,0 +1,138 @@
+"""migrate_battle_logs_logs_to_jsonb.
+
+Revision ID: a5b6c7d8e9f0
+Revises: z9a0b1c2d3e4
+Create Date: 2026-08-17
+
+Note:
+    battle_logs.logs（BattleLogRecord.logs）を JSON から JSONB に移行する（Issue #489）。
+    JSONB のバイナリ圧縮によるストレージ削減と、将来的なログ内容検索用のGINインデックス
+    整備が目的。JSONB はキー順序を保証しないが、バトルログはキー順序に依存していないため
+    問題ない。SQLite はJSONB型を持たないため、このマイグレーションはPostgreSQLでのみ
+    実行する（sqlite上では型変更なしでスキップし、既存のテストDB構成には影響しない）。
+
+    Neon実DBで検証したところ、最大行（テキスト換算で約86MB、pg_column_size約12.67MB）を
+    含んだ状態で `ALTER COLUMN ... TYPE JSONB` を実行すると `OutOfMemory` になった
+    （`maintenance_work_mem` をデフォルト64MB→512MBへ引き上げても解消せず、Neonの
+    コンピュートサイズ自体が小さいことが原因と判断）。ALTER TABLE ... TYPE は
+    テーブル全体を書き換える単一トランザクション・ACCESS EXCLUSIVEロックの操作であり、
+    バッチ分割ができないため、巨大な行を1回のキャストで丸ごと処理できるだけのメモリを
+    要求する。そのため、ALTERの前に閾値超の巨大行を退避・削除してからキャストする
+    2段階構成にした:
+
+    1. `_archive_and_delete_oversized_battle_logs()`: pg_column_size が
+       `ARCHIVE_SIZE_THRESHOLD_BYTES`（2MB）を超える行を、生JSONテキストのまま
+       ローカルファイル（`backend/scripts/verify/output/battle_logs_jsonb_migration_backup/`,
+       .gitignore対象）へバックアップしてから削除する。`battle_results.battle_log_id`
+       がこれらの行を参照している場合はNULLに更新してから削除する（FK制約
+       `fk_battle_results_battle_log_id` はON DELETEアクションが無いため、参照が
+       残ったままだと削除できない）。`BattleResult` 側の集計値（撃破数等）は既に
+       非正規化カラムとして保存済みのため、リプレイ用の生ログを失っても一覧表示への
+       影響はない。閾値2MBは実データの上位4件（12.67MB/9.41MB/8.09MB/1.94MB）のみを
+       対象にし、5件目（1.59MB）以降は残す値として選定した。
+    2. 残った行に対して `ALTER COLUMN logs TYPE JSONB USING logs::JSONB` を実行する。
+
+    GINインデックス（`CREATE INDEX ... USING GIN (logs)`）はIssue本文で「任意」とされていたが、
+    Neon実DBで作成してみたところインデックスサイズが約20MBとテーブル本体とほぼ同じになった
+    （ログ内の全キー・全階層をインデックス化するため）。現時点で具体的な検索ユースケードが
+    未定な一方でストレージ削減が目的の一つであるため、本Issueでは作成しない方針とした
+    （将来actor/action_type等の検索要件が具体化した時点で別途追加を検討する）。
+
+    ダウングレードでは列型をJSONへ戻すのみで、ステップ1で削除した行の復元は行わない
+    （バックアップファイルから手動で復元する運用とする）。
+"""
+
+import json
+from collections.abc import Sequence
+from pathlib import Path
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "a5b6c7d8e9f0"
+down_revision: str | None = "z9a0b1c2d3e4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+# pg_column_size(logs) がこれを超える行は、ALTER COLUMN TYPE 実行前に退避・削除する
+# （Neonの小さいコンピュートで単一行キャストのOOMを避けるため）。
+ARCHIVE_SIZE_THRESHOLD_BYTES = 2_000_000
+
+_BACKUP_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "verify"
+    / "output"
+    / "battle_logs_jsonb_migration_backup"
+)
+
+
+def _archive_and_delete_oversized_battle_logs(bind: sa.Connection) -> None:
+    """巨大なbattle_logs行をバックアップファイルへ退避してから削除する."""
+    rows = bind.execute(
+        sa.text(
+            "SELECT id, room_id, mission_id, created_at, logs::text AS logs_text, "
+            "pg_column_size(logs) AS logs_size "
+            "FROM battle_logs WHERE pg_column_size(logs) > :threshold "
+            "ORDER BY pg_column_size(logs) DESC"
+        ),
+        {"threshold": ARCHIVE_SIZE_THRESHOLD_BYTES},
+    ).fetchall()
+
+    if not rows:
+        return
+
+    _BACKUP_DIR.mkdir(parents=True, exist_ok=True)
+    manifest = []
+    for log_id, room_id, mission_id, created_at, logs_text, logs_size in rows:
+        backup_path = _BACKUP_DIR / f"{log_id}.json"
+        backup_path.write_text(logs_text, encoding="utf-8")
+        manifest.append(
+            {
+                "id": str(log_id),
+                "room_id": str(room_id) if room_id else None,
+                "mission_id": mission_id,
+                "created_at": created_at.isoformat(),
+                "logs_size_bytes": logs_size,
+                "backup_file": backup_path.name,
+            }
+        )
+        bind.execute(
+            sa.text(
+                "UPDATE battle_results SET battle_log_id = NULL WHERE battle_log_id = :id"
+            ),
+            {"id": log_id},
+        )
+        bind.execute(sa.text("DELETE FROM battle_logs WHERE id = :id"), {"id": log_id})
+
+    manifest_path = _BACKUP_DIR / "manifest.json"
+    manifest_path.write_text(
+        json.dumps(manifest, ensure_ascii=False, indent=2), encoding="utf-8"
+    )
+
+
+def upgrade() -> None:
+    """Migrate battle_logs.logs column from JSON to JSONB (PostgreSQL only)."""
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+
+    _archive_and_delete_oversized_battle_logs(bind)
+
+    # 巨大行を退避済みでも念のため maintenance_work_mem を引き上げておく。
+    op.execute("SET LOCAL maintenance_work_mem = '512MB'")
+    op.execute("ALTER TABLE battle_logs ALTER COLUMN logs TYPE JSONB USING logs::JSONB")
+
+
+def downgrade() -> None:
+    """Revert battle_logs.logs column from JSONB back to JSON (PostgreSQL only).
+
+    Note: 退避・削除した巨大行の復元は行わない（バックアップファイルから手動で復元すること）。
+    """
+    bind = op.get_bind()
+    if bind.dialect.name != "postgresql":
+        return
+
+    op.execute("ALTER TABLE battle_logs ALTER COLUMN logs TYPE JSON USING logs::JSON")

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -5,6 +5,7 @@ from typing import Any
 import numpy as np
 from pydantic import field_validator
 from sqlalchemy import JSON, UniqueConstraint
+from sqlalchemy.dialects.postgresql import JSONB
 from sqlmodel import Column, Field, SQLModel
 
 # --- Component Models (JSONとしてDBに保存される部品) ---
@@ -710,7 +711,9 @@ class BattleLogRecord(SQLModel, table=True):
         description="ソロミッション用ミッションID",
     )
     logs: list[dict] = Field(
-        default_factory=list, sa_column=Column(JSON), description="バトルログ全件"
+        default_factory=list,
+        sa_column=Column(JSON().with_variant(JSONB, "postgresql")),
+        description="バトルログ全件",
     )
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(UTC), description="作成日時"

--- a/docs/features/battle-log-feature.md
+++ b/docs/features/battle-log-feature.md
@@ -215,3 +215,36 @@ dictを直接返す経路は約66MBで済んだ（実測、`resource.getrusage()
 `main.py` に `GZipMiddleware`（`minimum_size=1000`）を追加済み。StreamingResponseに対しても
 チャンクごとに圧縮される。110,648件のレスポンスは86MB→約4.9MBまで圧縮される（転送量対策であり、
 上記メモリ問題そのものの対策ではない）。
+
+### `battle_logs.logs` のDB列型はPostgreSQLでは `JSONB`（Issue #489）
+
+`BattleLogRecord.logs`（`backend/app/models/models.py`）の `sa_column` は
+`Column(JSON().with_variant(JSONB, "postgresql"))` として定義している。PostgreSQL接続時のみ
+`JSONB`（バイナリ格納）として扱われ、テストで使うSQLiteなど`JSONB`を持たない方言では
+従来通り `JSON` として扱われる（`with_variant` は方言ごとに実際の型を切り替える仕組みで、
+テストDB構成を変えずに済む）。マイグレーション
+（`alembic/versions/a5b6c7d8e9f0_migrate_battle_logs_logs_to_jsonb.py`）は
+`ALTER COLUMN logs TYPE JSONB USING logs::JSONB` をPostgreSQL接続時のみ実行する。
+`JSONB` はキー順序を保証しないが、バトルログはキー順序に依存した処理をしていないため
+問題ない。
+
+GINインデックス（`USING GIN (logs)`）はIssue #489の本文で「任意」とされていたが、Neon実DBで
+試作したところインデックスサイズが約20MBとテーブル本体とほぼ同じになった（ログ内の
+全キー・全階層をインデックス化するため）。ストレージ削減が目的の一つである本Issueでは
+作成を見送った。将来actor/action_type等の具体的な検索要件が固まった時点で、部分インデックス
+（特定キーのみを対象にする等）を含めて別途検討すること。
+
+### 巨大行（数十MB級）はALTER COLUMN TYPE実行前に退避・削除する
+
+`ALTER TABLE ... ALTER COLUMN ... TYPE` はテーブル全体を書き換える単一トランザクション・
+ACCESS EXCLUSIVEロックの操作であり、バッチ分割ができない。Neonの実データには1行で
+テキスト換算約86MB（`pg_column_size`約12.67MB）に達するログが複数件存在し、これを含んだ
+まま `logs::JSONB` キャストを実行すると、`maintenance_work_mem` を64MB→512MBへ引き上げても
+`OutOfMemory` になった（Neonのコンピュートサイズ自体が小さいことが原因）。そのため
+マイグレーション内の `_archive_and_delete_oversized_battle_logs()` が `pg_column_size(logs)`
+が2MBを超える行を、生JSONテキストのまま
+`backend/scripts/verify/output/battle_logs_jsonb_migration_backup/`（`.gitignore`対象）へ
+バックアップした上で削除してから、残りの行に対してキャストを実行する。`battle_results`
+側は集計値が既に非正規化カラムとして保存済みのため、削除対象行を参照する
+`battle_results.battle_log_id` をNULLに更新するだけで一覧表示への影響はない
+（詳細はマイグレーションファイル自体のdocstringを参照）。

--- a/docs/features/battle-log-feature.md
+++ b/docs/features/battle-log-feature.md
@@ -223,7 +223,7 @@ dictを直接返す経路は約66MBで済んだ（実測、`resource.getrusage()
 `JSONB`（バイナリ格納）として扱われ、テストで使うSQLiteなど`JSONB`を持たない方言では
 従来通り `JSON` として扱われる（`with_variant` は方言ごとに実際の型を切り替える仕組みで、
 テストDB構成を変えずに済む）。マイグレーション
-（`alembic/versions/a5b6c7d8e9f0_migrate_battle_logs_logs_to_jsonb.py`）は
+（`backend/alembic/versions/a5b6c7d8e9f0_migrate_battle_logs_logs_to_jsonb.py`）は
 `ALTER COLUMN logs TYPE JSONB USING logs::JSONB` をPostgreSQL接続時のみ実行する。
 `JSONB` はキー順序を保証しないが、バトルログはキー順序に依存した処理をしていないため
 問題ない。


### PR DESCRIPTION
## 概要
`battle_logs.logs`（`BattleLogRecord.logs`）を `JSON` から `JSONB` に移行し、バイナリ圧縮によるストレージ効率改善を行う。

Closes #489

## 変更内容

### モデル定義（`backend/app/models/models.py`）
- `Column(JSON)` → `Column(JSON().with_variant(JSONB, "postgresql"))` に変更
- `with_variant` によりPostgreSQL接続時のみ`JSONB`として扱われ、テストで使うSQLite（`JSONB`型を持たない）は従来通り`JSON`のまま動作する

### マイグレーション（`backend/alembic/versions/a5b6c7d8e9f0_migrate_battle_logs_logs_to_jsonb.py`）
`ALTER COLUMN logs TYPE JSONB USING logs::JSONB` はテーブル全体を書き換える単一トランザクション・ACCESS EXCLUSIVEロックの操作でバッチ分割ができない。Neon実DBで検証したところ、1行でテキスト換算約86MBに達する巨大なログ行を含んだままキャストを実行すると `maintenance_work_mem` を64MB→512MBに引き上げても`OutOfMemory`になった（Neonのコンピュートサイズが小さいことが原因）。

そのため2段階構成にした：
1. `pg_column_size(logs)` が2MBを超える行を、生JSONテキストのままローカルファイル（`.gitignore`対象）へバックアップした上で削除（`battle_results.battle_log_id`の参照はNULLに更新。`BattleResult`側は集計値が既に非正規化カラムとして保存済みのため一覧表示への影響なし）
2. 残った行に対して `ALTER COLUMN ... TYPE JSONB` を実行

SQLiteでは型変更なしでスキップする。

### GINインデックスは見送り
Issue本文で「任意」とされていたGINインデックス（`USING GIN (logs)`）は、Neon実DBで試作したところインデックスサイズが約20MBとテーブル本体とほぼ同じになり、ストレージ削減という目的と相反するため作成を見送った。将来具体的な検索要件が固まった時点で別途検討する。

### ドキュメント
`docs/features/battle-log-feature.md` に上記の設計判断を追記。

## Neon実DBでの実測結果
- マイグレーション前: 52MB（32件、うち上位3件が計約26MB compressed）
- 巨大3行（12.67MB/9.41MB/8.09MB compressed）を退避・削除後、JSONBへキャスト、VACUUM実行
- マイグレーション後: 20MB（29件）

## Test plan
- [x] `python -m pytest tests --tb=short`（全件パス、既存のxfail1件を除く）
- [x] `alembic heads` / `python -m py_compile` でマイグレーションの静的検証
- [x] Neon実DBへ `alembic upgrade head` を適用し、列型が`jsonb`になったことを確認
- [x] バックアップファイルが正しく生成されることを確認（`backend/scripts/verify/output/battle_logs_jsonb_migration_backup/`、gitignore対象）
- [x] `battle_results.battle_log_id` のNULL化が意図通り行われたことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)