### PR TITLE
feat: バトルログをCloud StorageへオフロードしてNeon egressを削減する

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -9,3 +9,10 @@ DATABASE_URL=postgresql://user:password@localhost:5432/msbs_next
 # 本番環境のVercelドメインをカンマ区切りで指定
 # 例: ALLOWED_ORIGINS=https://your-app.vercel.app,https://your-app-preview.vercel.app
 ALLOWED_ORIGINS=
+
+# Battle Log Cloud Storage (Issue #493)
+# バトルリプレイ用生ログのオフロード先GCSバケット名。
+# Cloud Runランタイムサービスアカウントに対象バケットへの
+# storage.objects.get / storage.objects.create 権限が必要（署名付きURLは使わないため
+# IAM Credentials API の signBlob 権限は不要）。
+BATTLE_LOG_GCS_BUCKET=

--- a/backend/alembic/versions/b6c7d8e9f0a1_add_gcs_path_to_battle_logs.py
+++ b/backend/alembic/versions/b6c7d8e9f0a1_add_gcs_path_to_battle_logs.py
@@ -1,0 +1,42 @@
+"""add_gcs_path_to_battle_logs.
+
+Revision ID: b6c7d8e9f0a1
+Revises: a5b6c7d8e9f0
+Create Date: 2026-08-17
+
+Note:
+    `battle_logs.gcs_path`（`BattleLogRecord.gcs_path`）を追加する（Issue #493）。
+    リプレイログ本体をNeonからCloud Storageへオフロードし、閲覧のたびにNeonの
+    課金対象Network Transferが生ログサイズ分そのまま発生する問題を構造的に解消する。
+
+    このマイグレーションはカラム追加のみを行う。既存行のGCSへのバックフィル・
+    `logs`列のNULL化は別途 `backend/scripts/maintenance/offload_battle_logs_to_gcs.py`
+    で行う（ALTER TABLEと違いバックフィルは1行ずつのUPDATEで進められるため、
+    #489のような単一トランザクションでのOOMリスクがなく、マイグレーションに
+    含める必要がない）。
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "b6c7d8e9f0a1"
+down_revision: str | None = "a5b6c7d8e9f0"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    """Add nullable gcs_path column to battle_logs."""
+    op.add_column(
+        "battle_logs",
+        sa.Column("gcs_path", sa.String(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    """Drop gcs_path column from battle_logs."""
+    op.drop_column("battle_logs", "gcs_path")

--- a/backend/app/models/models.py
+++ b/backend/app/models/models.py
@@ -713,7 +713,16 @@ class BattleLogRecord(SQLModel, table=True):
     logs: list[dict] = Field(
         default_factory=list,
         sa_column=Column(JSON().with_variant(JSONB, "postgresql")),
-        description="バトルログ全件",
+        description="バトルログ全件（gcs_path設定後は空リストになる。Issue #493）",
+    )
+    gcs_path: str | None = Field(
+        default=None,
+        description=(
+            "オフロード済みログのCloud Storageオブジェクトパス（バケット内相対パス、"
+            "gs://は含まない）。設定済みの場合、配信は logs 列ではなくこちらを優先する"
+            "（Issue #493、Neon Network Transfer対策）。オフロード未完了・失敗時はNULLの"
+            "ままとなり、その間は logs 列からの配信にフォールバックする"
+        ),
     )
     created_at: datetime = Field(
         default_factory=lambda: datetime.now(UTC), description="作成日時"

--- a/backend/app/services/battle_log_storage_service.py
+++ b/backend/app/services/battle_log_storage_service.py
@@ -1,0 +1,182 @@
+"""バトルログをCloud Storage(GCS)へオフロード・読み出しするサービス（Issue #493）.
+
+`battle_logs.logs`（Neon/Postgres）は閲覧のたびに全量がNeonの課金対象Network Transfer
+として転送される（room_size=50/100規模で数十MB）。ログ本体をGCSへオフロードし、
+Neonからは`gcs_path`（オブジェクトパス）のみを引く構成にすることで、この転送経路から
+ログ本体を完全に外す。
+
+配信は「署名付きURLへリダイレクトしてブラウザから直接GCSを取得させる」方式ではなく、
+**Cloud Run自身がGCSオブジェクトをストリーム読み出しして中継する**方式を採る。
+リダイレクト方式は IAM Credentials API の `signBlob` 権限、GCSバケットのCORS設定、
+署名付きURLの有効期限・漏洩リスクといった追加の考慮点を持ち込むが、プロキシ方式では
+そのいずれも不要になる（Cloud Runは自身のランタイムサービスアカウントの
+`storage.objects.get`/`storage.objects.create`権限だけでよく、ブラウザは従来通り
+Cloud Runの同一オリジンにのみアクセスする）。トレードオフとしてCloud Run自体の
+転送量削減効果はないが、本Issueのスコープは「Neonの課金対象Network Transfer」の
+削減であり、Cloud Run→ブラウザ間は既にGZipMiddleware（Issue #488）で対策済みのため
+許容する。
+
+GCSオブジェクトはプレーンテキストのNDJSON（`Content-Type: application/x-ndjson`）で
+保存し、gzip圧縮はしない。圧縮はCloud Run側の`GZipMiddleware`がブラウザへの配信時に
+行うため、GCS側でContent-Encodingメタデータを管理する必要がない
+（設定を怠ると「配信できているのにブラウザ側で解凍されない」事故になるため、
+そもそもその経路自体をなくした）。
+"""
+
+import json
+import logging
+import os
+import uuid
+from collections.abc import AsyncIterator, Iterator
+
+logger = logging.getLogger(__name__)
+
+_BUCKET_ENV_VAR = "BATTLE_LOG_GCS_BUCKET"
+_OBJECT_PREFIX = "battle-logs"
+
+# GCSからの読み出し・書き込みを1回のI/Oで扱うチャンクサイズ。ブラウザへの配信は
+# StreamingResponseがこの単位でチャンク送出する。
+_STREAM_CHUNK_SIZE = 256 * 1024
+
+
+def _bucket_name() -> str:
+    bucket = os.environ.get(_BUCKET_ENV_VAR)
+    if not bucket:
+        raise RuntimeError(f"{_BUCKET_ENV_VAR} is not set")
+    return bucket
+
+
+def object_path_for(battle_log_id: uuid.UUID) -> str:
+    """バトルログIDからGCSオブジェクトパス（バケット内相対パス）を算出する."""
+    return f"{_OBJECT_PREFIX}/{battle_log_id}.ndjson"
+
+
+def _client():  # type: ignore[no-untyped-def]
+    # モジュールトップレベルでimportすると、GCSを使わない開発環境・テスト環境でも
+    # google-cloud-storageのインストールが必須になってしまうため遅延importする。
+    from google.cloud import storage
+
+    return storage.Client()
+
+
+def logs_to_ndjson_text(logs: list[dict]) -> str:
+    """ログdictの列をNDJSON（1行1エントリ）のテキストに変換する."""
+    if not logs:
+        return ""
+    return "\n".join(json.dumps(entry, ensure_ascii=False) for entry in logs) + "\n"
+
+
+def upload_battle_log(battle_log_id: uuid.UUID, logs: list[dict]) -> str:
+    """バトルログをGCSへNDJSONテキストとしてアップロードする.
+
+    Returns:
+        アップロード先のGCSオブジェクトパス（バケット内相対パス）。
+    """
+    path = object_path_for(battle_log_id)
+    body = logs_to_ndjson_text(logs)
+    bucket = _client().bucket(_bucket_name())
+    blob = bucket.blob(path)
+    blob.upload_from_string(body, content_type="application/x-ndjson")
+    return path
+
+
+def upload_ndjson_text(battle_log_id: uuid.UUID, ndjson_text: str) -> str:
+    """既にNDJSONテキスト化済みのログをそのままGCSへアップロードする.
+
+    #489のJSONBマイグレーションで退避されたバックアップ（JSON配列テキスト）を
+    NDJSONへ変換した上でアップロードする復旧用途など、`list[dict]`を経由せず
+    テキストのまま扱いたい場合に使う。
+    """
+    path = object_path_for(battle_log_id)
+    bucket = _client().bucket(_bucket_name())
+    blob = bucket.blob(path)
+    blob.upload_from_string(ndjson_text, content_type="application/x-ndjson")
+    return path
+
+
+def iter_battle_log_chunks(gcs_path: str) -> Iterator[bytes]:
+    """GCSオブジェクトをチャンク単位で読み出す同期ジェネレータ.
+
+    呼び出し側（`stream_battle_log_chunks`）がスレッドプール経由で呼ぶことを
+    前提とした同期I/O実装。GCSクライアントライブラリ自体が非同期I/Oに
+    対応していないため。
+    """
+    bucket = _client().bucket(_bucket_name())
+    blob = bucket.blob(gcs_path)
+    with blob.open("rb") as f:
+        while True:
+            chunk = f.read(_STREAM_CHUNK_SIZE)
+            if not chunk:
+                break
+            yield chunk
+
+
+async def stream_battle_log_chunks(gcs_path: str) -> AsyncIterator[bytes]:
+    """GCSオブジェクトをチャンク単位で読み出す非同期ジェネレータ.
+
+    `google-cloud-storage`は同期APIのみのため、イベントループをブロックしない
+    よう各読み出しをスレッドプールへ逃がす（`main.py`の`StreamingResponse`から
+    そのまま渡せる）。
+    """
+    from starlette.concurrency import run_in_threadpool
+
+    iterator = await run_in_threadpool(lambda: iter(iter_battle_log_chunks(gcs_path)))
+    while True:
+        chunk = await run_in_threadpool(next, iterator, None)
+        if chunk is None:
+            break
+        yield chunk
+
+
+def offload_battle_log_to_gcs(battle_log_id: uuid.UUID, logs: list[dict]) -> bool:
+    """1件のバトルログをGCSへアップロードし、成功時のみ`gcs_path`を設定してNeon側の`logs`をNULL化する.
+
+    バトル終了時の同期書き込み経路（`battle_logs.logs`への保存、既存の信頼性を
+    維持する）とは切り離したベストエフォートの後処理として呼ぶ。GCSアップロード・
+    DB更新のいずれかが失敗しても例外を投げず、`gcs_path`はNULLのまま残す
+    （write-behind方式）。読み出し側（`get_battle_logs`）は`gcs_path`が未設定の
+    場合Neonの`logs`列へ自動フォールバックするため、この関数の失敗はユーザーに
+    影響しない。失敗分・未実施分は`scripts/maintenance/offload_battle_logs_to_gcs.py`
+    の定期実行が`gcs_path IS NULL`な行を対象に再試行する。
+
+    Returns:
+        オフロードが完了した（GCSアップロード・DB更新とも成功した）場合True。
+    """
+    try:
+        gcs_path = upload_battle_log(battle_log_id, logs)
+    except Exception:
+        logger.exception(
+            "Failed to upload battle log %s to GCS; will retry via the backfill job",
+            battle_log_id,
+        )
+        return False
+
+    # 呼び出し元（リクエストのBackgroundTasks等）のセッションは既にクローズ済みの
+    # 可能性があるため、この関数専用に新しいセッションを開く。
+    from sqlmodel import Session
+
+    from app.db import engine
+    from app.models.models import BattleLogRecord
+
+    try:
+        with Session(engine) as session:
+            record = session.get(BattleLogRecord, battle_log_id)
+            if record is None:
+                logger.warning(
+                    "BattleLogRecord %s not found when finalizing GCS offload",
+                    battle_log_id,
+                )
+                return False
+            record.gcs_path = gcs_path
+            record.logs = []
+            session.add(record)
+            session.commit()
+    except Exception:
+        logger.exception(
+            "Uploaded battle log %s to GCS but failed to update gcs_path; "
+            "logs remain in Neon and will be retried via the backfill job",
+            battle_log_id,
+        )
+        return False
+
+    return True

--- a/backend/app/services/battle_log_storage_service.py
+++ b/backend/app/services/battle_log_storage_service.py
@@ -54,7 +54,7 @@ def object_path_for(battle_log_id: uuid.UUID) -> str:
 def _client():  # type: ignore[no-untyped-def]
     # モジュールトップレベルでimportすると、GCSを使わない開発環境・テスト環境でも
     # google-cloud-storageのインストールが必須になってしまうため遅延importする。
-    from google.cloud import storage
+    from google.cloud import storage  # type: ignore[attr-defined]
 
     return storage.Client()
 
@@ -69,14 +69,20 @@ def logs_to_ndjson_text(logs: list[dict]) -> str:
 def upload_battle_log(battle_log_id: uuid.UUID, logs: list[dict]) -> str:
     """バトルログをGCSへNDJSONテキストとしてアップロードする.
 
+    `upload_from_string()`で全件を1個の文字列に組み立ててから渡すと、元の`logs`
+    リストに加えて同サイズの文字列がもう1つメモリに乗る（実測86MB級のログでは
+    ピークメモリが倍増する）。`blob.open("w")`のストリーミング書き込みで1行ずつ
+    書き出すことでこれを避ける（Copilotレビュー指摘、PR #495）。
+
     Returns:
         アップロード先のGCSオブジェクトパス（バケット内相対パス）。
     """
     path = object_path_for(battle_log_id)
-    body = logs_to_ndjson_text(logs)
     bucket = _client().bucket(_bucket_name())
     blob = bucket.blob(path)
-    blob.upload_from_string(body, content_type="application/x-ndjson")
+    with blob.open("w", content_type="application/x-ndjson") as f:
+        for entry in logs:
+            f.write(json.dumps(entry, ensure_ascii=False) + "\n")
     return path
 
 
@@ -100,15 +106,26 @@ def iter_battle_log_chunks(gcs_path: str) -> Iterator[bytes]:
     呼び出し側（`stream_battle_log_chunks`）がスレッドプール経由で呼ぶことを
     前提とした同期I/O実装。GCSクライアントライブラリ自体が非同期I/Oに
     対応していないため。
+
+    バケットのライフサイクルルールによる削除等でオブジェクトが既に存在しない
+    場合、`google.cloud.exceptions.NotFound`を送出せず空（0チャンク）として扱う。
+    呼び出し元の`get_battle_logs`はこれを空のNDJSONとして返すため、500ではなく
+    通常のレスポンス（空リプレイ扱い）になる（Copilotレビュー指摘、PR #495）。
     """
+    from google.cloud.exceptions import NotFound
+
     bucket = _client().bucket(_bucket_name())
     blob = bucket.blob(gcs_path)
-    with blob.open("rb") as f:
-        while True:
-            chunk = f.read(_STREAM_CHUNK_SIZE)
-            if not chunk:
-                break
-            yield chunk
+    try:
+        with blob.open("rb") as f:
+            while True:
+                chunk = f.read(_STREAM_CHUNK_SIZE)
+                if not chunk:
+                    break
+                yield chunk
+    except NotFound:
+        logger.warning("GCS object not found for battle log stream: %s", gcs_path)
+        return
 
 
 async def stream_battle_log_chunks(gcs_path: str) -> AsyncIterator[bytes]:
@@ -129,7 +146,7 @@ async def stream_battle_log_chunks(gcs_path: str) -> AsyncIterator[bytes]:
 
 
 def offload_battle_log_to_gcs(battle_log_id: uuid.UUID, logs: list[dict]) -> bool:
-    """1件のバトルログをGCSへアップロードし、成功時のみ`gcs_path`を設定してNeon側の`logs`をNULL化する.
+    """1件のバトルログをGCSへアップロードし、成功時のみ`gcs_path`を設定してNeon側の`logs`を空リストにする.
 
     バトル終了時の同期書き込み経路（`battle_logs.logs`への保存、既存の信頼性を
     維持する）とは切り離したベストエフォートの後処理として呼ぶ。GCSアップロード・

--- a/backend/main.py
+++ b/backend/main.py
@@ -4,7 +4,7 @@ import uuid
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING
 
-from fastapi import Depends, FastAPI, HTTPException
+from fastapi import BackgroundTasks, Depends, FastAPI, HTTPException
 
 if TYPE_CHECKING:
     from app.engine.calculator import PilotStats
@@ -46,6 +46,10 @@ from app.routers import (
     teams,
 )
 from app.services.battle_digest_service import compute_battle_digest_fields
+from app.services.battle_log_storage_service import (
+    offload_battle_log_to_gcs,
+    stream_battle_log_chunks,
+)
 
 app = FastAPI(title="MSBS-Next API", redirect_slashes=False)
 
@@ -229,6 +233,7 @@ async def reload_master() -> dict:
 
 @app.post("/api/battle/simulate", response_model=BattleResponse)
 async def simulate_battle(
+    background_tasks: BackgroundTasks,
     mission_id: int = 1,
     session: Session = Depends(get_session),
     user_id: str | None = Depends(get_current_user_optional),
@@ -356,9 +361,10 @@ async def simulate_battle(
         )
 
     # 8. バトルログをDBに保存（battle_logsテーブル）
+    stripped_logs = strip_debug_fields(sim.logs)
     battle_log_record = BattleLogRecord(
         mission_id=mission_id,
-        logs=strip_debug_fields(sim.logs),
+        logs=stripped_logs,
         created_at=datetime.now(UTC),
     )
     session.add(battle_log_record)
@@ -410,6 +416,15 @@ async def simulate_battle(
     )
     session.add(battle_result)
     session.commit()
+
+    # 11. バトルログをCloud Storageへオフロード（Issue #493、Neon Network Transfer対策）。
+    #     BackgroundTasksはレスポンス送出後に実行されるため、コミット済みの
+    #     battle_log_record.id を安全に参照できる。失敗してもレスポンスには影響せず
+    #     （gcs_pathがNULLのままNeonのlogsへフォールバックする）、バックフィルジョブが
+    #     後から再試行する。
+    background_tasks.add_task(
+        offload_battle_log_to_gcs, battle_log_record.id, stripped_logs
+    )
 
     return BattleResponse(
         winner_id=winner_id,
@@ -557,6 +572,11 @@ async def get_battle_logs(
     `application/json` の配列レスポンスとして表示されクライアント実装を誤誘導する
     ため、代わりに `responses` で実際のcontent-typeを明示している。レスポンスの
     型・形式を変更する場合は `responses` の記述も合わせて更新すること。
+
+    `BattleLogRecord.gcs_path` が設定済みの場合はNeonの`logs`列を経由せず、Cloud
+    Storageへオフロード済みのNDJSONオブジェクトをストリーム中継する（Issue #493、
+    Neon Network Transfer対策）。未設定（オフロード未完了・失敗）の場合は従来通り
+    `logs`列から配信する。
     """
     try:
         battle_uuid = uuid.UUID(battle_id)
@@ -573,6 +593,14 @@ async def get_battle_logs(
     log_record = session.get(BattleLogRecord, battle.battle_log_id)
     if not log_record:
         return StreamingResponse(_ndjson_lines([]), media_type="application/x-ndjson")
+
+    if log_record.gcs_path:
+        # オフロード済み（Issue #493）: GCSオブジェクトは保存時点で既にNDJSONテキストの
+        # ため、dictへ再パースせずバイト列のままストリーム中継する。
+        return StreamingResponse(
+            stream_battle_log_chunks(log_record.gcs_path),
+            media_type="application/x-ndjson",
+        )
 
     return StreamingResponse(
         _ndjson_lines(log_record.logs), media_type="application/x-ndjson"

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -9,3 +9,4 @@ alembic
 pyjwt[crypto]
 cryptography
 httpx
+google-cloud-storage

--- a/backend/scripts/maintenance/README.md
+++ b/backend/scripts/maintenance/README.md
@@ -30,3 +30,44 @@ python scripts/clear_battle_results.py --user-id user_xxxxxxxxxxxx
 | `--dry-run` | 削除対象件数を表示するだけで実際には削除しない |
 | `--user-id USER_ID` | 削除対象を特定の Clerk User ID に絞り込む |
 | `--yes` / `-y` | 確認プロンプトをスキップして即座に削除を実行 |
+
+---
+
+# offload_battle_logs_to_gcs.py
+
+`battle_logs.logs` をCloud Storageへオフロードするスクリプトです（Issue #493）。
+Neonの課金対象Network Transferをリプレイ閲覧のたびに消費してしまう問題への対策として、
+ログ本体をNeonから追い出し `gcs_path` に置き換えます。既存データのバックフィルと、
+バトル終了時の非同期オフロード失敗分の再試行を兼ねます（Cloud Schedulerなどでの
+定期実行を想定）。
+
+> ⚠️ 実DB（Neon）への書き込みを伴います。実行前にユーザーへ確認してください。
+
+## 使い方
+
+```bash
+cd backend
+
+# 対象件数を確認するだけ（実際には送信しない）
+python scripts/maintenance/offload_battle_logs_to_gcs.py --dry-run
+
+# 先頭50件のみ処理
+python scripts/maintenance/offload_battle_logs_to_gcs.py --limit 50
+
+# 全件処理（確認プロンプトあり）
+python scripts/maintenance/offload_battle_logs_to_gcs.py
+
+# #489で退避・削除された巨大行をローカルバックアップから復元する場合
+python scripts/maintenance/offload_battle_logs_to_gcs.py --restore-archived --dry-run
+```
+
+`BATTLE_LOG_GCS_BUCKET` 環境変数でアップロード先バケットを指定します。
+
+## オプション
+
+| オプション | 説明 |
+|---|---|
+| `--dry-run` | 対象件数を表示するだけで実際にはアップロード・更新しない |
+| `--limit N` | 1回の実行で処理する件数の上限 |
+| `--yes` / `-y` | 確認プロンプトをスキップして即座に実行 |
+| `--restore-archived` | `gcs_path`未設定の通常行ではなく、#489で退避・削除された巨大行の復元モードに切り替える。`battle_results.battle_log_id`の再リンクは行わず、候補を表示するのみ（手動確認が必要） |

--- a/backend/scripts/maintenance/offload_battle_logs_to_gcs.py
+++ b/backend/scripts/maintenance/offload_battle_logs_to_gcs.py
@@ -24,6 +24,8 @@ import argparse
 import json
 import os
 import sys
+import uuid
+from datetime import datetime
 from pathlib import Path
 
 # パスを通す
@@ -37,6 +39,12 @@ from app.services.battle_log_storage_service import (  # noqa: E402
     offload_battle_log_to_gcs,
     upload_ndjson_text,
 )
+
+# 1回のDB往復で取得するIDの件数。ID自体は軽量だが、対応するlogs列は最大で
+# 数十MB/行になり得る（#489の記録ではテキスト換算86MB）ため、IDだけを
+# ページング取得し、logs本体は1行ずつロードして処理する（Copilotレビュー指摘、
+# PR #495）。まとめて`.all()`すると全行分のlogsが同時にメモリへ乗ってしまう。
+_ID_PAGE_SIZE = 100
 
 _BACKUP_DIR = (
     Path(__file__).resolve().parents[2]
@@ -87,14 +95,19 @@ def parse_args() -> argparse.Namespace:
             "復元してGCSへアップロードするモードに切り替える。BattleLogRecord行は"
             "元のIDで再作成するが、battle_results.battle_log_id の再リンクは行わない"
             "（退避時に参照元のbattle_results.idを記録していないため、どの行が"
-            "参照していたか機械的には特定できない。mission_id/created_atが近い"
-            "candidateを表示するので手動で確認・更新すること）"
+            "参照していたか機械的には特定できない。mission_idまたはroom_idが"
+            "一致するcandidateを表示するので手動で確認・更新すること）"
         ),
     )
     return parser.parse_args()
 
 
-def _run_backfill(dry_run: bool, limit: int | None, skip_confirm: bool) -> None:
+def _confirm_backfill(dry_run: bool, limit: int | None, skip_confirm: bool) -> bool:
+    """対象件数の表示・dry-run判定・確認プロンプトを行う.
+
+    Returns:
+        実際にオフロード処理へ進んでよい場合True。
+    """
     with Session(engine) as session:
         count_stmt = (
             select(func.count())
@@ -105,48 +118,74 @@ def _run_backfill(dry_run: bool, limit: int | None, skip_confirm: bool) -> None:
         )
         target_count = session.exec(count_stmt).one()
 
-        print("=" * 60)
-        print("バトルログ Cloud Storage オフロードスクリプト")
-        print("=" * 60)
-        print(f"未オフロード件数: {target_count} 件")
-        if limit is not None:
-            print(f"今回処理する上限: {limit} 件")
+    print("=" * 60)
+    print("バトルログ Cloud Storage オフロードスクリプト")
+    print("=" * 60)
+    print(f"未オフロード件数: {target_count} 件")
+    if limit is not None:
+        print(f"今回処理する上限: {limit} 件")
 
-        if target_count == 0:
-            print("\n対象がありません。終了します。")
-            return
+    if target_count == 0:
+        print("\n対象がありません。終了します。")
+        return False
 
-        if dry_run:
-            print("\n[DRY RUN] 実際のアップロードは行いません。")
-            return
+    if dry_run:
+        print("\n[DRY RUN] 実際のアップロードは行いません。")
+        return False
 
-        if not skip_confirm:
-            answer = (
-                input(
-                    f"\n{target_count} 件をGCSへオフロードします。続行しますか？ [y/N]: "
-                )
-                .strip()
-                .lower()
-            )
-            if answer not in ("y", "yes"):
-                print("キャンセルしました。")
-                return
+    if skip_confirm:
+        return True
 
-        stmt = select(BattleLogRecord.id, BattleLogRecord.logs).where(
-            BattleLogRecord.gcs_path.is_(None)  # type: ignore[union-attr]
-        )
-        if limit is not None:
-            stmt = stmt.limit(limit)
-        rows = session.exec(stmt).all()
+    answer = (
+        input(f"\n{target_count} 件をGCSへオフロードします。続行しますか？ [y/N]: ")
+        .strip()
+        .lower()
+    )
+    if answer not in ("y", "yes"):
+        print("キャンセルしました。")
+        return False
+    return True
+
+
+def _run_backfill(dry_run: bool, limit: int | None, skip_confirm: bool) -> None:
+    if not _confirm_backfill(dry_run, limit, skip_confirm):
+        return
 
     succeeded = 0
     failed = 0
-    for log_id, logs in rows:
-        if offload_battle_log_to_gcs(log_id, logs):
-            succeeded += 1
-        else:
-            failed += 1
-            print(f"  ✗ 失敗: {log_id}（次回実行で再試行されます）")
+    processed = 0
+    while limit is None or processed < limit:
+        page_size = (
+            _ID_PAGE_SIZE if limit is None else min(_ID_PAGE_SIZE, limit - processed)
+        )
+        with Session(engine) as session:
+            id_stmt = (
+                select(BattleLogRecord.id)
+                .where(BattleLogRecord.gcs_path.is_(None))  # type: ignore[union-attr]
+                .limit(page_size)
+            )
+            ids = session.exec(id_stmt).all()
+
+        if not ids:
+            break
+
+        for log_id in ids:
+            # logs本体はこの1行分だけをロードする（ページ全体をまとめて
+            # ロードしない）。offload_battle_log_to_gcs()内部でも別途
+            # セッションを開くため往復は増えるが、大規模行でのOOMを避ける
+            # ことを優先する。
+            with Session(engine) as session:
+                record = session.get(BattleLogRecord, log_id)
+            if record is None:
+                continue
+
+            if offload_battle_log_to_gcs(log_id, record.logs):
+                succeeded += 1
+            else:
+                failed += 1
+                print(f"  ✗ 失敗: {log_id}（次回実行で再試行されます）")
+
+        processed += len(ids)
 
     print(f"\n完了: 成功 {succeeded} 件 / 失敗 {failed} 件")
 
@@ -193,11 +232,21 @@ def _run_restore_archived(dry_run: bool, skip_confirm: bool) -> None:
 def _restore_one_archived_entry(session: Session, entry: dict) -> None:
     """バックアップmanifestの1件分を復元し、GCSへアップロードする.
 
+    manifest（JSON）から読んだ `id`/`room_id`/`created_at` は文字列のため、
+    `BattleLogRecord`のフィールド型（UUID/datetime）へ明示的に変換してから使う
+    （Copilotレビュー指摘、PR #495）。再実行時に同じIDの行が既に復元済みの場合は
+    安全にスキップする（INSERTの主キー重複エラーを避けるため）。
+
     `battle_results.battle_log_id` の再リンクは行わない（誤った行を書き換える
     リスクの方が、リプレイ不能のまま残るリスクより大きいため）。代わりに
     条件が一致する候補を参考表示するのみに留める。
     """
-    log_id = entry["id"]
+    log_id = uuid.UUID(entry["id"])
+
+    if session.get(BattleLogRecord, log_id) is not None:
+        print(f"  - スキップ（復元済み）: {log_id}")
+        return
+
     backup_file = _BACKUP_DIR / entry["backup_file"]
     if not backup_file.exists():
         print(f"  ✗ バックアップファイルが見つかりません: {backup_file}")
@@ -215,9 +264,9 @@ def _restore_one_archived_entry(session: Session, entry: dict) -> None:
 
     record = BattleLogRecord(
         id=log_id,
-        room_id=entry["room_id"],
+        room_id=uuid.UUID(entry["room_id"]) if entry.get("room_id") else None,
         mission_id=entry["mission_id"],
-        created_at=entry["created_at"],
+        created_at=datetime.fromisoformat(entry["created_at"]),
         logs=[],
         gcs_path=gcs_path,
     )
@@ -241,7 +290,7 @@ def _find_relink_candidates(session: Session, entry: dict) -> list:
     if entry.get("mission_id") is not None:
         stmt = stmt.where(BattleResult.mission_id == entry["mission_id"])
     elif entry.get("room_id") is not None:
-        stmt = stmt.where(BattleResult.room_id == entry["room_id"])
+        stmt = stmt.where(BattleResult.room_id == uuid.UUID(entry["room_id"]))
     return list(session.exec(stmt).all())
 
 

--- a/backend/scripts/maintenance/offload_battle_logs_to_gcs.py
+++ b/backend/scripts/maintenance/offload_battle_logs_to_gcs.py
@@ -1,0 +1,258 @@
+#!/usr/bin/env python3
+# backend/scripts/maintenance/offload_battle_logs_to_gcs.py
+"""battle_logs.logs をCloud Storageへオフロードするスクリプト（Issue #493）.
+
+以下2つの用途を兼ねる（どちらも「gcs_path が未設定の行を対象にアップロードし、
+成功したら gcs_path をセットして logs を空にする」という同一の処理のため）:
+
+1. 既存データのバックフィル: 本Issue導入前に作成された全行をGCSへ移行する
+2. 失敗分の再試行: バトル終了時の非同期オフロード（`main.py`の`BackgroundTasks`）が
+   失敗・未実施のまま残った行を拾い直す（Cloud Schedulerなどで定期実行する想定）
+
+`--restore-archived` を指定すると、#489のJSONBマイグレーションで`ARCHIVE_SIZE_THRESHOLD_BYTES`
+超のため退避・削除された行（`backend/scripts/verify/output/battle_logs_jsonb_migration_backup/`）
+をこのマシンのローカルバックアップから復元してGCSへアップロードする、別モードで動作する
+（詳細は該当オプションのヘルプを参照）。
+
+Usage:
+    python scripts/maintenance/offload_battle_logs_to_gcs.py --dry-run
+    python scripts/maintenance/offload_battle_logs_to_gcs.py --limit 50
+    python scripts/maintenance/offload_battle_logs_to_gcs.py --restore-archived --dry-run
+"""
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+
+# パスを通す
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+from sqlmodel import Session, func, select  # noqa: E402
+
+from app.db import engine  # noqa: E402
+from app.models.models import BattleLogRecord, BattleResult  # noqa: E402
+from app.services.battle_log_storage_service import (  # noqa: E402
+    offload_battle_log_to_gcs,
+    upload_ndjson_text,
+)
+
+_BACKUP_DIR = (
+    Path(__file__).resolve().parents[2]
+    / "scripts"
+    / "verify"
+    / "output"
+    / "battle_logs_jsonb_migration_backup"
+)
+
+
+def parse_args() -> argparse.Namespace:
+    """コマンドライン引数のパース."""
+    parser = argparse.ArgumentParser(
+        description="battle_logs.logs をCloud Storageへオフロードします。",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+使用例:
+  python scripts/maintenance/offload_battle_logs_to_gcs.py --dry-run     # 対象件数を確認するだけ
+  python scripts/maintenance/offload_battle_logs_to_gcs.py --limit 50    # 先頭50件のみ処理
+  python scripts/maintenance/offload_battle_logs_to_gcs.py               # 全件処理（確認プロンプトあり）
+  python scripts/maintenance/offload_battle_logs_to_gcs.py --restore-archived --dry-run
+        """,
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="対象件数を表示するだけで実際にはアップロード・更新しない",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        metavar="N",
+        help="1回の実行で処理する件数の上限（省略時は全件）",
+    )
+    parser.add_argument(
+        "--yes",
+        "-y",
+        action="store_true",
+        help="確認プロンプトをスキップして実行する",
+    )
+    parser.add_argument(
+        "--restore-archived",
+        action="store_true",
+        help=(
+            "gcs_path未設定の通常行ではなく、#489で退避・削除された巨大行を"
+            "ローカルバックアップ（本スクリプト実行マシン上に残っている場合のみ）から"
+            "復元してGCSへアップロードするモードに切り替える。BattleLogRecord行は"
+            "元のIDで再作成するが、battle_results.battle_log_id の再リンクは行わない"
+            "（退避時に参照元のbattle_results.idを記録していないため、どの行が"
+            "参照していたか機械的には特定できない。mission_id/created_atが近い"
+            "candidateを表示するので手動で確認・更新すること）"
+        ),
+    )
+    return parser.parse_args()
+
+
+def _run_backfill(dry_run: bool, limit: int | None, skip_confirm: bool) -> None:
+    with Session(engine) as session:
+        count_stmt = (
+            select(func.count())
+            .select_from(BattleLogRecord)
+            .where(
+                BattleLogRecord.gcs_path.is_(None)  # type: ignore[union-attr]
+            )
+        )
+        target_count = session.exec(count_stmt).one()
+
+        print("=" * 60)
+        print("バトルログ Cloud Storage オフロードスクリプト")
+        print("=" * 60)
+        print(f"未オフロード件数: {target_count} 件")
+        if limit is not None:
+            print(f"今回処理する上限: {limit} 件")
+
+        if target_count == 0:
+            print("\n対象がありません。終了します。")
+            return
+
+        if dry_run:
+            print("\n[DRY RUN] 実際のアップロードは行いません。")
+            return
+
+        if not skip_confirm:
+            answer = (
+                input(
+                    f"\n{target_count} 件をGCSへオフロードします。続行しますか？ [y/N]: "
+                )
+                .strip()
+                .lower()
+            )
+            if answer not in ("y", "yes"):
+                print("キャンセルしました。")
+                return
+
+        stmt = select(BattleLogRecord.id, BattleLogRecord.logs).where(
+            BattleLogRecord.gcs_path.is_(None)  # type: ignore[union-attr]
+        )
+        if limit is not None:
+            stmt = stmt.limit(limit)
+        rows = session.exec(stmt).all()
+
+    succeeded = 0
+    failed = 0
+    for log_id, logs in rows:
+        if offload_battle_log_to_gcs(log_id, logs):
+            succeeded += 1
+        else:
+            failed += 1
+            print(f"  ✗ 失敗: {log_id}（次回実行で再試行されます）")
+
+    print(f"\n完了: 成功 {succeeded} 件 / 失敗 {failed} 件")
+
+
+def _run_restore_archived(dry_run: bool, skip_confirm: bool) -> None:
+    manifest_path = _BACKUP_DIR / "manifest.json"
+    if not manifest_path.exists():
+        print(f"バックアップmanifestが見つかりません: {manifest_path}")
+        print(
+            "このマシンに#489マイグレーション実行時のバックアップが残っていない場合、"
+        )
+        print("該当バトルのリプレイは復旧不能です。")
+        return
+
+    manifest = json.loads(manifest_path.read_text(encoding="utf-8"))
+    print("=" * 60)
+    print("退避済みバトルログ 復元スクリプト")
+    print("=" * 60)
+    print(f"バックアップ対象: {len(manifest)} 件")
+
+    if dry_run:
+        for entry in manifest:
+            print(f"  - {entry['id']} ({entry['logs_size_bytes']} bytes)")
+        print("\n[DRY RUN] 実際の復元は行いません。")
+        return
+
+    if not skip_confirm:
+        answer = (
+            input(
+                f"\n{len(manifest)} 件を復元してGCSへアップロードします。続行しますか？ [y/N]: "
+            )
+            .strip()
+            .lower()
+        )
+        if answer not in ("y", "yes"):
+            print("キャンセルしました。")
+            return
+
+    with Session(engine) as session:
+        for entry in manifest:
+            _restore_one_archived_entry(session, entry)
+
+
+def _restore_one_archived_entry(session: Session, entry: dict) -> None:
+    """バックアップmanifestの1件分を復元し、GCSへアップロードする.
+
+    `battle_results.battle_log_id` の再リンクは行わない（誤った行を書き換える
+    リスクの方が、リプレイ不能のまま残るリスクより大きいため）。代わりに
+    条件が一致する候補を参考表示するのみに留める。
+    """
+    log_id = entry["id"]
+    backup_file = _BACKUP_DIR / entry["backup_file"]
+    if not backup_file.exists():
+        print(f"  ✗ バックアップファイルが見つかりません: {backup_file}")
+        return
+
+    # バックアップは `logs::text`（JSON配列テキスト）のまま保存されている
+    # （#489の退避処理はNDJSON化前の生カラム値をそのままダンプしたため）。
+    # GCS側の契約であるNDJSONへ変換してからアップロードする。
+    logs_array = json.loads(backup_file.read_text(encoding="utf-8"))
+    ndjson_text = "\n".join(json.dumps(item, ensure_ascii=False) for item in logs_array)
+    if logs_array:
+        ndjson_text += "\n"
+
+    gcs_path = upload_ndjson_text(log_id, ndjson_text)
+
+    record = BattleLogRecord(
+        id=log_id,
+        room_id=entry["room_id"],
+        mission_id=entry["mission_id"],
+        created_at=entry["created_at"],
+        logs=[],
+        gcs_path=gcs_path,
+    )
+    session.add(record)
+    session.commit()
+    print(f"  ✓ 復元・アップロード完了: {log_id}")
+
+    candidates = _find_relink_candidates(session, entry)
+    if candidates:
+        print(
+            "    再リンク候補（battle_log_id IS NULL かつ同条件、手動で確認）: "
+            f"{[str(c[0]) for c in candidates]}"
+        )
+
+
+def _find_relink_candidates(session: Session, entry: dict) -> list:
+    """`battle_results.battle_log_id` の再リンク先候補を検索する（参考表示用）."""
+    stmt = select(BattleResult.id, BattleResult.created_at).where(
+        BattleResult.battle_log_id.is_(None)  # type: ignore[union-attr]
+    )
+    if entry.get("mission_id") is not None:
+        stmt = stmt.where(BattleResult.mission_id == entry["mission_id"])
+    elif entry.get("room_id") is not None:
+        stmt = stmt.where(BattleResult.room_id == entry["room_id"])
+    return list(session.exec(stmt).all())
+
+
+def main() -> None:
+    """メイン処理."""
+    args = parse_args()
+    if args.restore_archived:
+        _run_restore_archived(dry_run=args.dry_run, skip_confirm=args.yes)
+    else:
+        _run_backfill(dry_run=args.dry_run, limit=args.limit, skip_confirm=args.yes)
+
+
+if __name__ == "__main__":
+    main()

--- a/backend/scripts/run_batch.py
+++ b/backend/scripts/run_batch.py
@@ -248,6 +248,13 @@ def _save_battle_results(
     obstacles_data = serialize_obstacles(simulator.obstacles)
 
     # バトルログをルーム単位で1件保存（全参加者で共有）
+    #
+    # GCSへのオフロード（Issue #493）はここでは行わない。この時点ではまだ
+    # session.commit()前で行がコミットされておらず、offload_battle_log_to_gcs()
+    # が開く別セッションからのUPDATEがこの行のロック解放待ちでブロックされる
+    # ため。バッチ実行のリプレイは実行直後に閲覧されるものでもないため、
+    # `scripts/maintenance/offload_battle_logs_to_gcs.py` の定期実行による
+    # 非同期オフロード（新規作成分・失敗再試行分の両方を兼ねる）に任せる。
     battle_log_record = BattleLogRecord(
         room_id=room.id,
         logs=strip_debug_fields(simulator.logs),

--- a/backend/tests/test_battle_logs_gcs_offload.py
+++ b/backend/tests/test_battle_logs_gcs_offload.py
@@ -1,0 +1,92 @@
+"""GET /api/battles/{battle_id}/logs のGCSオフロード分岐のテスト（Issue #493）."""
+
+import uuid
+from datetime import UTC, datetime
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+from sqlmodel import Session
+
+from app.models.models import BattleLogRecord, BattleResult
+
+
+def _create_battle_with_log(
+    session: Session, *, gcs_path: str | None, logs: list[dict]
+) -> BattleResult:
+    log_record = BattleLogRecord(logs=logs, gcs_path=gcs_path)
+    session.add(log_record)
+    session.flush()
+
+    battle = BattleResult(
+        battle_log_id=log_record.id,
+        win_loss="WIN",
+        created_at=datetime.now(UTC),
+    )
+    session.add(battle)
+    session.commit()
+    session.refresh(battle)
+    return battle
+
+
+def test_get_battle_logs_falls_back_to_neon_when_gcs_path_unset(
+    client: TestClient, session: Session
+) -> None:
+    """gcs_path未設定の場合は従来通りNeonのlogs列から配信されることを確認する."""
+    battle = _create_battle_with_log(
+        session, gcs_path=None, logs=[{"msg": "from-neon"}]
+    )
+
+    res = client.get(f"/api/battles/{battle.id}/logs")
+
+    assert res.status_code == 200
+    lines = [line for line in res.text.splitlines() if line.strip()]
+    assert len(lines) == 1
+    assert "from-neon" in lines[0]
+
+
+def test_get_battle_logs_streams_from_gcs_when_gcs_path_set(
+    client: TestClient, session: Session
+) -> None:
+    """gcs_path設定済みの場合はGCSオブジェクトを中継配信することを確認する.
+
+    Neonのlogs列（この場合は空リスト、オフロード完了後の実際の状態を模す）ではなく
+    GCS側のバイト列がそのままレスポンスに使われることを検証する。
+    """
+    battle = _create_battle_with_log(
+        session, gcs_path="battle-logs/mocked.ndjson", logs=[]
+    )
+
+    def fake_stream(gcs_path: str):
+        async def _gen():
+            yield b'{"msg": "from-gcs"}\n'
+
+        return _gen()
+
+    with patch("main.stream_battle_log_chunks", side_effect=fake_stream):
+        res = client.get(f"/api/battles/{battle.id}/logs")
+
+    assert res.status_code == 200
+    lines = [line for line in res.text.splitlines() if line.strip()]
+    assert len(lines) == 1
+    assert "from-gcs" in lines[0]
+
+
+def test_get_battle_logs_returns_empty_when_battle_log_id_missing(
+    client: TestClient, session: Session
+) -> None:
+    """battle_log_idが存在しないバトルは空のNDJSONを返すことを確認する（既存挙動の回帰確認）."""
+    battle = BattleResult(win_loss="WIN", created_at=datetime.now(UTC))
+    session.add(battle)
+    session.commit()
+    session.refresh(battle)
+
+    res = client.get(f"/api/battles/{battle.id}/logs")
+
+    assert res.status_code == 200
+    assert res.text.strip() == ""
+
+
+def test_get_battle_logs_404_for_unknown_battle(client: TestClient) -> None:
+    """存在しないbattle_idは404になることを確認する（既存挙動の回帰確認）."""
+    res = client.get(f"/api/battles/{uuid.uuid4()}/logs")
+    assert res.status_code == 404

--- a/backend/tests/unit/test_battle_log_storage_service.py
+++ b/backend/tests/unit/test_battle_log_storage_service.py
@@ -1,0 +1,114 @@
+"""battle_log_storage_service のユニットテスト（Issue #493）.
+
+実際のGCSへは接続せず、`google.cloud.storage.Client` をモックして
+アップロード・読み出し・オフロードのロジックのみを検証する。
+"""
+
+import os
+import uuid
+from unittest.mock import MagicMock, patch
+
+os.environ.setdefault("BATTLE_LOG_GCS_BUCKET", "test-battle-logs-bucket")
+
+from app.services import battle_log_storage_service as svc  # noqa: E402
+
+
+def test_object_path_for_uses_battle_log_id() -> None:
+    """バケット内相対パスが`battle-logs/{id}.ndjson`になることを確認する."""
+    log_id = uuid.uuid4()
+    assert svc.object_path_for(log_id) == f"battle-logs/{log_id}.ndjson"
+
+
+def test_logs_to_ndjson_text_empty() -> None:
+    """空リストは空文字列に変換されることを確認する."""
+    assert svc.logs_to_ndjson_text([]) == ""
+
+
+def test_logs_to_ndjson_text_one_entry_per_line() -> None:
+    """1エントリ1行のNDJSONテキストに変換されることを確認する."""
+    logs = [{"a": 1}, {"b": 2}]
+    text = svc.logs_to_ndjson_text(logs)
+    lines = text.splitlines()
+    assert len(lines) == 2
+    assert text.endswith("\n")
+
+
+def test_upload_battle_log_uploads_ndjson_without_content_encoding() -> None:
+    """アップロード時にContent-Encodingを設定していないことを確認する.
+
+    GCS側は非圧縮のプレーンテキストで保存し、圧縮はCloud Run側のGZipMiddlewareに
+    任せる設計（Issue #493）。ここでContent-Encoding: gzipを付けてしまうと、
+    アップロード時にテキストを実際にgzip圧縮していないため「メタデータ上は圧縮済みを
+    謳っているのに中身は生テキスト」という不整合になる。
+    """
+    log_id = uuid.uuid4()
+    mock_blob = MagicMock()
+    mock_bucket = MagicMock()
+    mock_bucket.blob.return_value = mock_blob
+    mock_client = MagicMock()
+    mock_client.bucket.return_value = mock_bucket
+
+    with patch.object(svc, "_client", return_value=mock_client):
+        path = svc.upload_battle_log(log_id, [{"msg": "hello"}])
+
+    assert path == f"battle-logs/{log_id}.ndjson"
+    mock_blob.upload_from_string.assert_called_once()
+    _, kwargs = mock_blob.upload_from_string.call_args
+    assert kwargs.get("content_type") == "application/x-ndjson"
+    assert "content_encoding" not in kwargs
+
+
+def test_offload_battle_log_to_gcs_returns_false_on_upload_failure() -> None:
+    """GCSアップロード失敗時は例外を投げずFalseを返すことを確認する（write-behind方式）."""
+    log_id = uuid.uuid4()
+    with patch.object(svc, "upload_battle_log", side_effect=RuntimeError("boom")):
+        result = svc.offload_battle_log_to_gcs(log_id, [{"a": 1}])
+    assert result is False
+
+
+def test_offload_battle_log_to_gcs_updates_record_on_success(session) -> None:  # noqa: ANN001
+    """成功時にgcs_pathが設定されlogsが空になることを確認する."""
+    from app.models.models import BattleLogRecord
+
+    record = BattleLogRecord(logs=[{"a": 1}])
+    session.add(record)
+    session.commit()
+    session.refresh(record)
+
+    with patch.object(svc, "upload_battle_log", return_value="battle-logs/x.ndjson"):
+        result = svc.offload_battle_log_to_gcs(record.id, record.logs)
+
+    assert result is True
+    session.refresh(record)
+    assert record.gcs_path == "battle-logs/x.ndjson"
+    assert record.logs == []
+
+
+def test_offload_battle_log_to_gcs_returns_false_when_record_missing() -> None:
+    """対象のBattleLogRecordが存在しない場合はFalseを返すことを確認する."""
+    missing_id = uuid.uuid4()
+    with patch.object(svc, "upload_battle_log", return_value="battle-logs/x.ndjson"):
+        result = svc.offload_battle_log_to_gcs(missing_id, [{"a": 1}])
+    assert result is False
+
+
+def test_stream_battle_log_chunks_yields_all_chunks() -> None:
+    """非同期ジェネレータが同期イテレータの全チャンクをそのまま中継することを確認する.
+
+    このプロジェクトにはpytest-asyncio等の非同期テスト基盤がないため、
+    `asyncio.run()`で素朴に非同期ジェネレータを消費して検証する。
+    """
+    import asyncio
+
+    def fake_iter_chunks(gcs_path: str):
+        yield b"line1\n"
+        yield b"line2\n"
+
+    async def _collect() -> list[bytes]:
+        with patch.object(svc, "iter_battle_log_chunks", side_effect=fake_iter_chunks):
+            return [
+                c async for c in svc.stream_battle_log_chunks("battle-logs/x.ndjson")
+            ]
+
+    chunks = asyncio.run(_collect())
+    assert chunks == [b"line1\n", b"line2\n"]

--- a/backend/tests/unit/test_battle_log_storage_service.py
+++ b/backend/tests/unit/test_battle_log_storage_service.py
@@ -33,29 +33,36 @@ def test_logs_to_ndjson_text_one_entry_per_line() -> None:
     assert text.endswith("\n")
 
 
-def test_upload_battle_log_uploads_ndjson_without_content_encoding() -> None:
-    """アップロード時にContent-Encodingを設定していないことを確認する.
+def test_upload_battle_log_streams_ndjson_without_content_encoding() -> None:
+    """アップロードが1行ずつのストリーミング書き込みで、Content-Encoding未設定であることを確認する.
 
     GCS側は非圧縮のプレーンテキストで保存し、圧縮はCloud Run側のGZipMiddlewareに
     任せる設計（Issue #493）。ここでContent-Encoding: gzipを付けてしまうと、
     アップロード時にテキストを実際にgzip圧縮していないため「メタデータ上は圧縮済みを
     謳っているのに中身は生テキスト」という不整合になる。
+
+    また、全件を1個の巨大な文字列に組み立ててから`upload_from_string()`する実装は
+    ログサイズ分のメモリが追加で必要になる（Copilotレビュー指摘、PR #495）ため、
+    `blob.open("w")`で1行ずつ書き込むストリーミング実装になっていることも確認する。
     """
     log_id = uuid.uuid4()
+    mock_file = MagicMock()
     mock_blob = MagicMock()
+    mock_blob.open.return_value.__enter__.return_value = mock_file
     mock_bucket = MagicMock()
     mock_bucket.blob.return_value = mock_blob
     mock_client = MagicMock()
     mock_client.bucket.return_value = mock_bucket
 
     with patch.object(svc, "_client", return_value=mock_client):
-        path = svc.upload_battle_log(log_id, [{"msg": "hello"}])
+        path = svc.upload_battle_log(log_id, [{"msg": "hello"}, {"msg": "world"}])
 
     assert path == f"battle-logs/{log_id}.ndjson"
-    mock_blob.upload_from_string.assert_called_once()
-    _, kwargs = mock_blob.upload_from_string.call_args
-    assert kwargs.get("content_type") == "application/x-ndjson"
-    assert "content_encoding" not in kwargs
+    mock_blob.open.assert_called_once_with("w", content_type="application/x-ndjson")
+    assert mock_file.write.call_count == 2
+    written = "".join(call.args[0] for call in mock_file.write.call_args_list)
+    assert "hello" in written
+    assert "world" in written
 
 
 def test_offload_battle_log_to_gcs_returns_false_on_upload_failure() -> None:
@@ -90,6 +97,28 @@ def test_offload_battle_log_to_gcs_returns_false_when_record_missing() -> None:
     with patch.object(svc, "upload_battle_log", return_value="battle-logs/x.ndjson"):
         result = svc.offload_battle_log_to_gcs(missing_id, [{"a": 1}])
     assert result is False
+
+
+def test_iter_battle_log_chunks_returns_empty_when_object_not_found() -> None:
+    """GCSオブジェクトが存在しない場合、例外にせず空として扱うことを確認する.
+
+    バケットのライフサイクルルールによる削除等でオブジェクトが失われていても、
+    `/api/battles/{id}/logs`が500にならず空NDJSONを返せるようにするため
+    （Copilotレビュー指摘、PR #495）。
+    """
+    from google.cloud.exceptions import NotFound
+
+    mock_blob = MagicMock()
+    mock_blob.open.side_effect = NotFound("not found")
+    mock_bucket = MagicMock()
+    mock_bucket.blob.return_value = mock_blob
+    mock_client = MagicMock()
+    mock_client.bucket.return_value = mock_bucket
+
+    with patch.object(svc, "_client", return_value=mock_client):
+        chunks = list(svc.iter_battle_log_chunks("battle-logs/missing.ndjson"))
+
+    assert chunks == []
 
 
 def test_stream_battle_log_chunks_yields_all_chunks() -> None:

--- a/docs/features/battle-log-feature.md
+++ b/docs/features/battle-log-feature.md
@@ -248,3 +248,86 @@ ACCESS EXCLUSIVEロックの操作であり、バッチ分割ができない。N
 側は集計値が既に非正規化カラムとして保存済みのため、削除対象行を参照する
 `battle_results.battle_log_id` をNULLに更新するだけで一覧表示への影響はない
 （詳細はマイグレーションファイル自体のdocstringを参照）。
+
+---
+
+## ログ本体のCloud Storageオフロード（Issue #493）
+
+`GET /api/battles/{battle_id}/logs` はNeon（PostgreSQL）からリプレイ閲覧のたびに
+生ログ全量を読み出しており、これはNeonの課金/枠対象となる「Network Transfer」に
+そのまま計上される。NDJSON化・GZip圧縮（Issue #488）は**Cloud Run→ブラウザ間**の
+転送量削減にしか効かず、**Neon→Cloud Run間**（Postgresワイヤプロトコル）は対象外
+だったため、room_size=50/100規模のバトル（1行で数十MB）が閲覧されるたびにNeonの
+egressがそのバトルのログサイズ分そのまま増加していた。
+
+対策として、ログ本体をNeonから追い出しCloud Storage（GCS）へオフロードする構成を
+導入した。`BattleLogRecord`（`app/models/models.py`）に `gcs_path: str | None` を
+追加し、オフロード完了後は `logs` 列を空リストにする。
+
+### 書き込み: write-behind方式（`app/services/battle_log_storage_service.py`）
+
+バトル終了時のログ保存（`battle_logs.logs`への書き込み）は既存のまま同期処理として
+維持し、その後**ベストエフォートの非同期処理**としてGCSへのオフロードを行う
+（`offload_battle_log_to_gcs()`）。GCSアップロード・DB更新（`gcs_path`のセットと
+`logs`のNULL化）のいずれかが失敗しても例外を投げず、`gcs_path`はNULLのまま残る。
+
+- `main.py` の `simulate_battle`（ソロミッション、即時実行）: FastAPIの
+  `BackgroundTasks` でレスポンス送出後に実行する。`session.commit()`後に
+  スケジュールするため、コミット済みの `battle_log_record.id` を安全に参照できる
+- `scripts/run_batch.py` の `_save_battle_results`（ルーム対戦バッチ）:
+  こちらはあえてオフロードを呼ばない。呼び出し時点でまだ`battle_log_record`の
+  行がコミットされておらず、`offload_battle_log_to_gcs()`が開く別セッションからの
+  UPDATEがロック解放待ちでブロックされるため。バッチ実行のリプレイは実行直後に
+  閲覧されるものでもないため、下記の定期バックフィルジョブに任せる
+
+### 読み出し: `gcs_path`優先、未設定時はNeonへフォールバック
+
+`get_battle_logs`（`main.py`）は `log_record.gcs_path` が設定済みならGCSオブジェクトを
+`stream_battle_log_chunks()` でストリーム中継し、未設定（オフロード未完了・失敗）なら
+従来通り `logs` 列から配信する。GCSオブジェクトは保存時点で既にNDJSONテキストのため、
+dictへの再パース・再シリアライズを挟まずバイト列のまま中継する。
+
+配信方式は「署名付きURLへのリダイレクト」ではなく**Cloud Run自身がGCSオブジェクトを
+ストリーム読み出しして中継するプロキシ方式**を採用した。リダイレクト方式は以下を
+追加で必要とするが、プロキシ方式ではいずれも不要になる:
+
+| 検討事項 | 署名付きURLリダイレクト方式 | 採用したプロキシ方式 |
+|---|---|---|
+| 署名権限 | IAM Credentials APIの`signBlob`（`roles/iam.serviceAccountTokenCreator`） | 不要（`storage.objects.get`のみ） |
+| GCSのContent-Encoding | gzip保存時は正しく設定しないと透過解凍されない事故になる | 不要（GCSは非圧縮のプレーンテキストで保存し、圧縮はCloud Run側のGZipMiddlewareに任せる） |
+| NDJSONストリーミング（#488）との整合 | ブラウザがファイル全体を一括ダウンロードする形になり前提が崩れる懸念 | 完全維持（データソースがNeonの行→GCSオブジェクトに変わるだけ） |
+| CORS | ブラウザ→GCS直接通信のためバケットへの設定が必要 | 不要（ブラウザは引き続きCloud Runの同一オリジンのみにアクセス） |
+| URL漏洩リスク | 署名付きURLを知っていれば認可チェックをバイパスされる | 発生しない（アクセス制御は従来通りCloud Run側の認可チェックのみ） |
+
+トレードオフとして、プロキシ方式はCloud Run自体の転送量・処理時間の削減効果はない。
+本Issueのスコープは「Neonの課金対象Network Transfer」の削減であり、Cloud Run→
+ブラウザ間は既にGZip圧縮（#488）で対策済みのため許容している。将来Cloud Run自体の
+負荷が問題になった場合は、signBlob権限を付与した上で署名付きURL方式へ切り替える
+選択肢を残す。
+
+### 既存データの移行・失敗分の再試行: `scripts/maintenance/offload_battle_logs_to_gcs.py`
+
+新規バトル用の非同期オフロードと同じ`offload_battle_log_to_gcs()`を、`gcs_path IS NULL`な
+全行に対して一括実行するバックフィル・再試行スクリプト。既存データの移行と、
+write-behind方式で失敗した分の再試行を同じ仕組みで兼ねる（Cloud Schedulerなどでの
+定期実行を想定）。
+
+`--restore-archived` オプションで、#489のJSONBマイグレーションで退避・削除された
+巨大行（`backend/scripts/verify/output/battle_logs_jsonb_migration_backup/`）を
+ローカルバックアップから復元してGCSへアップロードする別モードに切り替えられる。
+ただし退避時に参照元の`battle_results.id`を記録していないため、`battle_log_id`の
+再リンクは機械的には特定できない。条件が一致する候補を参考表示するのみに留め、
+自動更新はしない（誤った行を書き換えるリスクの方が大きいため）。
+
+### 環境変数
+
+`BATTLE_LOG_GCS_BUCKET`（`backend/.env.example`参照）でアップロード先バケットを
+指定する。Cloud Runランタイムサービスアカウントに対象バケットへの
+`storage.objects.get`/`storage.objects.create`権限が必要。
+
+### 保持期間短縮（GCSバケットのライフサイクルルールで対応）
+
+対策候補にあった「ログ保持期間の短縮」は、GCSバケットのライフサイクルルール
+（例: 90日でNearline/Coldlineへ移行、1年で削除）をインフラ側で設定するだけで
+コード変更なしに実現できる。ログ本体をNeonから切り離したことで、この設定変更が
+アプリケーションコードに影響しない。

--- a/infra/cloud-run/environment/prod/outputs.tf
+++ b/infra/cloud-run/environment/prod/outputs.tf
@@ -13,3 +13,8 @@ output "artifact_registry_repository_url" {
   description = "Artifact Registry repository URL"
   value       = module.base.repository_url
 }
+
+output "battle_logs_bucket_name" {
+  description = "バトルログオフロード先GCSバケット名（Issue #493）"
+  value       = module.cloud_run.battle_logs_bucket_name
+}

--- a/infra/cloud-run/modules/base/main.tf
+++ b/infra/cloud-run/modules/base/main.tf
@@ -7,6 +7,7 @@ resource "google_project_service" "required_apis" {
     "secretmanager.googleapis.com",
     "run.googleapis.com",
     "orgpolicy.googleapis.com",
+    "storage.googleapis.com",
   ])
 
   project                    = var.project_id

--- a/infra/cloud-run/modules/cloud-run/batch_job.tf
+++ b/infra/cloud-run/modules/cloud-run/batch_job.tf
@@ -58,6 +58,11 @@ resource "google_cloud_run_v2_job" "msbs_batch" {
           name  = "MAX_SIMULATION_STEPS"
           value = tostring(var.max_simulation_steps)
         }
+
+        env {
+          name  = "BATTLE_LOG_GCS_BUCKET"
+          value = google_storage_bucket.battle_logs.name
+        }
       }
     }
   }

--- a/infra/cloud-run/modules/cloud-run/battle_log_storage.tf
+++ b/infra/cloud-run/modules/cloud-run/battle_log_storage.tf
@@ -1,0 +1,66 @@
+# infra/cloud-run/modules/cloud-run/battle_log_storage.tf
+# バトルリプレイ用生ログのオフロード先GCSバケット（Issue #493）
+#
+# GET /api/battles/{id}/logs はリプレイ閲覧のたびにNeon(PostgreSQL)から生ログ全量を
+# 読み出しており、これがNeonの課金対象Network Transferをそのまま消費していた。
+# ログ本体をこのバケットへオフロードし、Neonにはgcs_path（オブジェクトパス）のみを
+# 残すことでこの転送経路からログ本体を完全に外す
+# （詳細は backend/app/services/battle_log_storage_service.py、
+# docs/features/battle-log-feature.md 参照）。
+
+resource "google_storage_bucket" "battle_logs" {
+  name                        = "${var.project_id}-battle-logs-${var.environment}"
+  location                    = var.region
+  uniform_bucket_level_access = true
+  force_destroy               = false
+
+  labels = { environment = var.environment }
+
+  # 保持期間短縮（対策候補の一つ）。ログ本体をNeonから切り離したことで、
+  # コード変更なしにバケットのライフサイクルルールだけで実現できる。
+  lifecycle_rule {
+    condition {
+      age = 90
+    }
+    action {
+      type          = "SetStorageClass"
+      storage_class = "NEARLINE"
+    }
+  }
+
+  lifecycle_rule {
+    condition {
+      age = 365
+    }
+    action {
+      type = "Delete"
+    }
+  }
+
+  # storage.googleapis.com の有効化は base モジュール（required_apis）側で行う。
+  # この module は base の repository_url 経由でしか base に依存していないため、
+  # storage API 自体への直接依存は表現できないが、対象プロジェクトには既存の
+  # バケット（tfstate等）があり storage API は有効化済みのため実害はない。
+}
+
+# Cloud Runサービス（main.py）・Cloud Run Jobs（run_batch.py、バックフィルスクリプト
+# 実行時も含む）はいずれも同じ google_service_account.cloud_run を使うため、
+# 1つのIAMバインディングで両方をカバーする。
+#
+# 配信をCloud Run自身によるGCSストリーム中継方式（署名付きURLリダイレクトではない）
+# にしたため、roles/iam.serviceAccountTokenCreator（signBlob用）は不要。読み書きに
+# 必要な最小権限として objectViewer（get/list） + objectCreator（アップロード）のみ
+# 付与する（objectAdmin は delete 権限まで含むが、アプリコードはオブジェクトを
+# 削除しないため不要。バケットのライフサイクルルールによる削除はGCS自体が
+# サービスエージェントとして行うため、Cloud Run側SAの権限とは無関係）。
+resource "google_storage_bucket_iam_member" "battle_logs_viewer" {
+  bucket = google_storage_bucket.battle_logs.name
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:${google_service_account.cloud_run.email}"
+}
+
+resource "google_storage_bucket_iam_member" "battle_logs_creator" {
+  bucket = google_storage_bucket.battle_logs.name
+  role   = "roles/storage.objectCreator"
+  member = "serviceAccount:${google_service_account.cloud_run.email}"
+}

--- a/infra/cloud-run/modules/cloud-run/main.tf
+++ b/infra/cloud-run/modules/cloud-run/main.tf
@@ -80,6 +80,11 @@ resource "google_cloud_run_v2_service" "main" {
         value = var.allowed_origins
       }
 
+      env {
+        name  = "BATTLE_LOG_GCS_BUCKET"
+        value = google_storage_bucket.battle_logs.name
+      }
+
       startup_probe {
         http_get {
           path = "/health"

--- a/infra/cloud-run/modules/cloud-run/outputs.tf
+++ b/infra/cloud-run/modules/cloud-run/outputs.tf
@@ -20,3 +20,8 @@ output "batch_job_name" {
   description = "Cloud Run Jobs のジョブ名（バッチ実行用）"
   value       = google_cloud_run_v2_job.msbs_batch.name
 }
+
+output "battle_logs_bucket_name" {
+  description = "バトルログオフロード先GCSバケット名（Issue #493）"
+  value       = google_storage_bucket.battle_logs.name
+}


### PR DESCRIPTION
## Summary
- リプレイログ取得（`GET /api/battles/{battle_id}/logs`）が閲覧のたびにNeonの課金対象Network Transferを生ログサイズ分そのまま消費する問題（#493）に対し、ログ本体をNeonからCloud Storage(GCS)へオフロードする構成を実装
- 配信は署名付きURLリダイレクトではなく、Cloud Run自身がGCSオブジェクトをストリーム中継するプロキシ方式を採用（signBlob権限・CORS設定・URL漏洩リスクが不要になる）
- 書き込みはwrite-behind方式（Neon書き込み→非同期GCSオフロード→成功時のみNeon側`logs`をNULL化）。失敗時は自動的にNeonへフォールバックし、ユーザー影響なし
- 既存データのバックフィル・失敗分の再試行を兼ねるスクリプト（`--restore-archived`で#489の退避済み巨大行の復元にも対応）を追加
- 本番GCPプロジェクト（msbs-next）へterraform apply済み。GCSバケット作成・IAM権限付与・環境変数設定が完了している

## 変更内容

### Backend
- `app/models/models.py`: `BattleLogRecord.gcs_path`追加
- `alembic/versions/b6c7d8e9f0a1_...`: `gcs_path`カラム追加のみ（バックフィルは別スクリプト、単一トランザクションでのOOMリスクを避けるため）**適用済み**
- `app/services/battle_log_storage_service.py`: GCSアップロード・ストリーム読み出し・オフロードのロジック（新規）
- `main.py`: `simulate_battle`でコミット後に`BackgroundTasks`経由でオフロードをスケジュール、`get_battle_logs`は`gcs_path`優先・未設定時はNeonへフォールバック
- `scripts/run_batch.py`: バッチ経路ではオフロードを呼ばない理由をコメントで明記（コミット前のロック競合を避けるため。定期バックフィルジョブに任せる）
- `scripts/maintenance/offload_battle_logs_to_gcs.py`: バックフィル・再試行・退避済み行の復元スクリプト（新規）
- `docs/features/battle-log-feature.md`: 新アーキテクチャの解説を追記
- `requirements.txt` / `.env.example`: `google-cloud-storage`・`BATTLE_LOG_GCS_BUCKET`追加

### Infra（terraform、`infra/cloud-run/`）**apply済み**
- `modules/cloud-run/battle_log_storage.tf`: `msbs-next-battle-logs-prod`バケット作成（90日でNearline、365日で削除のライフサイクルルール）
- Cloud Runランタイムサービスアカウント（`msbs-next-api-prod-sa`、Cloud Run本体・Cloud Run Jobsバッチ共通）へ`roles/storage.objectViewer`/`roles/storage.objectCreator`を付与
- `modules/base/main.tf`: `storage.googleapis.com` APIを有効化
- Cloud Runサービス・Jobs両方に`BATTLE_LOG_GCS_BUCKET`環境変数を追加
- apply時、`terraform.tfvars`（ローカル管理・gitignore対象）が実態と乖離していたドリフト（`memory_limit`が512Miのまま実際は1Giで稼働／バッチジョブの`batch_image_tag`未指定でデフォルト`latest`に巻き戻る問題）を本Issueとは別に検出・修正済み。tfvars自体はコミット対象外のため、他の実行者のローカルtfvarsには反映されていない点に注意

## デプロイ後に必要な作業
- **既存データのバックフィル**（`scripts/maintenance/offload_battle_logs_to_gcs.py`）: 本PRがCloud Runへデプロイされた後に実行すること。デプロイ前に実行すると、旧コード（`gcs_path`分岐を知らない）が`logs`列を直接参照するエンドポイントのままバックフィルで`logs`が空になり、既存リプレイが一時的に閲覧不能になる
- 対策前後でのNeon Network Transfer実測比較（バックフィル後、Neonコンソールで計測）

## Test plan
- [x] `pytest tests/` 全件通過（ローカルSQLite、GCSはモック）
- [x] `ruff check .` / `ruff format --check` / `mypy .` 全て通過
- [x] `alembic heads` でマイグレーションチェーンの整合性を確認（DB未接続の静的検証）
- [x] Neon（実DB）へ`alembic upgrade`適用済み、`alembic current`で`b6c7d8e9f0a1 (head)`を確認
- [x] `terraform plan`/`apply`で本番GCPプロジェクトへのインフラ変更を確認・適用済み
- [x] デプロイ後のCloud Runサービスが正常稼働中（`/health` → 200）であることを確認
- [ ] デプロイ後、GCSオフロード・配信の実地確認
- [ ] 既存データのバックフィル実行
- [ ] Neon Network Transferの実測比較

🤖 Generated with [Claude Code](https://claude.com/claude-code)
